### PR TITLE
Added --history-days option to CLI; stored in SSM

### DIFF
--- a/cdk-lib/core/user-config.ts
+++ b/cdk-lib/core/user-config.ts
@@ -4,5 +4,7 @@
 export interface UserConfig {
     expectedTraffic: number;
     spiDays: number;
+    historyDays: number;
     replicas: number;
+    pcapDays: number;
 }

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -12,7 +12,7 @@ from commands.get_login_details import cmd_get_login_details
 from commands.list_clusters import cmd_list_clusters
 from commands.remove_vpc import cmd_remove_vpc
 import constants as constants
-from core.capacity_planning import MAX_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_SPI_REPLICAS, DEFAULT_S3_STORAGE_DAYS
+from core.capacity_planning import MAX_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_REPLICAS, DEFAULT_S3_STORAGE_DAYS, DEFAULT_HISTORY_DAYS
 from logging_wrangler import LoggingWrangler, set_boto_log_level
 
 logger = logging.getLogger(__name__)
@@ -69,8 +69,14 @@ cli.add_command(destroy_demo_traffic)
     type=click.INT,
     required=False)
 @click.option(
+    "--history-days", 
+    help=(f"The number of days to store Arkime Viewer user history in the OpenSearch Domain.  Default: {DEFAULT_HISTORY_DAYS}"),
+    default=None,
+    type=click.INT,
+    required=False)
+@click.option(
     "--replicas", 
-    help=(f"The number replicas to make of the SPI metadata in the OpenSearch Domain.  Default: {DEFAULT_SPI_REPLICAS}"),
+    help=(f"The number replicas to make of the SPI metadata in the OpenSearch Domain.  Default: {DEFAULT_REPLICAS}"),
     default=None,
     type=click.INT,
     required=False)
@@ -81,10 +87,10 @@ cli.add_command(destroy_demo_traffic)
     type=click.INT,
     required=False)
 @click.pass_context
-def create_cluster(ctx, name, expected_traffic, spi_days, replicas, pcap_days):
+def create_cluster(ctx, name, expected_traffic, spi_days, history_days, replicas, pcap_days):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_create_cluster(profile, region, name, expected_traffic, spi_days, replicas, pcap_days)
+    cmd_create_cluster(profile, region, name, expected_traffic, spi_days, history_days, replicas, pcap_days)
 cli.add_command(create_cluster)
 
 @click.command(help="Tears down the Arkime Cluster in your account; by default, leaves your data intact")

--- a/manage_arkime/cdk_interactions/cdk_context.py
+++ b/manage_arkime/cdk_interactions/cdk_context.py
@@ -25,7 +25,7 @@ def generate_destroy_cluster_context(name: str) -> Dict[str, str]:
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, 1)
     )
-    fake_user_config = UserConfig(1, 1, 1, 1)
+    fake_user_config = UserConfig(1, 1, 1, 1, 1)
 
     destroy_context = _generate_cluster_context(name, fake_arn, fake_cluster_plan, fake_user_config)
     destroy_context[constants.CDK_CONTEXT_CMD_VAR] = constants.CMD_DESTROY_CLUSTER

--- a/manage_arkime/core/capacity_planning.py
+++ b/manage_arkime/core/capacity_planning.py
@@ -13,7 +13,8 @@ MINIMUM_TRAFFIC = 0.01 # Gbps; arbitrarily chosen, but will yield a minimal clus
 CAPACITY_BUFFER_FACTOR = 1.25 # Arbitrarily chosen
 MASTER_NODE_COUNT = 3 # Recommended number in docs
 DEFAULT_SPI_DAYS = 30 # How many days of SPI metadata to keep in the OS Domain
-DEFAULT_SPI_REPLICAS = 1 # How replicas of metadata to keep in the OS Domain
+DEFAULT_REPLICAS = 1 # How replicas of metadata to keep in the OS Domain
+DEFAULT_HISTORY_DAYS = 365 # How many days of Arkime Viewer user history to keep in the OS Domain
 DEFAULT_NUM_AZS = 2 # How many AWS Availability zones to utilize
 
 class TooMuchTraffic(Exception):

--- a/manage_arkime/core/user_config.py
+++ b/manage_arkime/core/user_config.py
@@ -8,12 +8,13 @@ logger = logging.getLogger(__name__)
 class UserConfig:
     expectedTraffic: float
     spiDays: int
+    historyDays: int
     replicas: int
     pcapDays: int
 
     def __equal__(self, other):
         return (self.expectedTraffic == other.expectedTraffic and self.spiDays == other.spiDays 
-                and self.replicas == other.replicas and self.pcapDays == other.pcapDays)
+                and self.replicas == other.replicas and self.pcapDays == other.pcapDays and self.historyDays == other.historyDays)
 
     def to_dict(self) -> Dict[str, any]:
         return {
@@ -21,5 +22,6 @@ class UserConfig:
             'spiDays': self.spiDays,
             'replicas': self.replicas,
             'pcapDays': self.pcapDays,
+            'historyDays': self.historyDays
         }
 

--- a/test_manage_arkime/commands/test_destroy_cluster.py
+++ b/test_manage_arkime/commands/test_destroy_cluster.py
@@ -63,7 +63,7 @@ def test_WHEN_cmd_destroy_cluster_called_AND_dont_destroy_everything_THEN_expect
                     "nameViewerUserSsmParam": constants.get_viewer_user_ssm_param_name(TEST_CLUSTER),
                     "nameViewerNodesStack": constants.get_viewer_nodes_stack_name(TEST_CLUSTER),
                     "planCluster": json.dumps(cluster_plan.to_dict()),
-                    "userConfig": json.dumps(UserConfig(1, 1, 1, 1).to_dict()),
+                    "userConfig": json.dumps(UserConfig(1, 1, 1, 1, 1).to_dict()),
                 }))
             }
         )
@@ -151,7 +151,7 @@ def test_WHEN_cmd_destroy_cluster_called_AND_destroy_everything_THEN_expected_cm
                     "nameViewerUserSsmParam": constants.get_viewer_user_ssm_param_name(TEST_CLUSTER),
                     "nameViewerNodesStack": constants.get_viewer_nodes_stack_name(TEST_CLUSTER),
                     "planCluster": json.dumps(cluster_plan.to_dict()),
-                    "userConfig": json.dumps(UserConfig(1, 1, 1, 1).to_dict()),
+                    "userConfig": json.dumps(UserConfig(1, 1, 1, 1, 1).to_dict()),
                 }))
             }
         )


### PR DESCRIPTION
## Description
* First part of enabling ISM
* Added user-history for the viewer to the configuration options in the CLI

## Tasks
* https://github.com/arkime/aws-aio/issues/63

## Testing
* Updated unit tests
* Ran `create-cluster` with the new option, made sure it appeared in SSM like expected

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py create-cluster --name MyCluster3 --expected-traffic 0.1 --spi-days 30 --replicas 1 --pcap-days 30 --history-days 120
2023-06-08 11:26:25 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime.log
2023-06-08 11:26:25 - Using AWS Credential Profile: default
2023-06-08 11:26:25 - Using AWS Region: default from AWS Config settings
2023-06-08 11:26:26 - Executing command: deploy MyCluster3-CaptureBucket MyCluster3-CaptureNodes MyCluster3-CaptureVPC MyCluster3-OSDomain MyCluster3-ViewerNodes
2023-06-08 11:26:26 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-06-08 11:27:41 - Deployment succeeded
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py create-cluster --name MyCluster3
2023-06-08 11:37:46 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime.log
2023-06-08 11:37:46 - Using AWS Credential Profile: default
2023-06-08 11:37:46 - Using AWS Region: default from AWS Config settings
2023-06-08 11:37:46 - Executing command: deploy MyCluster3-CaptureBucket MyCluster3-CaptureNodes MyCluster3-CaptureVPC MyCluster3-OSDomain MyCluster3-ViewerNodes
2023-06-08 11:37:46 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-06-08 11:38:08 - Deployment succeeded
```

```
{"busArn":"arn:aws:events:us-east-2:XXXXXXXXXXXX:event-bus/MyCluster3CaptureNodesClusterBus224EB36F","busName":"MyCluster3CaptureNodesClusterBus224EB36F","clusterName":"MyCluster3","vpceServiceId":"vpce-svc-0d6b05027bae05312","capacityPlan":{"captureNodes":{"instanceType":"m5.xlarge","desiredCount":1,"maxCount":2,"minCount":1},"captureVpc":{"numAzs":2},"ecsResources":{"cpu":3584,"memory":15360},"osDomain":{"dataNodes":{"count":2,"instanceType":"r6g.large.search","volumeSize":1024},"masterNodes":{"count":3,"instanceType":"m6g.large.search"}},"s3":{"pcapStorageClass":"STANDARD","pcapStorageDays":30}},"userConfig":{"expectedTraffic":0.1,"spiDays":30,"replicas":1,"pcapDays":30,"historyDays":120}}
```

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
