### PR TITLE
Made the Capture Node ASG Capacity configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ You can see your created cluster and the VPCs it is currently monitoring using t
 ./manage_arkime.py create-cluster --name MyCluster
 ```
 
+By default, you will be given the minimum-size Capture Node fleet.  If you have a specific amount of traffic you're expecting to need to be able to capture, you an specify it (in Gbps) using the `--expected-traffic` argument.  The CLI will provision an EC2 Autoscaling Group that should be able to handle that amount of capture plus a little extra.
+
+```
+./manage_arkime.py create-cluster --name MyCluster --expected-traffic 10
+```
+
 ### Setting up capture for a VPC
 
 Once you have an Arkime Cluster, you can begin capturing traffic in a target VPC using the `add-vpc` command, like so:

--- a/cdk-lib/cloud-demo.ts
+++ b/cdk-lib/cloud-demo.ts
@@ -47,6 +47,8 @@ switch(params.type) {
             clusterName: params.nameCluster,
             osDomain: osDomainStack.domain,
             osPassword: osDomainStack.osPassword,
+            planCaptureNodes: params.planCaptureNodes,
+            planEcsResources: params.planEcsResources,
             ssmParamNameCluster: params.nameClusterSsmParam
         });
         captureNodesStack.addDependency(captureBucketStack)

--- a/cdk-lib/core/capacity-plan.ts
+++ b/cdk-lib/core/capacity-plan.ts
@@ -1,0 +1,17 @@
+/**
+ * Structure to hold the capacity plan for a given set of capture nodes
+ */
+export interface CaptureNodesPlan {
+    instanceType: string;
+    desiredCount: number;
+    maxCount: number;
+    minCount: number;
+}
+
+/**
+ * Structure to hold the ECS system resource plan for a given set of capture nodes
+ */
+export interface EcsSysResourcePlan {
+    cpu: number;
+    memory: number;
+}

--- a/cdk-lib/core/command-params.ts
+++ b/cdk-lib/core/command-params.ts
@@ -1,3 +1,5 @@
+import * as plan from './capacity-plan';
+
 /**
  * Base type for receiving arguments from the Python side of the app.  These directly match the interface on the Python
  * side for a given command and can be type-cast into using JSON.  It's expected these will only be used during the
@@ -23,6 +25,8 @@ export interface ClusterMgmtParamsRaw extends CommandParamsRaw {
     nameViewerPassSsmParam: string;
     nameViewerUserSsmParam: string;
     nameViewerNodesStack: string;
+    planCaptureNodes: string;
+    planEcsResources: string;
 }
 
 /**
@@ -85,6 +89,8 @@ export interface ClusterMgmtParams extends CommandParams {
     nameViewerPassSsmParam: string;
     nameViewerUserSsmParam: string;
     nameViewerNodesStack: string;
+    planCaptureNodes: plan.CaptureNodesPlan;
+    planEcsResources: plan.EcsSysResourcePlan;
 }
 
 /**

--- a/cdk-lib/core/context-wrangling.ts
+++ b/cdk-lib/core/context-wrangling.ts
@@ -1,4 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
+import * as plan from './capacity-plan';
 import * as prms from './command-params';
 import {CDK_CONTEXT_CMD_VAR, CDK_CONTEXT_REGION_VAR, CDK_CONTEXT_PARAMS_VAR, ManagementCmd} from './constants';
 
@@ -98,6 +99,8 @@ function validateArgs(args: ValidateArgs) : (prms.ClusterMgmtParams | prms.Deplo
                 nameViewerPassSsmParam: rawClusterMgmtParamsObj.nameViewerPassSsmParam,
                 nameViewerUserSsmParam: rawClusterMgmtParamsObj.nameViewerUserSsmParam,
                 nameViewerNodesStack: rawClusterMgmtParamsObj.nameViewerNodesStack,
+                planCaptureNodes:  JSON.parse(rawClusterMgmtParamsObj.planCaptureNodes),
+                planEcsResources:  JSON.parse(rawClusterMgmtParamsObj.planEcsResources),
             }
             return clusterMgmtParams;
         case ManagementCmd.AddVpc: // Add and Remove VPC use the same parameters

--- a/cdk-lib/core/ssm-wrangling.ts
+++ b/cdk-lib/core/ssm-wrangling.ts
@@ -1,3 +1,5 @@
+import * as plan from '../core/capacity-plan';
+
 /**
  * This file contains functions and types that define a shared interface with the Python management CLI; the two need
  * to stay in sync.  We should probably find a way to put these definitions in a single location both the Python and
@@ -9,6 +11,8 @@ export interface ClusterSsmValue {
     readonly busName: string;
     readonly clusterName: string;
     readonly vpceServiceId: string;
+    readonly captureNodesPlan: plan.CaptureNodesPlan;
+    readonly ecsSysResourcePlan: plan.EcsSysResourcePlan;
 }
 
 export interface SubnetSsmValue {

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -12,7 +12,7 @@ from commands.get_login_details import cmd_get_login_details
 from commands.list_clusters import cmd_list_clusters
 from commands.remove_vpc import cmd_remove_vpc
 import constants as constants
-from core.capacity_planning import MINIMUM_TRAFFIC, MAX_TRAFFIC_PER_CLUSTER
+from core.capacity_planning import MAX_TRAFFIC_PER_CLUSTER, MINIMUM_TRAFFIC
 from logging_wrangler import LoggingWrangler, set_boto_log_level
 
 logger = logging.getLogger(__name__)
@@ -58,9 +58,9 @@ cli.add_command(destroy_demo_traffic)
 @click.option(
     "--expected-traffic", 
     help=("The amount of traffic, in gigabits-per-second, you expect your Arkime Cluster to receive."
-        + f"  Maximum: {MAX_TRAFFIC_PER_CLUSTER} Gbps"),
-    show_default=True,
-    default=MINIMUM_TRAFFIC,
+        + f"Minimum: {MINIMUM_TRAFFIC} Gbps,  Maximum: {MAX_TRAFFIC_PER_CLUSTER} Gbps"),
+    default=None,
+    type=click.INT,
     required=False)
 @click.pass_context
 def create_cluster(ctx, name, expected_traffic):

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -12,6 +12,7 @@ from commands.get_login_details import cmd_get_login_details
 from commands.list_clusters import cmd_list_clusters
 from commands.remove_vpc import cmd_remove_vpc
 import constants as constants
+from core.capacity_planning import MINIMUM_TRAFFIC, MAX_TRAFFIC_PER_CLUSTER
 from logging_wrangler import LoggingWrangler, set_boto_log_level
 
 logger = logging.getLogger(__name__)
@@ -54,11 +55,18 @@ cli.add_command(destroy_demo_traffic)
 
 @click.command(help="Creates an Arkime Cluster in your account")
 @click.option("--name", help="The name you want your Arkime Cluster and its associated resources to have", required=True)
+@click.option(
+    "--expected-traffic", 
+    help=("The amount of traffic, in gigabits-per-second, you expect your Arkime Cluster to receive."
+        + f"  Maximum: {MAX_TRAFFIC_PER_CLUSTER} Gbps"),
+    show_default=True,
+    default=MINIMUM_TRAFFIC,
+    required=False)
 @click.pass_context
-def create_cluster(ctx, name):
+def create_cluster(ctx, name, expected_traffic):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_create_cluster(profile, region, name)
+    cmd_create_cluster(profile, region, name, expected_traffic)
 cli.add_command(create_cluster)
 
 @click.command(help="Tears down the Arkime Cluster in your account; by default, leaves your data intact")

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -12,7 +12,7 @@ from commands.get_login_details import cmd_get_login_details
 from commands.list_clusters import cmd_list_clusters
 from commands.remove_vpc import cmd_remove_vpc
 import constants as constants
-from core.capacity_planning import MAX_TRAFFIC_PER_CLUSTER, MINIMUM_TRAFFIC
+from core.capacity_planning import MAX_TRAFFIC, MINIMUM_TRAFFIC
 from logging_wrangler import LoggingWrangler, set_boto_log_level
 
 logger = logging.getLogger(__name__)
@@ -58,7 +58,7 @@ cli.add_command(destroy_demo_traffic)
 @click.option(
     "--expected-traffic", 
     help=("The amount of traffic, in gigabits-per-second, you expect your Arkime Cluster to receive."
-        + f"Minimum: {MINIMUM_TRAFFIC} Gbps,  Maximum: {MAX_TRAFFIC_PER_CLUSTER} Gbps"),
+        + f"Minimum: {MINIMUM_TRAFFIC} Gbps,  Maximum: {MAX_TRAFFIC} Gbps"),
     default=None,
     type=click.INT,
     required=False)

--- a/manage_arkime/cdk_interactions/cdk_context.py
+++ b/manage_arkime/cdk_interactions/cdk_context.py
@@ -3,10 +3,10 @@ import shlex
 from typing import Dict
 
 import constants as constants
-from core.capacity_planning import CaptureNodesPlan, INSTANCE_TYPE_CAPTURE_NODE
+from core.capacity_planning import CaptureNodesPlan, INSTANCE_TYPE_CAPTURE_NODE, EcsSysResourcePlan
 
-def generate_create_cluster_context(name: str, viewer_cert_arn: str, capture_plan: CaptureNodesPlan) -> Dict[str, str]:
-    create_context = _generate_cluster_context(name, viewer_cert_arn, capture_plan)
+def generate_create_cluster_context(name: str, viewer_cert_arn: str, capture_plan: CaptureNodesPlan, ecs_resource_plan: EcsSysResourcePlan) -> Dict[str, str]:
+    create_context = _generate_cluster_context(name, viewer_cert_arn, capture_plan, ecs_resource_plan)
     create_context[constants.CDK_CONTEXT_CMD_VAR] = constants.CMD_CREATE_CLUSTER
     return create_context
 
@@ -15,13 +15,14 @@ def generate_destroy_cluster_context(name: str) -> Dict[str, str]:
     # we're tearing down the Cfn stack in which it would be used, the operation either succeeds they are irrelevant
     # or it fails/rolls back they are irrelevant.
     fake_arn = "N/A"
-    fake_capture_capacity = CaptureNodesPlan(INSTANCE_TYPE_CAPTURE_NODE, 1, 2)
+    fake_capture_capacity = CaptureNodesPlan(INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1)
+    fake_resource_plan = EcsSysResourcePlan(1, 1)
 
-    destroy_context = _generate_cluster_context(name, fake_arn, fake_capture_capacity)
+    destroy_context = _generate_cluster_context(name, fake_arn, fake_capture_capacity, fake_resource_plan)
     destroy_context[constants.CDK_CONTEXT_CMD_VAR] = constants.CMD_DESTROY_CLUSTER
     return destroy_context
 
-def _generate_cluster_context(name: str, viewer_cert_arn: str, capture_plan: CaptureNodesPlan) -> Dict[str, str]:
+def _generate_cluster_context(name: str, viewer_cert_arn: str, capture_plan: CaptureNodesPlan, ecs_resources_plan: EcsSysResourcePlan) -> Dict[str, str]:
     cmd_params = {
         "nameCluster": name,
         "nameCaptureBucketStack": constants.get_capture_bucket_stack_name(name),
@@ -36,7 +37,8 @@ def _generate_cluster_context(name: str, viewer_cert_arn: str, capture_plan: Cap
         "nameViewerPassSsmParam": constants.get_viewer_password_ssm_param_name(name),
         "nameViewerUserSsmParam": constants.get_viewer_user_ssm_param_name(name),
         "nameViewerNodesStack": constants.get_viewer_nodes_stack_name(name),
-        "planCaptureNodes": json.dumps(capture_plan.to_dict())
+        "planCaptureNodes": json.dumps(capture_plan.to_dict()),
+        "planEcsResources": json.dumps(ecs_resources_plan.to_dict())
     }
 
     return {

--- a/manage_arkime/commands/create_cluster.py
+++ b/manage_arkime/commands/create_cluster.py
@@ -1,4 +1,6 @@
+import json
 import logging
+from typing import Tuple
 
 from aws_interactions.acm_interactions import upload_default_elb_cert
 from aws_interactions.aws_client_provider import AwsClientProvider
@@ -6,16 +8,18 @@ import aws_interactions.ssm_operations as ssm_ops
 from cdk_interactions.cdk_client import CdkClient
 import cdk_interactions.cdk_context as context
 import constants as constants
-from core.capacity_planning import get_capture_node_capacity_plan
+from core.capacity_planning import get_capture_node_capacity_plan, get_ecs_sys_resource_plan, CaptureNodesPlan, EcsSysResourcePlan, MINIMUM_TRAFFIC
 
 logger = logging.getLogger(__name__)
 
 def cmd_create_cluster(profile: str, region: str, name: str, expected_traffic: int):
     logger.debug(f"Invoking create-cluster with profile '{profile}' and region '{region}'")
 
-    capture_plan = get_capture_node_capacity_plan(expected_traffic)
+    aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)
 
-    cert_arn = _set_up_viewer_cert(profile, region, name)
+    capture_plan, ecs_resource_plan = _get_capacity_plans(name, expected_traffic, aws_provider)
+
+    cert_arn = _set_up_viewer_cert(name, aws_provider)
 
     cdk_client = CdkClient()
     stacks_to_deploy = [
@@ -25,12 +29,36 @@ def cmd_create_cluster(profile: str, region: str, name: str, expected_traffic: i
         constants.get_opensearch_domain_stack_name(name),
         constants.get_viewer_nodes_stack_name(name)
     ]
-    create_context = context.generate_create_cluster_context(name, cert_arn, capture_plan)
+    create_context = context.generate_create_cluster_context(name, cert_arn, capture_plan, ecs_resource_plan)
     cdk_client.deploy(stacks_to_deploy, aws_profile=profile, aws_region=region, context=create_context)
 
-def _set_up_viewer_cert(profile: str, region: str, name: str) -> str:
-    aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)
+def _get_capacity_plans(cluster_name: str, expected_traffic: int, aws_provider: AwsClientProvider) -> Tuple[CaptureNodesPlan, EcsSysResourcePlan]:
+    
+    if not expected_traffic:
+        try:
+            plan_json = ssm_ops.get_ssm_param_json_value(
+                constants.get_cluster_ssm_param_name(cluster_name),
+                "captureNodesPlan",
+                aws_provider
+            )
+            capture_plan = CaptureNodesPlan(
+                instance_type=plan_json["instanceType"],
+                desired_count=plan_json["desiredCount"],
+                max_count=plan_json["maxCount"],
+                min_count=plan_json["minCount"],
+            )
 
+        except ssm_ops.ParamDoesNotExist:
+            capture_plan = get_capture_node_capacity_plan(MINIMUM_TRAFFIC)
+    else:
+        capture_plan = get_capture_node_capacity_plan(expected_traffic)
+
+    ecs_resource_plan = get_ecs_sys_resource_plan(capture_plan.instance_type)
+
+    return (capture_plan, ecs_resource_plan)
+        
+
+def _set_up_viewer_cert(name: str, aws_provider: AwsClientProvider) -> str:
     # Only set up the certificate if it doesn't exist
     cert_ssm_param = constants.get_viewer_cert_ssm_param_name(name)
     try:

--- a/manage_arkime/core/capacity_planning.py
+++ b/manage_arkime/core/capacity_planning.py
@@ -6,14 +6,14 @@ logger = logging.getLogger(__name__)
 
 INSTANCE_TYPE_CAPTURE_NODE = "m5.xlarge" # Arbitrarily chosen
 TRAFFIC_PER_M5_XL = 2 # in Gbps, guestimate, should be updated with experimental data
-MAX_TRAFFIC_PER_CLUSTER = 100 # Gbps, scaling limit of a single User Subnet VPC Endpoint
+MAX_TRAFFIC = 100 # Gbps, scaling limit of a single User Subnet VPC Endpoint
 MINIMUM_NODES = 1 # We'll always have at least one capture node
 MINIMUM_TRAFFIC = MINIMUM_NODES * TRAFFIC_PER_M5_XL
 CAPACITY_BUFFER_FACTOR = 1.25 # Arbitrarily chosen
 
 class TooMuchTraffic(Exception):
     def __init__(self, expected_traffic: int):
-        super().__init__(f"User's expected traffic ({expected_traffic} Gbps) exceed the limit of a single cluster ({MAX_TRAFFIC_PER_CLUSTER})")
+        super().__init__(f"User's expected traffic ({expected_traffic} Gbps) exceed the limit of a single cluster ({MAX_TRAFFIC})")
 
 @dataclass
 class CaptureNodesPlan:
@@ -42,7 +42,7 @@ def get_capture_node_capacity_plan(expected_traffic: int) -> CaptureNodesPlan:
 
     if not expected_traffic or expected_traffic < TRAFFIC_PER_M5_XL:
         desired_instances = MINIMUM_NODES
-    elif expected_traffic > MAX_TRAFFIC_PER_CLUSTER:
+    elif expected_traffic > MAX_TRAFFIC:
         raise TooMuchTraffic(expected_traffic)
     else:
         desired_instances = math.ceil(expected_traffic/TRAFFIC_PER_M5_XL)

--- a/manage_arkime/core/capacity_planning.py
+++ b/manage_arkime/core/capacity_planning.py
@@ -20,15 +20,18 @@ class CaptureNodesPlan:
     instance_type: str
     desired_count: int
     max_count: int
+    min_count: int
 
     def __equal__(self, other):
-        return self.instance_type == other.instance_type and self.desired_count == other.desired_count and self.max_count == other.max_count
+        return (self.instance_type == other.instance_type and self.desired_count == other.desired_count
+                and self.max_count == other.max_count and self.min_count == other.min_count)
 
     def to_dict(self):
         return {
             "instanceType": self.instance_type,
             "desiredCount": self.desired_count,
             "maxCount": self.max_count,
+            "minCount": self.min_count,
         }
 
 def get_capture_node_capacity_plan(expected_traffic: int) -> CaptureNodesPlan:
@@ -47,6 +50,44 @@ def get_capture_node_capacity_plan(expected_traffic: int) -> CaptureNodesPlan:
     return CaptureNodesPlan(
         INSTANCE_TYPE_CAPTURE_NODE,
         desired_instances,
-        math.ceil(desired_instances * CAPACITY_BUFFER_FACTOR)
+        math.ceil(desired_instances * CAPACITY_BUFFER_FACTOR),
+        MINIMUM_NODES
     )
 
+
+class UnknownInstanceType(Exception):
+    def __init__(self, instance_type: str):
+        super().__init__(f"Unknown instance type: {instance_type}")
+
+@dataclass
+class EcsSysResourcePlan:
+    cpu: int # vCPUs; 1024 per 1 vCPU
+    memory: int # in MB
+
+    def __equal__(self, other):
+        return self.cpu == other.cpu and self.memory == other.memory
+
+    def to_dict(self):
+        return {
+            "cpu": self.cpu,
+            "memory": self.memory
+        }
+
+def get_ecs_sys_resource_plan(instance_type: str) -> EcsSysResourcePlan:
+    """
+    Creates a capacity plan for the indicated instance type.
+    instance_type: The instance type to plan for
+    """
+
+    if instance_type == INSTANCE_TYPE_CAPTURE_NODE:
+        # We want the full capacity of our m5.xlarge because we're using HOST network type and therefore won't
+        # place multiple containers on a single host.  However, we can't ask for ALL of its resources (ostensibly,
+        # 4 vCPU and 16 GiB) because then ECS placement will fail.  We therefore ask for a slightly reduced
+        # amount.  This is the minimum amount we're requesting ECS to reserve, so it can't reserve more than
+        # exist.
+        return EcsSysResourcePlan(
+            3584, # 3.5 vCPUs
+            15360 # 15 GiB
+        )
+    else:
+        raise UnknownInstanceType(instance_type)

--- a/manage_arkime/core/capacity_planning.py
+++ b/manage_arkime/core/capacity_planning.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass
+import math
+import logging
+
+logger = logging.getLogger(__name__)
+
+INSTANCE_TYPE_CAPTURE_NODE = "m5.xlarge" # Arbitrarily chosen
+TRAFFIC_PER_M5_XL = 2 # in Gbps, guestimate, should be updated with experimental data
+MAX_TRAFFIC_PER_CLUSTER = 100 # Gbps, scaling limit of a single User Subnet VPC Endpoint
+MINIMUM_NODES = 1 # We'll always have at least one capture node
+MINIMUM_TRAFFIC = MINIMUM_NODES * TRAFFIC_PER_M5_XL
+CAPACITY_BUFFER_FACTOR = 1.25 # Arbitrarily chosen
+
+class TooMuchTraffic(Exception):
+    def __init__(self, expected_traffic: int):
+        super().__init__(f"User's expected traffic ({expected_traffic} Gbps) exceed the limit of a single cluster ({MAX_TRAFFIC_PER_CLUSTER})")
+
+@dataclass
+class CaptureNodesPlan:
+    instance_type: str
+    desired_count: int
+    max_count: int
+
+    def __equal__(self, other):
+        return self.instance_type == other.instance_type and self.desired_count == other.desired_count and self.max_count == other.max_count
+
+    def to_dict(self):
+        return {
+            "instanceType": self.instance_type,
+            "desiredCount": self.desired_count,
+            "maxCount": self.max_count,
+        }
+
+def get_capture_node_capacity_plan(expected_traffic: int) -> CaptureNodesPlan:
+    """
+    Creates a capacity plan for the indicated traffic load.
+    expected_traffic: The expected traffic volume for the Arkime cluster, in Gigabits Per Second (Gbps)
+    """
+
+    if not expected_traffic or expected_traffic < TRAFFIC_PER_M5_XL:
+        desired_instances = MINIMUM_NODES
+    elif expected_traffic > MAX_TRAFFIC_PER_CLUSTER:
+        raise TooMuchTraffic(expected_traffic)
+    else:
+        desired_instances = math.ceil(expected_traffic/TRAFFIC_PER_M5_XL)
+
+    return CaptureNodesPlan(
+        INSTANCE_TYPE_CAPTURE_NODE,
+        desired_instances,
+        math.ceil(desired_instances * CAPACITY_BUFFER_FACTOR)
+    )
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,12 @@
       "name": "cloud-demo",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "2.66.1",
+        "aws-cdk-lib": "^2.66.1",
         "constructs": "^10.0.0",
         "source-map-support": "^0.5.21"
       },
       "bin": {
-        "cloud-demo": "bin/cloud-demo.js"
+        "cloud-demo": "cdk-lib/cloud-demo.js"
       },
       "devDependencies": {
         "@types/jest": "^29.4.0",
@@ -1547,12 +1547,14 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1755,7 +1757,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/constructs": {
       "version": "10.1.263",
@@ -3074,6 +3077,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3396,6 +3400,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }

--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
   "devDependencies": {
     "@types/jest": "^29.4.0",
     "@types/node": "18.13.0",
+    "aws-cdk": "2.66.1",
     "jest": "^29.4.2",
     "ts-jest": "^29.0.5",
-    "aws-cdk": "2.66.1",
     "ts-node": "^10.9.1",
     "typescript": "~4.9.5"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.66.1",
+    "aws-cdk-lib": "^2.66.1",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"
   }

--- a/test_manage_arkime/core/test_capacity_planning.py
+++ b/test_manage_arkime/core/test_capacity_planning.py
@@ -27,7 +27,7 @@ def test_WHEN_get_capture_node_capacity_plan_called_THEN_as_expected():
 
     # TEST 4: Max expected traffic number
 
-    actual_value = cap.get_capture_node_capacity_plan(cap.MAX_TRAFFIC_PER_CLUSTER)
+    actual_value = cap.get_capture_node_capacity_plan(cap.MAX_TRAFFIC)
     expected_value = cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 50, 63, 1)
 
     assert expected_value == actual_value
@@ -35,7 +35,7 @@ def test_WHEN_get_capture_node_capacity_plan_called_THEN_as_expected():
     # TEST 5: Excessive expected traffic number
 
     with pytest.raises(cap.TooMuchTraffic):
-        cap.get_capture_node_capacity_plan(cap.MAX_TRAFFIC_PER_CLUSTER + 10)
+        cap.get_capture_node_capacity_plan(cap.MAX_TRAFFIC + 10)
 
 
 def test_WHEN_get_ecs_sys_resource_plan_called_THEN_as_expected():

--- a/test_manage_arkime/core/test_capacity_planning.py
+++ b/test_manage_arkime/core/test_capacity_planning.py
@@ -7,28 +7,28 @@ def test_WHEN_get_capture_node_capacity_plan_called_THEN_as_expected():
     # TEST 1: No expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(None)
-    expected_value = cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2)
+    expected_value = cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1)
 
     assert expected_value == actual_value
     
     # TEST 2: Small expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(0.001)
-    expected_value = cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2)
+    expected_value = cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1)
 
     assert expected_value == actual_value
 
     # TEST 3: Mid-range expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(20)
-    expected_value = cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 10, 13)
+    expected_value = cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 10, 13, 1)
 
     assert expected_value == actual_value
 
     # TEST 4: Max expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(cap.MAX_TRAFFIC_PER_CLUSTER)
-    expected_value = cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 50, 63)
+    expected_value = cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 50, 63, 1)
 
     assert expected_value == actual_value
 
@@ -38,3 +38,13 @@ def test_WHEN_get_capture_node_capacity_plan_called_THEN_as_expected():
         cap.get_capture_node_capacity_plan(cap.MAX_TRAFFIC_PER_CLUSTER + 10)
 
 
+def test_WHEN_get_ecs_sys_resource_plan_called_THEN_as_expected():
+    # TEST 1: Get an m5.xlarge instance
+    actual_value = cap.get_ecs_sys_resource_plan(cap.INSTANCE_TYPE_CAPTURE_NODE)
+    expected_value = cap.EcsSysResourcePlan(3584, 15360)
+
+    assert expected_value == actual_value
+
+    # TEST 2: Get an unknown instance type
+    with pytest.raises(cap.UnknownInstanceType):
+        cap.get_ecs_sys_resource_plan("unknown")

--- a/test_manage_arkime/core/test_capacity_planning.py
+++ b/test_manage_arkime/core/test_capacity_planning.py
@@ -1,0 +1,40 @@
+import pytest
+
+import core.capacity_planning as cap
+
+
+def test_WHEN_get_capture_node_capacity_plan_called_THEN_as_expected():
+    # TEST 1: No expected traffic number
+
+    actual_value = cap.get_capture_node_capacity_plan(None)
+    expected_value = cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2)
+
+    assert expected_value == actual_value
+    
+    # TEST 2: Small expected traffic number
+
+    actual_value = cap.get_capture_node_capacity_plan(0.001)
+    expected_value = cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2)
+
+    assert expected_value == actual_value
+
+    # TEST 3: Mid-range expected traffic number
+
+    actual_value = cap.get_capture_node_capacity_plan(20)
+    expected_value = cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 10, 13)
+
+    assert expected_value == actual_value
+
+    # TEST 4: Max expected traffic number
+
+    actual_value = cap.get_capture_node_capacity_plan(cap.MAX_TRAFFIC_PER_CLUSTER)
+    expected_value = cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 50, 63)
+
+    assert expected_value == actual_value
+
+    # TEST 5: Excessive expected traffic number
+
+    with pytest.raises(cap.TooMuchTraffic):
+        cap.get_capture_node_capacity_plan(cap.MAX_TRAFFIC_PER_CLUSTER + 10)
+
+

--- a/test_manage_arkime/test_create_cluster.py
+++ b/test_manage_arkime/test_create_cluster.py
@@ -5,7 +5,7 @@ import unittest.mock as mock
 import aws_interactions.ssm_operations as ssm_ops
 from commands.create_cluster import cmd_create_cluster, _set_up_viewer_cert
 import constants as constants
-
+from core.capacity_planning import CaptureNodesPlan
 
 @mock.patch("commands.create_cluster._set_up_viewer_cert")
 @mock.patch("commands.create_cluster.CdkClient")
@@ -17,7 +17,7 @@ def test_WHEN_cmd_create_cluster_called_THEN_cdk_command_correct(mock_cdk_client
     mock_cdk_client_cls.return_value = mock_client
 
     # Run our test
-    cmd_create_cluster("profile", "region", "my-cluster")
+    cmd_create_cluster("profile", "region", "my-cluster", 40)
 
     # Check our results
     expected_calls = [
@@ -47,6 +47,7 @@ def test_WHEN_cmd_create_cluster_called_THEN_cdk_command_correct(mock_cdk_client
                     "nameViewerPassSsmParam": constants.get_viewer_password_ssm_param_name("my-cluster"),
                     "nameViewerUserSsmParam": constants.get_viewer_user_ssm_param_name("my-cluster"),
                     "nameViewerNodesStack": constants.get_viewer_nodes_stack_name("my-cluster"),
+                    "planCaptureNodes": json.dumps(CaptureNodesPlan("m5.xlarge", 20, 25).to_dict())
                 }))
             }
         )

--- a/test_manage_arkime/test_create_cluster.py
+++ b/test_manage_arkime/test_create_cluster.py
@@ -3,21 +3,27 @@ import shlex
 import unittest.mock as mock
 
 import aws_interactions.ssm_operations as ssm_ops
-from commands.create_cluster import cmd_create_cluster, _set_up_viewer_cert
+from commands.create_cluster import cmd_create_cluster, _set_up_viewer_cert, _get_capacity_plans
 import constants as constants
-from core.capacity_planning import CaptureNodesPlan
+from core.capacity_planning import CaptureNodesPlan, EcsSysResourcePlan, MINIMUM_TRAFFIC
 
+@mock.patch("commands.create_cluster.AwsClientProvider", mock.Mock())
+@mock.patch("commands.create_cluster._get_capacity_plans")
 @mock.patch("commands.create_cluster._set_up_viewer_cert")
 @mock.patch("commands.create_cluster.CdkClient")
-def test_WHEN_cmd_create_cluster_called_THEN_cdk_command_correct(mock_cdk_client_cls, mock_set_up):
+def test_WHEN_cmd_create_cluster_called_THEN_cdk_command_correct(mock_cdk_client_cls, mock_set_up, mock_get_plans):
     # Set up our mock
     mock_set_up.return_value = "arn"
 
     mock_client = mock.Mock()
     mock_cdk_client_cls.return_value = mock_client
 
+    cap_plan = CaptureNodesPlan("m5.xlarge", 20, 25, 1)
+    ecs_plan = EcsSysResourcePlan(3584, 15360)
+    mock_get_plans.return_value = (cap_plan, ecs_plan)
+
     # Run our test
-    cmd_create_cluster("profile", "region", "my-cluster", 40)
+    cmd_create_cluster("profile", "region", "my-cluster", None)
 
     # Check our results
     expected_calls = [
@@ -47,7 +53,8 @@ def test_WHEN_cmd_create_cluster_called_THEN_cdk_command_correct(mock_cdk_client
                     "nameViewerPassSsmParam": constants.get_viewer_password_ssm_param_name("my-cluster"),
                     "nameViewerUserSsmParam": constants.get_viewer_user_ssm_param_name("my-cluster"),
                     "nameViewerNodesStack": constants.get_viewer_nodes_stack_name("my-cluster"),
-                    "planCaptureNodes": json.dumps(CaptureNodesPlan("m5.xlarge", 20, 25).to_dict())
+                    "planCaptureNodes": json.dumps(cap_plan.to_dict()),
+                    "planEcsResources": json.dumps(ecs_plan.to_dict())
                 }))
             }
         )
@@ -55,11 +62,84 @@ def test_WHEN_cmd_create_cluster_called_THEN_cdk_command_correct(mock_cdk_client
     assert expected_calls == mock_client.deploy.call_args_list
 
     expected_set_up_calls = [
-        mock.call("profile", "region", "my-cluster")
+        mock.call("my-cluster", mock.ANY)
     ]
     assert expected_set_up_calls == mock_set_up.call_args_list
 
-@mock.patch("commands.create_cluster.AwsClientProvider", mock.Mock())
+@mock.patch("commands.create_cluster.ssm_ops")
+def test_WHEN_get_capacity_plans_called_AND_use_existing_THEN_as_expected(mock_ssm_ops):
+    # Set up our mock
+    mock_ssm_ops.get_ssm_param_json_value.return_value = {"instanceType":"m5.xlarge","desiredCount":10,"maxCount":12,"minCount":1}
+
+    mock_provider = mock.Mock()
+
+    # Run our test
+    actual_cap, actual_resources = _get_capacity_plans("my-cluster", None, mock_provider)
+
+    # Check our results
+    assert CaptureNodesPlan("m5.xlarge", 10, 12, 1) == actual_cap
+    assert EcsSysResourcePlan(3584, 15360) == actual_resources
+
+    expected_get_ssm_calls = [
+        mock.call(constants.get_cluster_ssm_param_name("my-cluster"), "captureNodesPlan", mock.ANY)
+    ]
+    assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
+
+@mock.patch("commands.create_cluster.get_capture_node_capacity_plan")
+@mock.patch("commands.create_cluster.ssm_ops")
+def test_WHEN_get_capacity_plans_called_AND_use_default_THEN_as_expected(mock_ssm_ops, mock_get_cap):
+    # Set up our mock
+    mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
+    mock_ssm_ops.get_ssm_param_json_value.side_effect = ssm_ops.ParamDoesNotExist("")
+
+    mock_get_cap.return_value = CaptureNodesPlan("m5.xlarge", 1, 2, 1)
+
+    mock_provider = mock.Mock()
+
+    # Run our test
+    actual_cap, actual_resources = _get_capacity_plans("my-cluster", None, mock_provider)
+
+    # Check our results
+    assert mock_get_cap.return_value == actual_cap
+    assert EcsSysResourcePlan(3584, 15360) == actual_resources
+
+    expected_get_cap_calls = [
+        mock.call(MINIMUM_TRAFFIC)
+    ]
+    assert expected_get_cap_calls == mock_get_cap.call_args_list
+
+    expected_get_ssm_calls = [
+        mock.call(constants.get_cluster_ssm_param_name("my-cluster"), "captureNodesPlan", mock.ANY)
+    ]
+    assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
+
+@mock.patch("commands.create_cluster.get_capture_node_capacity_plan")
+@mock.patch("commands.create_cluster.ssm_ops")
+def test_WHEN_get_capacity_plans_called_AND_gen_plan_THEN_as_expected(mock_ssm_ops, mock_get_cap):
+    # Set up our mock
+    mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
+    mock_ssm_ops.get_ssm_param_json_value.side_effect = ssm_ops.ParamDoesNotExist("")
+
+    mock_get_cap.return_value = CaptureNodesPlan("m5.xlarge", 10, 12, 1)
+
+    mock_provider = mock.Mock()
+
+    # Run our test
+    actual_cap, actual_resources = _get_capacity_plans("my-cluster", 20, mock_provider)
+
+    # Check our results
+    assert mock_get_cap.return_value == actual_cap
+    assert EcsSysResourcePlan(3584, 15360) == actual_resources
+
+    expected_get_cap_calls = [
+        mock.call(20)
+    ]
+    assert expected_get_cap_calls == mock_get_cap.call_args_list
+
+    expected_get_ssm_calls = []
+    assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
+
+
 @mock.patch("commands.create_cluster.upload_default_elb_cert")
 @mock.patch("commands.create_cluster.ssm_ops")
 def test_WHEN_set_up_viewer_cert_called_THEN_set_up_correctly(mock_ssm_ops, mock_upload):
@@ -69,8 +149,10 @@ def test_WHEN_set_up_viewer_cert_called_THEN_set_up_correctly(mock_ssm_ops, mock
 
     mock_upload.return_value = "arn"
 
+    mock_provider = mock.Mock()
+
     # Run our test
-    actual_value = _set_up_viewer_cert("profile", "region", "my-cluster")
+    actual_value = _set_up_viewer_cert("my-cluster", mock_provider)
 
     # Check our results
     assert "arn" == actual_value
@@ -103,8 +185,10 @@ def test_WHEN_set_up_viewer_cert_called_AND_already_exists_THEN_skips_creation(m
     mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
     mock_ssm_ops.get_ssm_param_value.return_value = "arn"
 
+    mock_provider = mock.Mock()
+
     # Run our test
-    actual_value = _set_up_viewer_cert("profile", "region", "my-cluster")
+    actual_value = _set_up_viewer_cert("my-cluster", mock_provider)
 
     # Check our results
     assert "arn" == actual_value

--- a/test_manage_arkime/test_destroy_cluster.py
+++ b/test_manage_arkime/test_destroy_cluster.py
@@ -5,7 +5,7 @@ import unittest.mock as mock
 from aws_interactions.ssm_operations import ParamDoesNotExist
 from commands.destroy_cluster import cmd_destroy_cluster, _destroy_viewer_cert
 import constants as constants
-from core.capacity_planning import CaptureNodesPlan
+from core.capacity_planning import CaptureNodesPlan, EcsSysResourcePlan
 
 TEST_CLUSTER = "my-cluster"
 
@@ -52,7 +52,8 @@ def test_WHEN_cmd_destroy_cluster_called_AND_dont_destroy_everything_THEN_expect
                     "nameViewerPassSsmParam": constants.get_viewer_password_ssm_param_name(TEST_CLUSTER),
                     "nameViewerUserSsmParam": constants.get_viewer_user_ssm_param_name(TEST_CLUSTER),
                     "nameViewerNodesStack": constants.get_viewer_nodes_stack_name(TEST_CLUSTER),
-                    "planCaptureNodes": json.dumps(CaptureNodesPlan("m5.xlarge", 1, 2).to_dict())
+                    "planCaptureNodes": json.dumps(CaptureNodesPlan("m5.xlarge", 1, 2, 1).to_dict()),
+                    "planEcsResources": json.dumps(EcsSysResourcePlan(1, 1).to_dict())
                 }))
             }
         )
@@ -131,7 +132,8 @@ def test_WHEN_cmd_destroy_cluster_called_AND_destroy_everything_THEN_expected_cm
                     "nameViewerPassSsmParam": constants.get_viewer_password_ssm_param_name(TEST_CLUSTER),
                     "nameViewerUserSsmParam": constants.get_viewer_user_ssm_param_name(TEST_CLUSTER),
                     "nameViewerNodesStack": constants.get_viewer_nodes_stack_name(TEST_CLUSTER),
-                    "planCaptureNodes": json.dumps(CaptureNodesPlan("m5.xlarge", 1, 2).to_dict())
+                    "planCaptureNodes": json.dumps(CaptureNodesPlan("m5.xlarge", 1, 2, 1).to_dict()),
+                    "planEcsResources": json.dumps(EcsSysResourcePlan(1, 1).to_dict())
                 }))
             }
         )

--- a/test_manage_arkime/test_destroy_cluster.py
+++ b/test_manage_arkime/test_destroy_cluster.py
@@ -5,6 +5,7 @@ import unittest.mock as mock
 from aws_interactions.ssm_operations import ParamDoesNotExist
 from commands.destroy_cluster import cmd_destroy_cluster, _destroy_viewer_cert
 import constants as constants
+from core.capacity_planning import CaptureNodesPlan
 
 TEST_CLUSTER = "my-cluster"
 
@@ -51,6 +52,7 @@ def test_WHEN_cmd_destroy_cluster_called_AND_dont_destroy_everything_THEN_expect
                     "nameViewerPassSsmParam": constants.get_viewer_password_ssm_param_name(TEST_CLUSTER),
                     "nameViewerUserSsmParam": constants.get_viewer_user_ssm_param_name(TEST_CLUSTER),
                     "nameViewerNodesStack": constants.get_viewer_nodes_stack_name(TEST_CLUSTER),
+                    "planCaptureNodes": json.dumps(CaptureNodesPlan("m5.xlarge", 1, 2).to_dict())
                 }))
             }
         )
@@ -129,6 +131,7 @@ def test_WHEN_cmd_destroy_cluster_called_AND_destroy_everything_THEN_expected_cm
                     "nameViewerPassSsmParam": constants.get_viewer_password_ssm_param_name(TEST_CLUSTER),
                     "nameViewerUserSsmParam": constants.get_viewer_user_ssm_param_name(TEST_CLUSTER),
                     "nameViewerNodesStack": constants.get_viewer_nodes_stack_name(TEST_CLUSTER),
+                    "planCaptureNodes": json.dumps(CaptureNodesPlan("m5.xlarge", 1, 2).to_dict())
                 }))
             }
         )


### PR DESCRIPTION
## Description
* Added a CLI option to set the amount of traffic the Capture Nodes should be configured to handle
* If the user doesn't specify it, a minimum amount is used (one ec2 instance worth).  If the user specifies the value, then later changes it, we'll update the configuration to reflect the new user-provided one.  In the event the user calls `create-cluster` again after setting the capacity to a non-default value, but does not specify a traffic amount in the new call, we re-use the old value.
* Updated README to mention the capacity setting

## Issues
* https://github.com/arkime/aws-aio/issues/52
* https://github.com/arkime/aws-aio/issues/34

## Testing
* Added unit tests
* Ran the option manually and observed that the SSM state and the actual capacity in EC2 changed as expected.


```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py create-cluster --name MyCluster --expected-traffic 10
2023-05-25 09:25:05 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime.log
2023-05-25 09:25:05 - Using AWS Credential Profile: default
2023-05-25 09:25:05 - Using AWS Region: default from AWS Config settings
2023-05-25 09:25:05 - Executing command: deploy MyCluster-CaptureBucket MyCluster-CaptureNodes MyCluster-CaptureVPC MyCluster-OSDomain MyCluster-ViewerNodes
2023-05-25 09:25:05 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-05-25 09:26:04 - Deployment succeeded

SSM State:
{"busArn":"arn:aws:events:us-east-2:XXXXXXXXXXXX:event-bus/MyClusterCaptureNodesClusterBus8101CEAA","busName":"MyClusterCaptureNodesClusterBus8101CEAA","clusterName":"MyCluster","vpceServiceId":"vpce-svc-040bea42f051de3a6","captureNodesPlan":{"instanceType":"m5.xlarge","desiredCount":5,"maxCount":7,"minCount":1},"ecsSysResourcePlan":{"cpu":3584,"memory":15360}}
```

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py create-cluster --name MyCluster
2023-05-25 09:27:25 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime.log
2023-05-25 09:27:25 - Using AWS Credential Profile: default
2023-05-25 09:27:25 - Using AWS Region: default from AWS Config settings
2023-05-25 09:27:25 - Executing command: deploy MyCluster-CaptureBucket MyCluster-CaptureNodes MyCluster-CaptureVPC MyCluster-OSDomain MyCluster-ViewerNodes
2023-05-25 09:27:25 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-05-25 09:27:40 - Deployment succeeded

SSM State:
{"busArn":"arn:aws:events:us-east-2:XXXXXXXXXXXX:event-bus/MyClusterCaptureNodesClusterBus8101CEAA","busName":"MyClusterCaptureNodesClusterBus8101CEAA","clusterName":"MyCluster","vpceServiceId":"vpce-svc-040bea42f051de3a6","captureNodesPlan":{"instanceType":"m5.xlarge","desiredCount":5,"maxCount":7,"minCount":1},"ecsSysResourcePlan":{"cpu":3584,"memory":15360}}
```

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py create-cluster --name MyCluster --expected-traffic 2
2023-05-25 09:31:47 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime.log
2023-05-25 09:31:47 - Using AWS Credential Profile: default
2023-05-25 09:31:47 - Using AWS Region: default from AWS Config settings
2023-05-25 09:32:54 - Executing command: deploy MyCluster-CaptureBucket MyCluster-CaptureNodes MyCluster-CaptureVPC MyCluster-OSDomain MyCluster-ViewerNodes
2023-05-25 09:32:54 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-05-25 09:41:43 - Deployment succeeded

SSM State:
{"busArn":"arn:aws:events:us-east-2:XXXXXXXXXXXX:event-bus/MyClusterCaptureNodesClusterBus8101CEAA","busName":"MyClusterCaptureNodesClusterBus8101CEAA","clusterName":"MyCluster","vpceServiceId":"vpce-svc-040bea42f051de3a6","captureNodesPlan":{"instanceType":"m5.xlarge","desiredCount":1,"maxCount":2,"minCount":1},"ecsSysResourcePlan":{"cpu":3584,"memory":15360}}
```