### PR TITLE
Made S3 retention policy configurable

### DIFF
--- a/cdk-lib/capture-stacks/capture-nodes-stack.ts
+++ b/cdk-lib/capture-stacks/capture-nodes-stack.ts
@@ -162,6 +162,7 @@ export class CaptureNodesStack extends cdk.Stack {
                 'LB_HEALTH_PORT': healthCheckPort.toString(),
                 'OPENSEARCH_ENDPOINT': props.osDomain.domainEndpoint,
                 'OPENSEARCH_SECRET_ARN': props.osPassword.secretArn,
+                'S3_STORAGE_CLASS': props.planCluster.s3.pcapStorageClass,
             },
             cpu: props.planCluster.ecsResources.cpu,
             memoryLimitMiB: props.planCluster.ecsResources.memory,

--- a/cdk-lib/cloud-demo.ts
+++ b/cdk-lib/cloud-demo.ts
@@ -25,6 +25,7 @@ switch(params.type) {
     case 'ClusterMgmtParams':
         const captureBucketStack = new CaptureBucketStack(app, params.nameCaptureBucketStack, {
             env: env,
+            planCluster: params.planCluster,
             ssmParamName: params.nameCaptureBucketSsmParam,
         });
 

--- a/cdk-lib/core/capacity-plan.ts
+++ b/cdk-lib/core/capacity-plan.ts
@@ -49,6 +49,14 @@ export interface CaptureVpcPlan {
 }
 
 /**
+ * Structure to hold the details of the cluster's S3 usage plan
+ */
+export interface S3Plan {
+    pcapStorageClass: string;
+    pcapStorageDays: number;
+}
+
+/**
  * Structure to hold the overall capacity plan for an Arkime Cluster
  */
 export interface ClusterPlan {
@@ -56,4 +64,5 @@ export interface ClusterPlan {
     captureVpc: CaptureVpcPlan;
     ecsResources: EcsSysResourcePlan;
     osDomain: OSDomainPlan;
+    s3: S3Plan;
 }

--- a/docker-capture-node/arkime_config.ini
+++ b/docker-capture-node/arkime_config.ini
@@ -24,6 +24,7 @@ pcapWriteMethod=s3
 s3Compression=zstd
 s3Region=_REGION_
 s3Bucket=_BUCKET_
+s3StorageClass=_STORAGE_CLASS_
 s3UseECSEnv=true
 maxFileTimeM=1
 

--- a/docker-capture-node/run_capture_node.sh
+++ b/docker-capture-node/run_capture_node.sh
@@ -10,6 +10,7 @@ echo "Bucket Name: $BUCKET_NAME"
 echo "LB Healthcheck Port: $LB_HEALTH_PORT"
 echo "OpenSearch Endpoint: $OPENSEARCH_ENDPOINT"
 echo "OpenSearch Secret Arn: $OPENSEARCH_SECRET_ARN"
+echo "S3 Storage Class: $S3_STORAGE_CLASS"
 echo "============================================================"
 
 # Pull configuration from ENV and AWS in order to set up our Arkime install.  The ENV variables come from the Fargate
@@ -26,6 +27,7 @@ sed -i'' "s/_AUTH_/$BASE64_AUTH/g" /opt/arkime/etc/config.ini
 sed -i'' "s/_BUCKET_/$BUCKET_NAME/g" /opt/arkime/etc/config.ini
 sed -i'' "s/_HEALTH_PORT_/$LB_HEALTH_PORT/g" /opt/arkime/etc/config.ini
 sed -i'' "s/_REGION_/$AWS_REGION/g" /opt/arkime/etc/config.ini
+sed -i'' "s/_STORAGE_CLASS_/$S3_STORAGE_CLASS/g" /opt/arkime/etc/config.ini
 echo "Successfully configured /opt/arkime/etc/config.ini"
 
 echo "Testing connection/creds to OpenSearch domain $OPENSEARCH_ENDPOINT ..."

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -12,7 +12,7 @@ from commands.get_login_details import cmd_get_login_details
 from commands.list_clusters import cmd_list_clusters
 from commands.remove_vpc import cmd_remove_vpc
 import constants as constants
-from core.capacity_planning import MAX_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_SPI_REPLICAS
+from core.capacity_planning import MAX_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_SPI_REPLICAS, DEFAULT_S3_STORAGE_DAYS
 from logging_wrangler import LoggingWrangler, set_boto_log_level
 
 logger = logging.getLogger(__name__)
@@ -74,11 +74,17 @@ cli.add_command(destroy_demo_traffic)
     default=None,
     type=click.INT,
     required=False)
+@click.option(
+    "--pcap-days", 
+    help=(f"The number of days to store PCAP files in S3.  Default: {DEFAULT_S3_STORAGE_DAYS}"),
+    default=None,
+    type=click.INT,
+    required=False)
 @click.pass_context
-def create_cluster(ctx, name, expected_traffic, spi_days, replicas):
+def create_cluster(ctx, name, expected_traffic, spi_days, replicas, pcap_days):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_create_cluster(profile, region, name, expected_traffic, spi_days, replicas)
+    cmd_create_cluster(profile, region, name, expected_traffic, spi_days, replicas, pcap_days)
 cli.add_command(create_cluster)
 
 @click.command(help="Tears down the Arkime Cluster in your account; by default, leaves your data intact")

--- a/manage_arkime/cdk_interactions/cdk_context.py
+++ b/manage_arkime/cdk_interactions/cdk_context.py
@@ -4,7 +4,8 @@ from typing import Dict
 
 import constants as constants
 from core.capacity_planning import (CaptureNodesPlan, CaptureVpcPlan, ClusterPlan, DataNodesPlan, EcsSysResourcePlan, 
-                                    MasterNodesPlan, OSDomainPlan, INSTANCE_TYPE_CAPTURE_NODE, DEFAULT_NUM_AZS)
+                                    MasterNodesPlan, OSDomainPlan, INSTANCE_TYPE_CAPTURE_NODE, DEFAULT_NUM_AZS, S3Plan,
+                                    DEFAULT_S3_STORAGE_CLASS)
 from core.user_config import UserConfig
 
 def generate_create_cluster_context(name: str, viewer_cert_arn: str, cluster_plan: ClusterPlan, user_config: UserConfig) -> Dict[str, str]:
@@ -21,9 +22,10 @@ def generate_destroy_cluster_context(name: str) -> Dict[str, str]:
         CaptureNodesPlan(INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
         CaptureVpcPlan(1),
         EcsSysResourcePlan(1, 1),
-        OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search"))
+        OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
+        S3Plan(DEFAULT_S3_STORAGE_CLASS, 1)
     )
-    fake_user_config = UserConfig(1, 1, 1)
+    fake_user_config = UserConfig(1, 1, 1, 1)
 
     destroy_context = _generate_cluster_context(name, fake_arn, fake_cluster_plan, fake_user_config)
     destroy_context[constants.CDK_CONTEXT_CMD_VAR] = constants.CMD_DESTROY_CLUSTER

--- a/manage_arkime/core/user_config.py
+++ b/manage_arkime/core/user_config.py
@@ -9,15 +9,17 @@ class UserConfig:
     expectedTraffic: float
     spiDays: int
     replicas: int
+    pcapDays: int
 
     def __equal__(self, other):
         return (self.expectedTraffic == other.expectedTraffic and self.spiDays == other.spiDays 
-                and self.replicas == other.replicas)
+                and self.replicas == other.replicas and self.pcapDays == other.pcapDays)
 
     def to_dict(self) -> Dict[str, any]:
         return {
             'expectedTraffic': self.expectedTraffic,
             'spiDays': self.spiDays,
-            'replicas': self.replicas
+            'replicas': self.replicas,
+            'pcapDays': self.pcapDays,
         }
 

--- a/test_manage_arkime/commands/test_destroy_cluster.py
+++ b/test_manage_arkime/commands/test_destroy_cluster.py
@@ -6,7 +6,7 @@ from aws_interactions.ssm_operations import ParamDoesNotExist
 from commands.destroy_cluster import cmd_destroy_cluster, _destroy_viewer_cert
 import constants as constants
 from core.capacity_planning import (CaptureNodesPlan, EcsSysResourcePlan, OSDomainPlan, DataNodesPlan, MasterNodesPlan,
-                                    ClusterPlan, CaptureVpcPlan)
+                                    ClusterPlan, CaptureVpcPlan, S3Plan, DEFAULT_S3_STORAGE_CLASS)
 from core.user_config import UserConfig
 
 TEST_CLUSTER = "my-cluster"
@@ -27,7 +27,8 @@ def test_WHEN_cmd_destroy_cluster_called_AND_dont_destroy_everything_THEN_expect
         CaptureNodesPlan("m5.xlarge", 1, 2, 1),
         CaptureVpcPlan(1),
         EcsSysResourcePlan(1, 1),
-        OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search"))
+        OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
+        S3Plan(DEFAULT_S3_STORAGE_CLASS, 1)
     )
 
     # Run our test
@@ -62,7 +63,7 @@ def test_WHEN_cmd_destroy_cluster_called_AND_dont_destroy_everything_THEN_expect
                     "nameViewerUserSsmParam": constants.get_viewer_user_ssm_param_name(TEST_CLUSTER),
                     "nameViewerNodesStack": constants.get_viewer_nodes_stack_name(TEST_CLUSTER),
                     "planCluster": json.dumps(cluster_plan.to_dict()),
-                    "userConfig": json.dumps(UserConfig(1, 1, 1).to_dict()),
+                    "userConfig": json.dumps(UserConfig(1, 1, 1, 1).to_dict()),
                 }))
             }
         )
@@ -97,7 +98,8 @@ def test_WHEN_cmd_destroy_cluster_called_AND_destroy_everything_THEN_expected_cm
         CaptureNodesPlan("m5.xlarge", 1, 2, 1),
         CaptureVpcPlan(1),
         EcsSysResourcePlan(1, 1),
-        OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search"))
+        OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
+        S3Plan(DEFAULT_S3_STORAGE_CLASS, 1)
     )
 
     # Run our test
@@ -149,7 +151,7 @@ def test_WHEN_cmd_destroy_cluster_called_AND_destroy_everything_THEN_expected_cm
                     "nameViewerUserSsmParam": constants.get_viewer_user_ssm_param_name(TEST_CLUSTER),
                     "nameViewerNodesStack": constants.get_viewer_nodes_stack_name(TEST_CLUSTER),
                     "planCluster": json.dumps(cluster_plan.to_dict()),
-                    "userConfig": json.dumps(UserConfig(1, 1, 1).to_dict()),
+                    "userConfig": json.dumps(UserConfig(1, 1, 1, 1).to_dict()),
                 }))
             }
         )


### PR DESCRIPTION
## Description
* Surfaced a CLI option for users to set the number of days that PCAP data will be retained in S3
* Piped through the S3 storage class to use from the Python layer, but did not surface it in any CLI options (yet)
* Began enforcing SSL usage to access the PCAP data in S3 (security best practice)

## Tasks
* https://github.com/arkime/aws-aio/issues/61

## Testing
* Unit tests
* Updated an existing Cluster with the new configuration, checked in the SSM Parameter Store, S3 configuration, and ECS logs that things got configured liked I expected them to.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
