### PR TITLE
OpenSearch Domain capacity now configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ You can see your created cluster and the VPCs it is currently monitoring using t
 By default, you will be given the minimum-size Capture Cluster.  You can provision a Cluster that will serve your expected usage using a set of optional command-line parameters, which will ensure the EC2 Capture Nodes and OpenSearch Domain are suitably provisioned (plus a little extra for safety):
 
 ```
-./manage_arkime.py create-cluster --name MyCluster --expected-traffic 1 --spi-days 30 --replicas 2
+./manage_arkime.py create-cluster --name MyCluster --expected-traffic 1 --spi-days 30 --replicas 1
 ```
 
 ### Setting up capture for a VPC

--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ You can see your created cluster and the VPCs it is currently monitoring using t
 ./manage_arkime.py create-cluster --name MyCluster
 ```
 
-By default, you will be given the minimum-size Capture Node fleet.  If you have a specific amount of traffic you're expecting to need to be able to capture, you an specify it (in Gbps) using the `--expected-traffic` argument.  The CLI will provision an EC2 Autoscaling Group that should be able to handle that amount of capture plus a little extra.
+By default, you will be given the minimum-size Capture Cluster.  You can provision a Cluster that will serve your expected usage using a set of optional command-line parameters, which will ensure the EC2 Capture Nodes and OpenSearch Domain are suitably provisioned (plus a little extra for safety):
 
 ```
-./manage_arkime.py create-cluster --name MyCluster --expected-traffic 10
+./manage_arkime.py create-cluster --name MyCluster --expected-traffic 1 --spi-days 30 --replicas 2
 ```
 
 ### Setting up capture for a VPC

--- a/cdk-lib/capture-stacks/capture-nodes-stack.ts
+++ b/cdk-lib/capture-stacks/capture-nodes-stack.ts
@@ -18,6 +18,7 @@ import { Construct } from 'constructs';
 import * as constants from '../core/constants';
 import * as plan from '../core/capacity-plan';
 import {ClusterSsmValue} from '../core/ssm-wrangling';
+import * as user from '../core/user-config';
 
 export interface CaptureNodesStackProps extends cdk.StackProps {
     readonly captureBucket: s3.Bucket;
@@ -28,6 +29,7 @@ export interface CaptureNodesStackProps extends cdk.StackProps {
     readonly osPassword: secretsmanager.Secret;
     readonly planCluster: plan.ClusterPlan;
     readonly ssmParamNameCluster: string;
+    readonly userConfig: user.UserConfig;
 }
 
 export class CaptureNodesStack extends cdk.Stack {
@@ -241,7 +243,8 @@ export class CaptureNodesStack extends cdk.Stack {
             busName: clusterBus.eventBusName,
             clusterName: props.clusterName, 
             vpceServiceId: gwlbEndpointService.ref,
-            capacityPlan: props.planCluster
+            capacityPlan: props.planCluster,
+            userConfig: props.userConfig
         }
         const clusterParam = new ssm.StringParameter(this, 'ClusterParam', {
             allowedPattern: '.*',

--- a/cdk-lib/capture-stacks/capture-vpc-stack.ts
+++ b/cdk-lib/capture-stacks/capture-vpc-stack.ts
@@ -4,15 +4,21 @@ import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as logs from 'aws-cdk-lib/aws-logs';
 import { Stack, StackProps } from 'aws-cdk-lib';
 
+import * as plan from '../core/capacity-plan';
+
+export interface CaptureVpcStackProps extends StackProps {
+    readonly planCluster: plan.ClusterPlan;
+}
+
 export class CaptureVpcStack extends Stack {
   public readonly vpc: ec2.Vpc;
   public readonly flowLog: ec2.FlowLog;
 
-  constructor(scope: Construct, id: string, props: StackProps) {
+  constructor(scope: Construct, id: string, props: CaptureVpcStackProps) {
     super(scope, id, props);
 
     this.vpc = new ec2.Vpc(this, 'VPC', {
-        maxAzs: 2,
+        maxAzs: props.planCluster.captureVpc.numAzs,
         subnetConfiguration: [
             {
                 subnetType: ec2.SubnetType.PUBLIC,

--- a/cdk-lib/cloud-demo.ts
+++ b/cdk-lib/cloud-demo.ts
@@ -29,12 +29,14 @@ switch(params.type) {
         });
 
         const captureVpcStack = new CaptureVpcStack(app, params.nameCaptureVpcStack, {
-            env: env
+            env: env,
+            planCluster: params.planCluster,
         });
 
         const osDomainStack = new OpenSearchDomainStack(app, params.nameOSDomainStack, {
             env: env,
             captureVpc: captureVpcStack.vpc,
+            planCluster: params.planCluster,
             ssmParamName: params.nameOSDomainSsmParam,
         });
         osDomainStack.addDependency(captureVpcStack)
@@ -47,8 +49,7 @@ switch(params.type) {
             clusterName: params.nameCluster,
             osDomain: osDomainStack.domain,
             osPassword: osDomainStack.osPassword,
-            planCaptureNodes: params.planCaptureNodes,
-            planEcsResources: params.planEcsResources,
+            planCluster: params.planCluster,
             ssmParamNameCluster: params.nameClusterSsmParam
         });
         captureNodesStack.addDependency(captureBucketStack)

--- a/cdk-lib/cloud-demo.ts
+++ b/cdk-lib/cloud-demo.ts
@@ -50,7 +50,8 @@ switch(params.type) {
             osDomain: osDomainStack.domain,
             osPassword: osDomainStack.osPassword,
             planCluster: params.planCluster,
-            ssmParamNameCluster: params.nameClusterSsmParam
+            ssmParamNameCluster: params.nameClusterSsmParam,
+            userConfig: params.userConfig
         });
         captureNodesStack.addDependency(captureBucketStack)
         captureNodesStack.addDependency(captureVpcStack)

--- a/cdk-lib/core/capacity-plan.ts
+++ b/cdk-lib/core/capacity-plan.ts
@@ -15,3 +15,45 @@ export interface EcsSysResourcePlan {
     cpu: number;
     memory: number;
 }
+
+/**
+ * Structure to hold the capacity plan for an OS Domain's data nodes
+ */
+export interface DataNodesPlan {
+    count: number;
+    instanceType: string;
+    volumeSize: number;
+}
+
+/**
+ * Structure to hold the capacity plan for an OS Domain's master nodes
+ */
+export interface MasterNodesPlan {
+    count: number;
+    instanceType: string;
+}
+
+/**
+ * Structure to hold the overall capacity plan for an OS Domain
+ */
+export interface OSDomainPlan {
+    dataNodes: DataNodesPlan;
+    masterNodes: MasterNodesPlan;
+}
+
+/**
+ * Structure to hold the details of the cluster's Capture VPC
+ */
+export interface CaptureVpcPlan {
+    numAzs: number;
+}
+
+/**
+ * Structure to hold the overall capacity plan for an Arkime Cluster
+ */
+export interface ClusterPlan {
+    captureNodes: CaptureNodesPlan;
+    captureVpc: CaptureVpcPlan;
+    ecsResources: EcsSysResourcePlan;
+    osDomain: OSDomainPlan;
+}

--- a/cdk-lib/core/command-params.ts
+++ b/cdk-lib/core/command-params.ts
@@ -25,8 +25,7 @@ export interface ClusterMgmtParamsRaw extends CommandParamsRaw {
     nameViewerPassSsmParam: string;
     nameViewerUserSsmParam: string;
     nameViewerNodesStack: string;
-    planCaptureNodes: string;
-    planEcsResources: string;
+    planCluster: string;
 }
 
 /**
@@ -89,8 +88,7 @@ export interface ClusterMgmtParams extends CommandParams {
     nameViewerPassSsmParam: string;
     nameViewerUserSsmParam: string;
     nameViewerNodesStack: string;
-    planCaptureNodes: plan.CaptureNodesPlan;
-    planEcsResources: plan.EcsSysResourcePlan;
+    planCluster: plan.ClusterPlan;
 }
 
 /**

--- a/cdk-lib/core/command-params.ts
+++ b/cdk-lib/core/command-params.ts
@@ -1,4 +1,5 @@
 import * as plan from './capacity-plan';
+import * as user from './user-config';
 
 /**
  * Base type for receiving arguments from the Python side of the app.  These directly match the interface on the Python
@@ -26,6 +27,7 @@ export interface ClusterMgmtParamsRaw extends CommandParamsRaw {
     nameViewerUserSsmParam: string;
     nameViewerNodesStack: string;
     planCluster: string;
+    userConfig: string;
 }
 
 /**
@@ -89,6 +91,7 @@ export interface ClusterMgmtParams extends CommandParams {
     nameViewerUserSsmParam: string;
     nameViewerNodesStack: string;
     planCluster: plan.ClusterPlan;
+    userConfig: user.UserConfig;
 }
 
 /**

--- a/cdk-lib/core/context-wrangling.ts
+++ b/cdk-lib/core/context-wrangling.ts
@@ -15,7 +15,7 @@ import {CDK_CONTEXT_CMD_VAR, CDK_CONTEXT_REGION_VAR, CDK_CONTEXT_PARAMS_VAR, Man
 export function getCommandParams(app: cdk.App) : (prms.ClusterMgmtParams | prms.DeployDemoTrafficParams | prms.DestroyDemoTrafficParams | prms.MirrorMgmtParams) {
     // This ENV variable is set by the CDK CLI.  It reads it from your AWS Credential profile, and configures the var
     // before invoking CDK actions.
-    const awsAccount: string | undefined = process.env.CDK_DEFAULT_ACCOUNT    
+    const awsAccount: string | undefined = process.env.CDK_DEFAULT_ACCOUNT
 
     // Like the CDK_DEFAULT_ACCOUNT, the CDK CLI sets the CDK_DEFAULT_REGION by reading the AWS Credential profile.
     // However, we want the user to to able to specify a different region than the default so we optionaly pass in one
@@ -100,6 +100,7 @@ function validateArgs(args: ValidateArgs) : (prms.ClusterMgmtParams | prms.Deplo
                 nameViewerUserSsmParam: rawClusterMgmtParamsObj.nameViewerUserSsmParam,
                 nameViewerNodesStack: rawClusterMgmtParamsObj.nameViewerNodesStack,
                 planCluster:  JSON.parse(rawClusterMgmtParamsObj.planCluster),
+                userConfig: JSON.parse(rawClusterMgmtParamsObj.userConfig),
             }
             return clusterMgmtParams;
         case ManagementCmd.AddVpc: // Add and Remove VPC use the same parameters

--- a/cdk-lib/core/context-wrangling.ts
+++ b/cdk-lib/core/context-wrangling.ts
@@ -99,8 +99,7 @@ function validateArgs(args: ValidateArgs) : (prms.ClusterMgmtParams | prms.Deplo
                 nameViewerPassSsmParam: rawClusterMgmtParamsObj.nameViewerPassSsmParam,
                 nameViewerUserSsmParam: rawClusterMgmtParamsObj.nameViewerUserSsmParam,
                 nameViewerNodesStack: rawClusterMgmtParamsObj.nameViewerNodesStack,
-                planCaptureNodes:  JSON.parse(rawClusterMgmtParamsObj.planCaptureNodes),
-                planEcsResources:  JSON.parse(rawClusterMgmtParamsObj.planEcsResources),
+                planCluster:  JSON.parse(rawClusterMgmtParamsObj.planCluster),
             }
             return clusterMgmtParams;
         case ManagementCmd.AddVpc: // Add and Remove VPC use the same parameters

--- a/cdk-lib/core/ssm-wrangling.ts
+++ b/cdk-lib/core/ssm-wrangling.ts
@@ -1,4 +1,5 @@
 import * as plan from '../core/capacity-plan';
+import * as user from '../core/user-config';
 
 /**
  * This file contains functions and types that define a shared interface with the Python management CLI; the two need
@@ -12,6 +13,7 @@ export interface ClusterSsmValue {
     readonly clusterName: string;
     readonly vpceServiceId: string;
     readonly capacityPlan: plan.ClusterPlan;
+    readonly userConfig: user.UserConfig;
 }
 
 export interface SubnetSsmValue {

--- a/cdk-lib/core/ssm-wrangling.ts
+++ b/cdk-lib/core/ssm-wrangling.ts
@@ -11,8 +11,7 @@ export interface ClusterSsmValue {
     readonly busName: string;
     readonly clusterName: string;
     readonly vpceServiceId: string;
-    readonly captureNodesPlan: plan.CaptureNodesPlan;
-    readonly ecsSysResourcePlan: plan.EcsSysResourcePlan;
+    readonly capacityPlan: plan.ClusterPlan;
 }
 
 export interface SubnetSsmValue {

--- a/cdk-lib/core/user-config.ts
+++ b/cdk-lib/core/user-config.ts
@@ -1,0 +1,8 @@
+/**
+ * Structure to hold the user's input configuration
+ */
+export interface UserConfig {
+    expectedTraffic: number;
+    spiDays: number;
+    replicas: number;
+}

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -57,7 +57,7 @@ cli.add_command(destroy_demo_traffic)
 @click.option("--name", help="The name you want your Arkime Cluster and its associated resources to have", required=True)
 @click.option(
     "--expected-traffic", 
-    help=("The amount of traffic, in gigabits-per-second, you expect your Arkime Cluster to receive."
+    help=("The average amount of traffic, in gigabits-per-second, you expect your Arkime Cluster to receive."
         + f"Maximum: {MAX_TRAFFIC} Gbps"),
     default=None,
     type=click.FLOAT,

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -12,7 +12,7 @@ from commands.get_login_details import cmd_get_login_details
 from commands.list_clusters import cmd_list_clusters
 from commands.remove_vpc import cmd_remove_vpc
 import constants as constants
-from core.capacity_planning import MAX_TRAFFIC, MINIMUM_TRAFFIC
+from core.capacity_planning import MAX_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_SPI_REPLICAS
 from logging_wrangler import LoggingWrangler, set_boto_log_level
 
 logger = logging.getLogger(__name__)
@@ -58,15 +58,27 @@ cli.add_command(destroy_demo_traffic)
 @click.option(
     "--expected-traffic", 
     help=("The amount of traffic, in gigabits-per-second, you expect your Arkime Cluster to receive."
-        + f"Minimum: {MINIMUM_TRAFFIC} Gbps,  Maximum: {MAX_TRAFFIC} Gbps"),
+        + f"Maximum: {MAX_TRAFFIC} Gbps"),
     default=None,
     type=click.FLOAT,
     required=False)
+@click.option(
+    "--spi-days", 
+    help=(f"The number of days to store SPI metadata in the OpenSearch Domain.  Default: {DEFAULT_SPI_DAYS}"),
+    default=None,
+    type=click.INT,
+    required=False)
+@click.option(
+    "--replicas", 
+    help=(f"The number replicas to make of the SPI metadata in the OpenSearch Domain.  Default: {DEFAULT_SPI_REPLICAS}"),
+    default=None,
+    type=click.INT,
+    required=False)
 @click.pass_context
-def create_cluster(ctx, name, expected_traffic):
+def create_cluster(ctx, name, expected_traffic, spi_days, replicas):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_create_cluster(profile, region, name, expected_traffic)
+    cmd_create_cluster(profile, region, name, expected_traffic, spi_days, replicas)
 cli.add_command(create_cluster)
 
 @click.command(help="Tears down the Arkime Cluster in your account; by default, leaves your data intact")

--- a/manage_arkime/commands/create_cluster.py
+++ b/manage_arkime/commands/create_cluster.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from typing import Tuple
 
 from aws_interactions.acm_interactions import upload_default_elb_cert
 from aws_interactions.aws_client_provider import AwsClientProvider
@@ -9,21 +8,18 @@ from cdk_interactions.cdk_client import CdkClient
 import cdk_interactions.cdk_context as context
 import constants as constants
 from core.capacity_planning import (get_capture_node_capacity_plan, get_ecs_sys_resource_plan, get_os_domain_plan, ClusterPlan,
-                                    CaptureNodesPlan, CaptureVpcPlan, EcsSysResourcePlan, OSDomainPlan, MINIMUM_TRAFFIC,
-                                    DEFAULT_SPI_DAYS, DEFAULT_SPI_REPLICAS, DEFAULT_NUM_AZS)
+                                    CaptureVpcPlan, MINIMUM_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_SPI_REPLICAS, DEFAULT_NUM_AZS)
+from core.user_config import UserConfig
 
 logger = logging.getLogger(__name__)
-
-class MustProvideAllParams(Exception):
-    def __init__(self):
-        super().__init__("If you specify one of the optional capacity parameters, you must specify all of them.")
 
 def cmd_create_cluster(profile: str, region: str, name: str, expected_traffic: float, spi_days: int, replicas: int):
     logger.debug(f"Invoking create-cluster with profile '{profile}' and region '{region}'")
 
     aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)
 
-    capacity_plan = _get_capacity_plan(name, expected_traffic, spi_days, replicas, aws_provider)
+    user_config = _get_user_config(name, expected_traffic, spi_days, replicas, aws_provider)
+    capacity_plan = _get_capacity_plan(user_config)
 
     cert_arn = _set_up_viewer_cert(name, aws_provider)
 
@@ -35,38 +31,41 @@ def cmd_create_cluster(profile: str, region: str, name: str, expected_traffic: f
         constants.get_opensearch_domain_stack_name(name),
         constants.get_viewer_nodes_stack_name(name)
     ]
-    create_context = context.generate_create_cluster_context(name, cert_arn, capacity_plan)
+    create_context = context.generate_create_cluster_context(name, cert_arn, capacity_plan, user_config)
     cdk_client.deploy(stacks_to_deploy, aws_profile=profile, aws_region=region, context=create_context)
 
-def _get_capacity_plan(cluster_name: str, expected_traffic: float, spi_days: int, replicas: int, aws_provider: AwsClientProvider) -> ClusterPlan:
-    
-    # None of the parameters defined
-    if (not expected_traffic) and (not spi_days) and (not replicas):
+def _get_user_config(cluster_name: str, expected_traffic: float, spi_days: int, replicas: int, aws_provider: AwsClientProvider) -> UserConfig:
+    # At least one parameter isn't defined
+    if None in [expected_traffic, spi_days, replicas]:
         # Re-use the existing configuration if it exists
         try:
-            plan_json = ssm_ops.get_ssm_param_json_value(
+            stored_config_json = ssm_ops.get_ssm_param_json_value(
                 constants.get_cluster_ssm_param_name(cluster_name),
-                "capacityPlan",
+                "userConfig",
                 aws_provider
             )
-            capacity_plan = ClusterPlan.from_dict(plan_json)
+            user_config = UserConfig(**stored_config_json)
 
-            return capacity_plan
+            if expected_traffic is not None:
+                user_config.expectedTraffic = expected_traffic
+            if spi_days is not None:
+                user_config.spiDays = spi_days
+            if replicas is not None:
+                user_config.replicas = replicas
+
+            return user_config
 
         # Existing configuration doesn't exist, use defaults
         except ssm_ops.ParamDoesNotExist:
-            capture_plan = get_capture_node_capacity_plan(MINIMUM_TRAFFIC)
-            capture_vpc_plan = CaptureVpcPlan(DEFAULT_NUM_AZS)
-            os_domain_plan = get_os_domain_plan(MINIMUM_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_SPI_REPLICAS, capture_vpc_plan.numAzs)
+            return UserConfig(MINIMUM_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_SPI_REPLICAS)
     # All of the parameters defined
-    elif expected_traffic and spi_days and replicas:
-        capture_plan = get_capture_node_capacity_plan(expected_traffic)
-        capture_vpc_plan = CaptureVpcPlan(DEFAULT_NUM_AZS)
-        os_domain_plan = get_os_domain_plan(expected_traffic, spi_days, replicas, capture_vpc_plan.numAzs)
-    # Some, but not all, of the parameters defined
     else:
-        raise MustProvideAllParams()
+        return UserConfig(expected_traffic, spi_days, replicas)
 
+def _get_capacity_plan(user_config: UserConfig) -> ClusterPlan:
+    capture_plan = get_capture_node_capacity_plan(user_config.expectedTraffic)
+    capture_vpc_plan = CaptureVpcPlan(DEFAULT_NUM_AZS)
+    os_domain_plan = get_os_domain_plan(user_config.expectedTraffic, user_config.spiDays, user_config.replicas, capture_vpc_plan.numAzs)
     ecs_resource_plan = get_ecs_sys_resource_plan(capture_plan.instanceType)
 
     return ClusterPlan(capture_plan, capture_vpc_plan, ecs_resource_plan, os_domain_plan)

--- a/manage_arkime/core/capacity_planning.py
+++ b/manage_arkime/core/capacity_planning.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from enum import Enum
 import math
 import logging
 from typing import Dict, Type, TypeVar
@@ -36,7 +35,7 @@ class CaptureNodesPlan:
         return (self.instanceType == other.instance_type and self.desiredCount == other.desired_count
                 and self.maxCount == other.max_count and self.minCount == other.min_count)
 
-    def to_dict(self) -> Dict[str, str]:
+    def to_dict(self) -> Dict[str, any]:
         return {
             "instanceType": self.instanceType,
             "desiredCount": self.desiredCount,
@@ -77,7 +76,7 @@ class EcsSysResourcePlan:
     def __equal__(self, other):
         return self.cpu == other.cpu and self.memory == other.memory
 
-    def to_dict(self) -> Dict[str, str]:
+    def to_dict(self) -> Dict[str, any]:
         return {
             "cpu": self.cpu,
             "memory": self.memory
@@ -135,7 +134,7 @@ class DataNodesPlan:
         return (self.count == other.count and self.instanceType == other.type
                 and self.volumeSize == other.vol_size)
 
-    def to_dict(self) -> Dict[str, str]:
+    def to_dict(self) -> Dict[str, any]:
         return {
             "count": self.count,
             "instanceType": self.instanceType,
@@ -150,7 +149,7 @@ class MasterNodesPlan:
     def __equal__(self, other):
         return (self.count == other.count and self.instanceType == other.type)
 
-    def to_dict(self) -> Dict[str, str]:
+    def to_dict(self) -> Dict[str, any]:
         return {
             "count": self.count,
             "instanceType": self.instanceType
@@ -167,7 +166,7 @@ class OSDomainPlan:
         return (self.dataNodes == other.dataNodes
                 and self.masterNodes == other.masterNodes)
 
-    def to_dict(self) -> Dict[str, str]:
+    def to_dict(self) -> Dict[str, any]:
         return {
             "dataNodes": self.dataNodes.to_dict(),
             "masterNodes": self.masterNodes.to_dict()
@@ -298,7 +297,7 @@ class CaptureVpcPlan:
     def __equal__(self, other):
         return self.numAzs == other.numAzs
     
-    def to_dict(self) -> Dict[str, str]:
+    def to_dict(self) -> Dict[str, any]:
         return {
             "numAzs": self.numAzs
         }
@@ -316,7 +315,7 @@ class ClusterPlan:
         return (self.captureNodes == other.captureNodes and self.ecsResources == other.ecsResources 
                 and self.osDomain == other.osDomain and self.captureVpc == other.vpc)
 
-    def to_dict(self) -> Dict[str, str]:
+    def to_dict(self) -> Dict[str, any]:
         return {
             "captureNodes": self.captureNodes.to_dict(),
             "captureVpc": self.captureVpc.to_dict(),

--- a/manage_arkime/core/user_config.py
+++ b/manage_arkime/core/user_config.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+import logging
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class UserConfig:
+    expectedTraffic: float
+    spiDays: int
+    replicas: int
+
+    def __equal__(self, other):
+        return (self.expectedTraffic == other.expectedTraffic and self.spiDays == other.spiDays 
+                and self.replicas == other.replicas)
+
+    def to_dict(self) -> Dict[str, any]:
+        return {
+            'expectedTraffic': self.expectedTraffic,
+            'spiDays': self.spiDays,
+            'replicas': self.replicas
+        }
+

--- a/test_manage_arkime/commands/test_create_cluster.py
+++ b/test_manage_arkime/commands/test_create_cluster.py
@@ -4,21 +4,26 @@ import shlex
 import unittest.mock as mock
 
 import aws_interactions.ssm_operations as ssm_ops
-from commands.create_cluster import cmd_create_cluster, _set_up_viewer_cert, _get_capacity_plan, MustProvideAllParams
+from commands.create_cluster import cmd_create_cluster, _set_up_viewer_cert, _get_capacity_plan, _get_user_config
 import constants as constants
 from core.capacity_planning import (CaptureNodesPlan, EcsSysResourcePlan, MINIMUM_TRAFFIC, OSDomainPlan, DataNodesPlan, MasterNodesPlan,
                                     CaptureVpcPlan, ClusterPlan, DEFAULT_SPI_DAYS, DEFAULT_SPI_REPLICAS, DEFAULT_NUM_AZS)
+from core.user_config import UserConfig
 
 @mock.patch("commands.create_cluster.AwsClientProvider", mock.Mock())
+@mock.patch("commands.create_cluster._get_user_config")
 @mock.patch("commands.create_cluster._get_capacity_plan")
 @mock.patch("commands.create_cluster._set_up_viewer_cert")
 @mock.patch("commands.create_cluster.CdkClient")
-def test_WHEN_cmd_create_cluster_called_THEN_cdk_command_correct(mock_cdk_client_cls, mock_set_up, mock_get_plans):
+def test_WHEN_cmd_create_cluster_called_THEN_cdk_command_correct(mock_cdk_client_cls, mock_set_up, mock_get_plans, mock_get_config):
     # Set up our mock
     mock_set_up.return_value = "arn"
 
     mock_client = mock.Mock()
     mock_cdk_client_cls.return_value = mock_client
+
+    user_config = UserConfig(1, 30, 2)
+    mock_get_config.return_value = user_config
 
     cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 20, 25, 1),
@@ -60,6 +65,7 @@ def test_WHEN_cmd_create_cluster_called_THEN_cdk_command_correct(mock_cdk_client
                     "nameViewerUserSsmParam": constants.get_viewer_user_ssm_param_name("my-cluster"),
                     "nameViewerNodesStack": constants.get_viewer_nodes_stack_name("my-cluster"),
                     "planCluster": json.dumps(cluster_plan.to_dict()),
+                    "userConfig": json.dumps(user_config.to_dict()),
                 }))
             }
         )
@@ -72,50 +78,93 @@ def test_WHEN_cmd_create_cluster_called_THEN_cdk_command_correct(mock_cdk_client
     assert expected_set_up_calls == mock_set_up.call_args_list
 
 @mock.patch("commands.create_cluster.ssm_ops")
-def test_WHEN_get_capacity_plan_called_AND_use_existing_THEN_as_expected(mock_ssm_ops):
+def test_WHEN_get_user_config_called_AND_use_existing_THEN_as_expected(mock_ssm_ops):
     # Set up our mock
     mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
 
     mock_ssm_ops.get_ssm_param_json_value.return_value = {
-        "captureNodes": {
-            "instanceType":"m5.xlarge","desiredCount":10,"maxCount":12,"minCount":1
-        },
-        "captureVpc": {
-            "numAzs": 3
-        },
-        "ecsResources": {
-            "cpu": 3584, "memory": 15360
-        },
-        "osDomain": {
-            "dataNodes": {
-                "count": 6, "instanceType": "t3.small.search", "volumeSize": 100
-            },
-            "masterNodes": {
-                "count": 3, "instanceType": "c6g.2xlarge.search",
-            }
-        }
+        "expectedTraffic": 1.2,
+        "spiDays": 40,
+        "replicas": 2
     }
 
     mock_provider = mock.Mock()
 
     # Run our test
-    actual_value = _get_capacity_plan("my-cluster", None, None, None, mock_provider)
+    actual_value = _get_user_config("my-cluster", None, None, None, mock_provider)
 
     # Check our results
-    assert CaptureNodesPlan("m5.xlarge", 10, 12, 1) == actual_value.captureNodes
-    assert CaptureVpcPlan(3) == actual_value.captureVpc
-    assert EcsSysResourcePlan(3584, 15360) == actual_value.ecsResources
-    assert OSDomainPlan(DataNodesPlan(6, "t3.small.search", 100), MasterNodesPlan(3, "c6g.2xlarge.search")) == actual_value.osDomain
+    assert UserConfig(1.2, 40, 2) == actual_value
 
     expected_get_ssm_calls = [
-        mock.call(constants.get_cluster_ssm_param_name("my-cluster"), "capacityPlan", mock.ANY)
+        mock.call(constants.get_cluster_ssm_param_name("my-cluster"), "userConfig", mock.ANY)
     ]
     assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
+
+@mock.patch("commands.create_cluster.ssm_ops")
+def test_WHEN_get_user_config_called_AND_partial_update_THEN_as_expected(mock_ssm_ops):
+    # Set up our mock
+    mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
+
+    mock_ssm_ops.get_ssm_param_json_value.return_value = {
+        "expectedTraffic": 1.2,
+        "spiDays": 40,
+        "replicas": 2
+    }
+
+    mock_provider = mock.Mock()
+
+    # Run our test
+    actual_value = _get_user_config("my-cluster", None, 30, None, mock_provider)
+
+    # Check our results
+    assert UserConfig(1.2, 30, 2) == actual_value
+
+    expected_get_ssm_calls = [
+        mock.call(constants.get_cluster_ssm_param_name("my-cluster"), "userConfig", mock.ANY)
+    ]
+    assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
+
+@mock.patch("commands.create_cluster.ssm_ops")
+def test_WHEN_get_user_config_called_AND_use_default_THEN_as_expected(mock_ssm_ops):
+    # Set up our mock
+    mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
+    mock_ssm_ops.get_ssm_param_json_value.side_effect = ssm_ops.ParamDoesNotExist("")
+
+    mock_provider = mock.Mock()
+
+    # Run our test
+    actual_value = _get_user_config("my-cluster", None, None, None, mock_provider)
+
+    # Check our results
+    assert UserConfig(MINIMUM_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_SPI_REPLICAS) == actual_value
+
+    expected_get_ssm_calls = [
+        mock.call(constants.get_cluster_ssm_param_name("my-cluster"), "userConfig", mock.ANY)
+    ]
+    assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
+
+@mock.patch("commands.create_cluster.ssm_ops")
+def test_WHEN_get_user_config_called_AND_specify_all_THEN_as_expected(mock_ssm_ops):
+    # Set up our mock
+    mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
+
+    mock_provider = mock.Mock()
+
+    # Run our test
+    actual_value = _get_user_config("my-cluster", 10, 40, 2, mock_provider)
+
+    # Check our results
+    assert UserConfig(10, 40, 2) == actual_value
+
+    expected_get_ssm_calls = []
+    assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
+
 
 @mock.patch("commands.create_cluster.get_os_domain_plan")
 @mock.patch("commands.create_cluster.get_capture_node_capacity_plan")
 @mock.patch("commands.create_cluster.ssm_ops")
-def test_WHEN_get_capacity_plan_called_AND_use_default_THEN_as_expected(mock_ssm_ops, mock_get_cap, mock_get_os):
+def test_WHEN_get_capacity_plan_called_THEN_as_expected(mock_ssm_ops, mock_get_cap, mock_get_os):
     # Set up our mock
     mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
     mock_ssm_ops.get_ssm_param_json_value.side_effect = ssm_ops.ParamDoesNotExist("")
@@ -126,7 +175,7 @@ def test_WHEN_get_capacity_plan_called_AND_use_default_THEN_as_expected(mock_ssm
     mock_provider = mock.Mock()
 
     # Run our test
-    actual_value = _get_capacity_plan("my-cluster", None, None, None, mock_provider)
+    actual_value = _get_capacity_plan(UserConfig(1, 40, 2))
 
     # Check our results
     assert mock_get_cap.return_value == actual_value.captureNodes
@@ -135,62 +184,24 @@ def test_WHEN_get_capacity_plan_called_AND_use_default_THEN_as_expected(mock_ssm
     assert EcsSysResourcePlan(3584, 15360) == actual_value.ecsResources
 
     expected_get_cap_calls = [
-        mock.call(MINIMUM_TRAFFIC)
+        mock.call(1)
     ]
     assert expected_get_cap_calls == mock_get_cap.call_args_list
 
     expected_get_os_calls = [
-        mock.call(MINIMUM_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_SPI_REPLICAS, DEFAULT_NUM_AZS)
+        mock.call(1, 40, 2, DEFAULT_NUM_AZS)
     ]
     assert expected_get_os_calls == mock_get_os.call_args_list
 
-    expected_get_ssm_calls = [
-        mock.call(constants.get_cluster_ssm_param_name("my-cluster"), "capacityPlan", mock.ANY)
-    ]
-    assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
 
-@mock.patch("commands.create_cluster.get_os_domain_plan")
-@mock.patch("commands.create_cluster.get_capture_node_capacity_plan")
-@mock.patch("commands.create_cluster.ssm_ops")
-def test_WHEN_get_capacity_plan_called_AND_gen_plan_THEN_as_expected(mock_ssm_ops, mock_get_cap, mock_get_os):
-    # Set up our mock
-    mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
-    mock_ssm_ops.get_ssm_param_json_value.side_effect = ssm_ops.ParamDoesNotExist("")
 
-    mock_get_cap.return_value = CaptureNodesPlan("m5.xlarge", 10, 12, 1)
-    mock_get_os.return_value = OSDomainPlan(DataNodesPlan(20, "r6g.large.search", 100), MasterNodesPlan(3, "m6g.large.search"))
 
-    mock_provider = mock.Mock()
 
-    # Run our test
-    actual_value = _get_capacity_plan("my-cluster", 10, 40, 2, mock_provider)
 
-    # Check our results
-    assert mock_get_cap.return_value == actual_value.captureNodes
-    assert CaptureVpcPlan(DEFAULT_NUM_AZS) == actual_value.captureVpc
-    assert mock_get_os.return_value == actual_value.osDomain
-    assert EcsSysResourcePlan(3584, 15360) == actual_value.ecsResources
 
-    expected_get_cap_calls = [
-        mock.call(10)
-    ]
-    assert expected_get_cap_calls == mock_get_cap.call_args_list
 
-    expected_get_os_calls = [
-        mock.call(10, 40, 2, DEFAULT_NUM_AZS)
-    ]
-    assert expected_get_os_calls == mock_get_os.call_args_list
 
-    expected_get_ssm_calls = []
-    assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
 
-def test_WHEN_get_capacity_plan_called_AND_not_all_params_THEN_as_expected():
-    # Set up our mock
-    mock_provider = mock.Mock()
-
-    # Run our test
-    with pytest.raises(MustProvideAllParams):
-        _get_capacity_plan("my-cluster", 10, None, None, mock_provider)
 
 @mock.patch("commands.create_cluster.upload_default_elb_cert")
 @mock.patch("commands.create_cluster.ssm_ops")

--- a/test_manage_arkime/commands/test_destroy_cluster.py
+++ b/test_manage_arkime/commands/test_destroy_cluster.py
@@ -7,6 +7,7 @@ from commands.destroy_cluster import cmd_destroy_cluster, _destroy_viewer_cert
 import constants as constants
 from core.capacity_planning import (CaptureNodesPlan, EcsSysResourcePlan, OSDomainPlan, DataNodesPlan, MasterNodesPlan,
                                     ClusterPlan, CaptureVpcPlan)
+from core.user_config import UserConfig
 
 TEST_CLUSTER = "my-cluster"
 
@@ -61,6 +62,7 @@ def test_WHEN_cmd_destroy_cluster_called_AND_dont_destroy_everything_THEN_expect
                     "nameViewerUserSsmParam": constants.get_viewer_user_ssm_param_name(TEST_CLUSTER),
                     "nameViewerNodesStack": constants.get_viewer_nodes_stack_name(TEST_CLUSTER),
                     "planCluster": json.dumps(cluster_plan.to_dict()),
+                    "userConfig": json.dumps(UserConfig(1, 1, 1).to_dict()),
                 }))
             }
         )
@@ -147,6 +149,7 @@ def test_WHEN_cmd_destroy_cluster_called_AND_destroy_everything_THEN_expected_cm
                     "nameViewerUserSsmParam": constants.get_viewer_user_ssm_param_name(TEST_CLUSTER),
                     "nameViewerNodesStack": constants.get_viewer_nodes_stack_name(TEST_CLUSTER),
                     "planCluster": json.dumps(cluster_plan.to_dict()),
+                    "userConfig": json.dumps(UserConfig(1, 1, 1).to_dict()),
                 }))
             }
         )

--- a/test_manage_arkime/core/test_capacity_planning.py
+++ b/test_manage_arkime/core/test_capacity_planning.py
@@ -48,3 +48,129 @@ def test_WHEN_get_ecs_sys_resource_plan_called_THEN_as_expected():
     # TEST 2: Get an unknown instance type
     with pytest.raises(cap.UnknownInstanceType):
         cap.get_ecs_sys_resource_plan("unknown")
+
+def test_WHEN_get_total_storage_called_THEN_as_expected():
+    # TEST 1: No replicas
+    actual_value = cap._get_total_storage(10, 30, 0)
+    expected_value = 97200
+
+    assert expected_value == actual_value
+
+    # TEST 2: Single replica
+    actual_value = cap._get_total_storage(10, 30, 1)
+    expected_value = 97200*2
+
+    assert expected_value == actual_value
+
+    # TEST 3: Many replicas
+    actual_value = cap._get_total_storage(10, 30, 5)
+    expected_value = 97200*6
+
+    assert expected_value == actual_value
+
+def test_WHEN_get_data_node_plan_called_THEN_as_expected():
+    # TEST 1: Toy setup
+    actual_value = cap._get_data_node_plan(10, 3)
+    expected_value = cap.DataNodesPlan(2, cap.T3_SMALL_SEARCH.type, cap.T3_SMALL_SEARCH.vol_size)
+    assert expected_value == actual_value
+
+    # TEST 2: Tiny setup
+    actual_value = cap._get_data_node_plan(650, 3)
+    expected_value = cap.DataNodesPlan(7, cap.T3_SMALL_SEARCH.type, cap.T3_SMALL_SEARCH.vol_size)
+    assert expected_value == actual_value
+
+    # TEST 2b: Tiny setup, 2 AZs
+    actual_value = cap._get_data_node_plan(650, 2)
+    expected_value = cap.DataNodesPlan(8, cap.T3_SMALL_SEARCH.type, cap.T3_SMALL_SEARCH.vol_size)
+    assert expected_value == actual_value
+
+    # TEST 3: Small setup (1)
+    actual_value = cap._get_data_node_plan(1100, 3)
+    expected_value = cap.DataNodesPlan(2, cap.R6G_LARGE_SEARCH.type, cap.R6G_LARGE_SEARCH.vol_size)
+    assert expected_value == actual_value
+
+    # TEST 4: Small setup (2)
+    actual_value = cap._get_data_node_plan(65000, 3)
+    expected_value = cap.DataNodesPlan(64, cap.R6G_LARGE_SEARCH.type, cap.R6G_LARGE_SEARCH.vol_size)
+    assert expected_value == actual_value
+
+    # TEST 5: Medium setup (1)
+    actual_value = cap._get_data_node_plan(90000, 3)
+    expected_value = cap.DataNodesPlan(15, cap.R6G_4XLARGE_SEARCH.type, cap.R6G_4XLARGE_SEARCH.vol_size)
+    assert expected_value == actual_value
+
+    # TEST 5b: Medium setup (1), 2 AZs
+    actual_value = cap._get_data_node_plan(90000, 2)
+    expected_value = cap.DataNodesPlan(16, cap.R6G_4XLARGE_SEARCH.type, cap.R6G_4XLARGE_SEARCH.vol_size)
+    assert expected_value == actual_value
+
+    # TEST 6: Medium setup (2)
+    actual_value = cap._get_data_node_plan(450000, 3)
+    expected_value = cap.DataNodesPlan(74, cap.R6G_4XLARGE_SEARCH.type, cap.R6G_4XLARGE_SEARCH.vol_size)
+    assert expected_value == actual_value
+
+    # TEST 7: Large setup (1)
+    actual_value = cap._get_data_node_plan(500000, 3)
+    expected_value = cap.DataNodesPlan(41, cap.R6G_12XLARGE_SEARCH.type, cap.R6G_12XLARGE_SEARCH.vol_size)
+    assert expected_value == actual_value
+
+    # TEST 8: Enormous setup
+    actual_value = cap._get_data_node_plan(1200000, 3)
+    expected_value = cap.DataNodesPlan(98, cap.R6G_12XLARGE_SEARCH.type, cap.R6G_12XLARGE_SEARCH.vol_size)
+    assert expected_value == actual_value
+
+def test_WHEN_get_master_node_plan_called_THEN_as_expected():
+    # TEST: Non-graviton
+    actual_value = cap._get_master_node_plan(5, 2, cap.T3_SMALL_SEARCH.type)
+    expected_value = cap.MasterNodesPlan(3, "m5.large.search")
+    assert expected_value == actual_value
+
+    # TEST: Small data
+    actual_value = cap._get_master_node_plan(5, 2, "blah")
+    expected_value = cap.MasterNodesPlan(3, "m6g.large.search")
+    assert expected_value == actual_value
+
+    # TEST: Small data w/ lots of data nodes
+    actual_value = cap._get_master_node_plan(5, 11, "blah")
+    expected_value = cap.MasterNodesPlan(3, "c6g.2xlarge.search")
+    assert expected_value == actual_value
+
+    # TEST: Small data w/ lots and lots of data nodes
+    actual_value = cap._get_master_node_plan(5, 31, "blah")
+    expected_value = cap.MasterNodesPlan(3, "r6g.2xlarge.search")
+    assert expected_value == actual_value
+
+    # TEST: Medium data
+    actual_value = cap._get_master_node_plan(401000, 20, "blah")
+    expected_value = cap.MasterNodesPlan(3, "c6g.2xlarge.search")
+    assert expected_value == actual_value
+
+    # TEST: Medium data w/ lots of data nodes
+    actual_value = cap._get_master_node_plan(401000, 31, "blah")
+    expected_value = cap.MasterNodesPlan(3, "r6g.2xlarge.search")
+    assert expected_value == actual_value
+
+    # TEST: Large data
+    actual_value = cap._get_master_node_plan(1250000, 80, "blah")
+    expected_value = cap.MasterNodesPlan(3, "r6g.2xlarge.search")
+    assert expected_value == actual_value
+
+    # TEST: Large data w/ lots of data nodes
+    actual_value = cap._get_master_node_plan(1250000, 130, "blah")
+    expected_value = cap.MasterNodesPlan(3, "r6g.4xlarge.search")
+    assert expected_value == actual_value
+
+    # TEST: Enormous data w/ lots of data nodes
+    actual_value = cap._get_master_node_plan(3010000, 120, "blah")
+    expected_value = cap.MasterNodesPlan(3, "r6g.4xlarge.search")
+    assert expected_value == actual_value
+
+def test_WHEN_get_os_domain_plan_called_THEN_as_expected():
+    actual_value = cap.get_os_domain_plan(20, 30, 1, 2)
+    expected_value = cap.OSDomainPlan(
+        cap.DataNodesPlan(64, cap.R6G_4XLARGE_SEARCH.type, cap.R6G_4XLARGE_SEARCH.vol_size),
+        cap.MasterNodesPlan(3, "r6g.2xlarge.search")
+    )
+    assert expected_value == actual_value
+
+    


### PR DESCRIPTION
## Description
* Made the OpenSearch Domain used for SPI data configurable via the command-line.
* By default, the user gets a minimal Capture Node ASG and OpenSearch Domain.  If they specify non-default values, they get a cluster that should be capable of servicing their indicated traffic load.  If they re-deploy after setting non-default values, the previously configured values are re-used unless they provide new values.
* The user can change the individual capacity options and the code will gracefully pull the other, unspecified values if they exist.

## Issues
* https://github.com/arkime/aws-aio/issues/56

## Testing
* Added Unit Tests
* Tested the behavior manually using the CLI.  Confirmed it correctly followed the constraints we imposed with our capacity plan for a few scenarios as a supplement to the extensive unit testing.  Pasted below is the CLI output and cluster capacity configuration after deployment.

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py create-cluster --name MyCluster3 --expected-traffic 0.01 --spi-days 30 --replicas 1
2023-06-01 16:55:46 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime.log
2023-06-01 16:55:46 - Using AWS Credential Profile: default
2023-06-01 16:55:46 - Using AWS Region: default from AWS Config settings
2023-06-01 16:55:47 - Executing command: deploy MyCluster3-CaptureBucket MyCluster3-CaptureNodes MyCluster3-CaptureVPC MyCluster3-OSDomain MyCluster3-ViewerNodes
2023-06-01 16:55:47 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-06-01 17:15:28 - Deployment succeeded

-----------------------------------------------------------

{"busArn":"arn:aws:events:us-east-2:968674222892:event-bus/MyCluster3CaptureNodesClusterBus224EB36F","busName":"MyCluster3CaptureNodesClusterBus224EB36F","clusterName":"MyCluster3","vpceServiceId":"vpce-svc-0d6b05027bae05312","capacityPlan":{"captureNodes":{"instanceType":"m5.xlarge","desiredCount":1,"maxCount":2,"minCount":1},"captureVpc":{"numAzs":2},"ecsResources":{"cpu":3584,"memory":15360},"osDomain":{"dataNodes":{"count":2,"instanceType":"t3.small.search","volumeSize":100},"masterNodes":{"count":3,"instanceType":"m5.large.search"}}},"userConfig":{"expectedTraffic":0.01,"spiDays":30,"replicas":1}}
```

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py create-cluster --name MyCluster3 --expected-traffic 0.1
2023-06-01 17:16:35 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime.log
2023-06-01 17:16:35 - Using AWS Credential Profile: default
2023-06-01 17:16:35 - Using AWS Region: default from AWS Config settings
2023-06-01 17:16:36 - Executing command: deploy MyCluster3-CaptureBucket MyCluster3-CaptureNodes MyCluster3-CaptureVPC MyCluster3-OSDomain MyCluster3-ViewerNodes
2023-06-01 17:16:36 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-06-01 17:45:43 - Deployment succeeded
-----------------------------------------------------------

{"busArn":"arn:aws:events:us-east-2:968674222892:event-bus/MyCluster3CaptureNodesClusterBus224EB36F","busName":"MyCluster3CaptureNodesClusterBus224EB36F","clusterName":"MyCluster3","vpceServiceId":"vpce-svc-0d6b05027bae05312","capacityPlan":{"captureNodes":{"instanceType":"m5.xlarge","desiredCount":1,"maxCount":2,"minCount":1},"captureVpc":{"numAzs":2},"ecsResources":{"cpu":3584,"memory":15360},"osDomain":{"dataNodes":{"count":2,"instanceType":"r6g.large.search","volumeSize":1024},"masterNodes":{"count":3,"instanceType":"m6g.large.search"}}},"userConfig":{"expectedTraffic":0.1,"spiDays":30,"replicas":1}}
```

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py create-cluster --name MyCluster3
2023-06-01 17:46:55 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime.log
2023-06-01 17:46:55 - Using AWS Credential Profile: default
2023-06-01 17:46:55 - Using AWS Region: default from AWS Config settings
2023-06-01 17:46:56 - Executing command: deploy MyCluster3-CaptureBucket MyCluster3-CaptureNodes MyCluster3-CaptureVPC MyCluster3-OSDomain MyCluster3-ViewerNodes
2023-06-01 17:46:56 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-06-01 17:47:24 - Deployment succeeded

-----------------------------------------------------------

{"busArn":"arn:aws:events:us-east-2:968674222892:event-bus/MyCluster3CaptureNodesClusterBus224EB36F","busName":"MyCluster3CaptureNodesClusterBus224EB36F","clusterName":"MyCluster3","vpceServiceId":"vpce-svc-0d6b05027bae05312","capacityPlan":{"captureNodes":{"instanceType":"m5.xlarge","desiredCount":1,"maxCount":2,"minCount":1},"captureVpc":{"numAzs":2},"ecsResources":{"cpu":3584,"memory":15360},"osDomain":{"dataNodes":{"count":2,"instanceType":"r6g.large.search","volumeSize":1024},"masterNodes":{"count":3,"instanceType":"m6g.large.search"}}},"userConfig":{"expectedTraffic":0.1,"spiDays":30,"replicas":1}}
```

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
