### PR TITLE
create-cluster now prints a usage report before creation

### DIFF
--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -86,11 +86,18 @@ cli.add_command(destroy_demo_traffic)
     default=None,
     type=click.INT,
     required=False)
+@click.option(
+    "--preconfirm-usage", 
+    help="Skips the manual confirmation that the capacity to be provisioned is as expected.",
+    is_flag=True,
+    show_default=True,
+    default=False
+)
 @click.pass_context
-def create_cluster(ctx, name, expected_traffic, spi_days, history_days, replicas, pcap_days):
+def create_cluster(ctx, name, expected_traffic, spi_days, history_days, replicas, pcap_days, preconfirm_usage):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_create_cluster(profile, region, name, expected_traffic, spi_days, history_days, replicas, pcap_days)
+    cmd_create_cluster(profile, region, name, expected_traffic, spi_days, history_days, replicas, pcap_days, preconfirm_usage)
 cli.add_command(create_cluster)
 
 @click.command(help="Tears down the Arkime Cluster in your account; by default, leaves your data intact")

--- a/manage_arkime/commands/create_cluster.py
+++ b/manage_arkime/commands/create_cluster.py
@@ -9,7 +9,8 @@ import cdk_interactions.cdk_context as context
 import constants as constants
 from core.capacity_planning import (get_capture_node_capacity_plan, get_ecs_sys_resource_plan, get_os_domain_plan, ClusterPlan,
                                     CaptureVpcPlan, MINIMUM_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_REPLICAS, DEFAULT_NUM_AZS,
-                                    S3Plan, DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS, DEFAULT_HISTORY_DAYS, UsageReport)
+                                    S3Plan, DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS, DEFAULT_HISTORY_DAYS, UsageReport,
+                                    CaptureNodesPlan, DataNodesPlan, EcsSysResourcePlan, MasterNodesPlan, OSDomainPlan)
 from core.user_config import UserConfig
 
 logger = logging.getLogger(__name__)
@@ -21,9 +22,10 @@ def cmd_create_cluster(profile: str, region: str, name: str, expected_traffic: f
     aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)
 
     user_config = _get_user_config(name, expected_traffic, spi_days, history_days, replicas, pcap_days, aws_provider)
-    capacity_plan = _get_capacity_plan(user_config)
+    previous_capacity_plan = _get_previous_capacity_plan(name, aws_provider)
+    next_capacity_plan = _get_next_capacity_plan(user_config)
 
-    if not _confirm_usage(capacity_plan, preconfirm_usage):
+    if not _confirm_usage(previous_capacity_plan, next_capacity_plan, preconfirm_usage):
         logger.info("Aborting per user response")
         return
 
@@ -37,7 +39,7 @@ def cmd_create_cluster(profile: str, region: str, name: str, expected_traffic: f
         constants.get_opensearch_domain_stack_name(name),
         constants.get_viewer_nodes_stack_name(name)
     ]
-    create_context = context.generate_create_cluster_context(name, cert_arn, capacity_plan, user_config)
+    create_context = context.generate_create_cluster_context(name, cert_arn, next_capacity_plan, user_config)
     cdk_client.deploy(stacks_to_deploy, aws_profile=profile, aws_region=region, context=create_context)
 
 def _get_user_config(cluster_name: str, expected_traffic: float, spi_days: int, history_days: int, replicas: int, 
@@ -72,8 +74,28 @@ def _get_user_config(cluster_name: str, expected_traffic: float, spi_days: int, 
     # All of the parameters defined
     else:
         return UserConfig(expected_traffic, spi_days, history_days, replicas, pcap_days)
+    
+def _get_previous_capacity_plan(cluster_name: str, aws_provider: AwsClientProvider) -> ClusterPlan:
+    # Pull the existing plan, if possible
+    try:
+        stored_plan_json = ssm_ops.get_ssm_param_json_value(
+            constants.get_cluster_ssm_param_name(cluster_name),
+            "capacityPlan",
+            aws_provider
+        )
+        return ClusterPlan.from_dict(stored_plan_json)
 
-def _get_capacity_plan(user_config: UserConfig) -> ClusterPlan:
+    # Existing plan doesn't exist; return a blank plan
+    except ssm_ops.ParamDoesNotExist:
+        return ClusterPlan(
+            CaptureNodesPlan(None, None, None, None),
+            CaptureVpcPlan(None),
+            EcsSysResourcePlan(None, None),
+            OSDomainPlan(DataNodesPlan(None, None, None), MasterNodesPlan(None, None)),
+            S3Plan(None, None)
+        )
+
+def _get_next_capacity_plan(user_config: UserConfig) -> ClusterPlan:
     capture_plan = get_capture_node_capacity_plan(user_config.expectedTraffic)
     capture_vpc_plan = CaptureVpcPlan(DEFAULT_NUM_AZS)
     os_domain_plan = get_os_domain_plan(user_config.expectedTraffic, user_config.spiDays, user_config.replicas, capture_vpc_plan.numAzs)
@@ -82,10 +104,10 @@ def _get_capacity_plan(user_config: UserConfig) -> ClusterPlan:
 
     return ClusterPlan(capture_plan, capture_vpc_plan, ecs_resource_plan, os_domain_plan, s3_plan)
 
-def _confirm_usage(capacity_plan: ClusterPlan, preconfirm_usage: bool) -> bool:
+def _confirm_usage(prev_capacity_plan: ClusterPlan, next_capacity_plan: ClusterPlan, preconfirm_usage: bool) -> bool:
     if preconfirm_usage:
         return True
-    return UsageReport(capacity_plan).get_confirmation()
+    return UsageReport(prev_capacity_plan, next_capacity_plan).get_confirmation()
 
 def _set_up_viewer_cert(name: str, aws_provider: AwsClientProvider) -> str:
     # Only set up the certificate if it doesn't exist

--- a/manage_arkime/core/capacity_planning.py
+++ b/manage_arkime/core/capacity_planning.py
@@ -357,23 +357,24 @@ class ClusterPlan:
     
 @dataclass
 class UsageReport:
-    cluster_plan: ClusterPlan
+    prev_plan: ClusterPlan
+    next_plan: ClusterPlan
 
     def get_report(self) -> str:
         report_text = (
             "Capture Nodes:\n"
-            + f"    Max Count: {self.cluster_plan.captureNodes.maxCount}\n"
-            + f"    Desired Count: {self.cluster_plan.captureNodes.desiredCount}\n"
-            + f"    Min Count: {self.cluster_plan.captureNodes.minCount}\n"
-            + f"    Type: {self.cluster_plan.captureNodes.instanceType}\n"
+            + f"    Max Count: {self.prev_plan.captureNodes.maxCount} -> {self.next_plan.captureNodes.maxCount}\n"
+            + f"    Desired Count: {self.prev_plan.captureNodes.desiredCount} -> {self.next_plan.captureNodes.desiredCount}\n"
+            + f"    Min Count: {self.prev_plan.captureNodes.minCount} -> {self.next_plan.captureNodes.minCount}\n"
+            + f"    Type: {self.prev_plan.captureNodes.instanceType} -> {self.next_plan.captureNodes.instanceType}\n"
             + "OpenSearch Domain:\n"
-            + f"    Master Node Count: {self.cluster_plan.osDomain.masterNodes.count}\n"
-            + f"    Master Node Type: {self.cluster_plan.osDomain.masterNodes.instanceType}\n"
-            + f"    Data Node Count: {self.cluster_plan.osDomain.dataNodes.count}\n"
-            + f"    Data Node Type: {self.cluster_plan.osDomain.dataNodes.instanceType}\n"
-            + f"    Data Node Volume Size [GB]: {self.cluster_plan.osDomain.dataNodes.volumeSize}\n"
+            + f"    Master Node Count: {self.prev_plan.osDomain.masterNodes.count} -> {self.next_plan.osDomain.masterNodes.count}\n"
+            + f"    Master Node Type: {self.prev_plan.osDomain.masterNodes.instanceType} -> {self.next_plan.osDomain.masterNodes.instanceType}\n"
+            + f"    Data Node Count: {self.prev_plan.osDomain.dataNodes.count} -> {self.next_plan.osDomain.dataNodes.count}\n"
+            + f"    Data Node Type: {self.prev_plan.osDomain.dataNodes.instanceType} -> {self.next_plan.osDomain.dataNodes.instanceType}\n"
+            + f"    Data Node Volume Size [GB]: {self.prev_plan.osDomain.dataNodes.volumeSize} -> {self.next_plan.osDomain.dataNodes.volumeSize}\n"
             + "S3 PCAP:\n"
-            + f"    Retention Period [days]: {self.cluster_plan.s3.pcapStorageDays}\n"                       
+            + f"    Retention Period [days]: {self.prev_plan.s3.pcapStorageDays} -> {self.next_plan.s3.pcapStorageDays}\n"                       
         )
         return report_text
     

--- a/manage_arkime/core/capacity_planning.py
+++ b/manage_arkime/core/capacity_planning.py
@@ -3,7 +3,6 @@ import math
 import logging
 from typing import Dict, Type, TypeVar
 
-import shell_interactions as shell
 
 logger = logging.getLogger(__name__)
 
@@ -355,35 +354,3 @@ class ClusterPlan:
 
         return cls(capture_nodes, capture_vpc, ecs_resources, os_domain, s3)
     
-@dataclass
-class UsageReport:
-    prev_plan: ClusterPlan
-    next_plan: ClusterPlan
-
-    def get_report(self) -> str:
-        report_text = (
-            "Capture Nodes:\n"
-            + f"    Max Count: {self.prev_plan.captureNodes.maxCount} -> {self.next_plan.captureNodes.maxCount}\n"
-            + f"    Desired Count: {self.prev_plan.captureNodes.desiredCount} -> {self.next_plan.captureNodes.desiredCount}\n"
-            + f"    Min Count: {self.prev_plan.captureNodes.minCount} -> {self.next_plan.captureNodes.minCount}\n"
-            + f"    Type: {self.prev_plan.captureNodes.instanceType} -> {self.next_plan.captureNodes.instanceType}\n"
-            + "OpenSearch Domain:\n"
-            + f"    Master Node Count: {self.prev_plan.osDomain.masterNodes.count} -> {self.next_plan.osDomain.masterNodes.count}\n"
-            + f"    Master Node Type: {self.prev_plan.osDomain.masterNodes.instanceType} -> {self.next_plan.osDomain.masterNodes.instanceType}\n"
-            + f"    Data Node Count: {self.prev_plan.osDomain.dataNodes.count} -> {self.next_plan.osDomain.dataNodes.count}\n"
-            + f"    Data Node Type: {self.prev_plan.osDomain.dataNodes.instanceType} -> {self.next_plan.osDomain.dataNodes.instanceType}\n"
-            + f"    Data Node Volume Size [GB]: {self.prev_plan.osDomain.dataNodes.volumeSize} -> {self.next_plan.osDomain.dataNodes.volumeSize}\n"
-            + "S3 PCAP:\n"
-            + f"    Retention Period [days]: {self.prev_plan.s3.pcapStorageDays} -> {self.next_plan.s3.pcapStorageDays}\n"                       
-        )
-        return report_text
-    
-    def get_confirmation(self) -> bool:
-        confirm_prompt = (
-            "Your settings will result in the follow AWS Resource usage:\n"
-            + self.get_report()
-            + "\n"
-            + "Do you approve this usage (y/yes or n/no)? "
-        )
-        prompt_response = shell.louder_input(message=confirm_prompt, print_header=True)
-        return prompt_response.strip().lower() in ["y", "yes"]

--- a/manage_arkime/core/usage_report.py
+++ b/manage_arkime/core/usage_report.py
@@ -1,0 +1,45 @@
+import shell_interactions as shell
+from core.capacity_planning import ClusterPlan
+from core.user_config import UserConfig
+
+
+from dataclasses import dataclass
+
+
+@dataclass
+class UsageReport:
+    prev_plan: ClusterPlan
+    next_plan: ClusterPlan
+    prev_config: UserConfig
+    next_config: UserConfig
+
+    def get_report(self) -> str:
+        report_text = (
+            "Arkime Metadata:\n"
+            + f"    Session Retention [days]: {self.prev_config.spiDays} -> {self.next_config.spiDays}\n"
+            + f"    User History Retention [days]: {self.prev_config.historyDays} -> {self.next_config.historyDays}\n"
+            + "Capture Nodes:\n"
+            + f"    Max Count: {self.prev_plan.captureNodes.maxCount} -> {self.next_plan.captureNodes.maxCount}\n"
+            + f"    Desired Count: {self.prev_plan.captureNodes.desiredCount} -> {self.next_plan.captureNodes.desiredCount}\n"
+            + f"    Min Count: {self.prev_plan.captureNodes.minCount} -> {self.next_plan.captureNodes.minCount}\n"
+            + f"    Type: {self.prev_plan.captureNodes.instanceType} -> {self.next_plan.captureNodes.instanceType}\n"
+            + "OpenSearch Domain:\n"
+            + f"    Master Node Count: {self.prev_plan.osDomain.masterNodes.count} -> {self.next_plan.osDomain.masterNodes.count}\n"
+            + f"    Master Node Type: {self.prev_plan.osDomain.masterNodes.instanceType} -> {self.next_plan.osDomain.masterNodes.instanceType}\n"
+            + f"    Data Node Count: {self.prev_plan.osDomain.dataNodes.count} -> {self.next_plan.osDomain.dataNodes.count}\n"
+            + f"    Data Node Type: {self.prev_plan.osDomain.dataNodes.instanceType} -> {self.next_plan.osDomain.dataNodes.instanceType}\n"
+            + f"    Data Node Volume Size [GB]: {self.prev_plan.osDomain.dataNodes.volumeSize} -> {self.next_plan.osDomain.dataNodes.volumeSize}\n"
+            + "S3:\n"
+            + f"    PCAP Retention [days]: {self.prev_plan.s3.pcapStorageDays} -> {self.next_plan.s3.pcapStorageDays}\n"
+        )
+        return report_text
+
+    def get_confirmation(self) -> bool:
+        confirm_prompt = (
+            "Your settings will result in the follow AWS Resource usage:\n"
+            + self.get_report()
+            + "\n"
+            + "Do you approve this usage (y/yes or n/no)? "
+        )
+        prompt_response = shell.louder_input(message=confirm_prompt, print_header=True)
+        return prompt_response.strip().lower() in ["y", "yes"]

--- a/test_manage_arkime/core/test_capacity_planning.py
+++ b/test_manage_arkime/core/test_capacity_planning.py
@@ -1,5 +1,4 @@
 import pytest
-import unittest.mock as mock
 
 import core.capacity_planning as cap
 
@@ -172,101 +171,6 @@ def test_WHEN_get_os_domain_plan_called_THEN_as_expected():
         cap.DataNodesPlan(64, cap.R6G_4XLARGE_SEARCH.type, cap.R6G_4XLARGE_SEARCH.vol_size),
         cap.MasterNodesPlan(3, "r6g.2xlarge.search")
     )
-    assert expected_value == actual_value
-
-def test_WHEN_UsageReport_get_report_THEN_as_expected():
-    # Set up the test
-    prev_plan = cap.ClusterPlan(
-        cap.CaptureNodesPlan(None, None, None, None),
-        cap.CaptureVpcPlan(None),
-        cap.EcsSysResourcePlan(None, None),
-        cap.OSDomainPlan(cap.DataNodesPlan(None, None, None), cap.MasterNodesPlan(None, None)),
-        cap.S3Plan(None, None)
-    )
-    next_plan = cap.ClusterPlan(
-        cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
-        cap.CaptureVpcPlan(1),
-        cap.EcsSysResourcePlan(1, 1),
-        cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
-        cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30)
-    )
-
-    # Run the test
-    actual_report = cap.UsageReport(prev_plan, next_plan).get_report()
-
-    # Check the results
-    expected_report = (
-        "Capture Nodes:\n"
-        + "    Max Count: None -> 2\n"
-        + "    Desired Count: None -> 1\n"
-        + "    Min Count: None -> 1\n"
-        + f"    Type: None -> {cap.INSTANCE_TYPE_CAPTURE_NODE}\n"
-        + "OpenSearch Domain:\n"
-        + "    Master Node Count: None -> 3\n"
-        + "    Master Node Type: None -> m6g.large.search\n"
-        + "    Data Node Count: None -> 2\n"
-        + "    Data Node Type: None -> t3.small.search\n"
-        + "    Data Node Volume Size [GB]: None -> 100\n"
-        + "S3 PCAP:\n"
-        + "    Retention Period [days]: None -> 30\n"                       
-    )
-
-    assert expected_report == actual_report
-
-@mock.patch('core.capacity_planning.shell')
-def test_WHEN_UsageReport_get_confirmation_AND_yes_THEN_as_expected(mock_shell):
-    # Set up the test
-    prev_plan = cap.ClusterPlan(
-        cap.CaptureNodesPlan(None, None, None, None),
-        cap.CaptureVpcPlan(None),
-        cap.EcsSysResourcePlan(None, None),
-        cap.OSDomainPlan(cap.DataNodesPlan(None, None, None), cap.MasterNodesPlan(None, None)),
-        cap.S3Plan(None, None)
-    )
-    next_plan = cap.ClusterPlan(
-        cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
-        cap.CaptureVpcPlan(1),
-        cap.EcsSysResourcePlan(1, 1),
-        cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
-        cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30)
-    )
-
-    mock_input = mock_shell.louder_input
-    mock_input.return_value = "yes"
-
-    # Run the test
-    actual_value = cap.UsageReport(prev_plan, next_plan).get_confirmation()
-
-    # Check the results
-    expected_value = True
-    assert expected_value == actual_value
-
-@mock.patch('core.capacity_planning.shell')
-def test_WHEN_UsageReport_get_confirmation_AND_no_THEN_as_expected(mock_shell):
-    # Set up the test
-    prev_plan = cap.ClusterPlan(
-        cap.CaptureNodesPlan(None, None, None, None),
-        cap.CaptureVpcPlan(None),
-        cap.EcsSysResourcePlan(None, None),
-        cap.OSDomainPlan(cap.DataNodesPlan(None, None, None), cap.MasterNodesPlan(None, None)),
-        cap.S3Plan(None, None)
-    )
-    next_plan = cap.ClusterPlan(
-        cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
-        cap.CaptureVpcPlan(1),
-        cap.EcsSysResourcePlan(1, 1),
-        cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
-        cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30)
-    )
-
-    mock_input = mock_shell.louder_input
-    mock_input.return_value = "no"
-
-    # Run the test
-    actual_value = cap.UsageReport(prev_plan, next_plan).get_confirmation()
-
-    # Check the results
-    expected_value = False
     assert expected_value == actual_value
 
     

--- a/test_manage_arkime/core/test_capacity_planning.py
+++ b/test_manage_arkime/core/test_capacity_planning.py
@@ -176,7 +176,14 @@ def test_WHEN_get_os_domain_plan_called_THEN_as_expected():
 
 def test_WHEN_UsageReport_get_report_THEN_as_expected():
     # Set up the test
-    cluster_plan = cap.ClusterPlan(
+    prev_plan = cap.ClusterPlan(
+        cap.CaptureNodesPlan(None, None, None, None),
+        cap.CaptureVpcPlan(None),
+        cap.EcsSysResourcePlan(None, None),
+        cap.OSDomainPlan(cap.DataNodesPlan(None, None, None), cap.MasterNodesPlan(None, None)),
+        cap.S3Plan(None, None)
+    )
+    next_plan = cap.ClusterPlan(
         cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
         cap.CaptureVpcPlan(1),
         cap.EcsSysResourcePlan(1, 1),
@@ -185,23 +192,23 @@ def test_WHEN_UsageReport_get_report_THEN_as_expected():
     )
 
     # Run the test
-    actual_report = cap.UsageReport(cluster_plan).get_report()
+    actual_report = cap.UsageReport(prev_plan, next_plan).get_report()
 
     # Check the results
     expected_report = (
         "Capture Nodes:\n"
-        + "    Max Count: 2\n"
-        + "    Desired Count: 1\n"
-        + "    Min Count: 1\n"
-        + f"    Type: {cap.INSTANCE_TYPE_CAPTURE_NODE}\n"
+        + "    Max Count: None -> 2\n"
+        + "    Desired Count: None -> 1\n"
+        + "    Min Count: None -> 1\n"
+        + f"    Type: None -> {cap.INSTANCE_TYPE_CAPTURE_NODE}\n"
         + "OpenSearch Domain:\n"
-        + "    Master Node Count: 3\n"
-        + "    Master Node Type: m6g.large.search\n"
-        + "    Data Node Count: 2\n"
-        + "    Data Node Type: t3.small.search\n"
-        + "    Data Node Volume Size [GB]: 100\n"
+        + "    Master Node Count: None -> 3\n"
+        + "    Master Node Type: None -> m6g.large.search\n"
+        + "    Data Node Count: None -> 2\n"
+        + "    Data Node Type: None -> t3.small.search\n"
+        + "    Data Node Volume Size [GB]: None -> 100\n"
         + "S3 PCAP:\n"
-        + "    Retention Period [days]: 30\n"                       
+        + "    Retention Period [days]: None -> 30\n"                       
     )
 
     assert expected_report == actual_report
@@ -209,7 +216,14 @@ def test_WHEN_UsageReport_get_report_THEN_as_expected():
 @mock.patch('core.capacity_planning.shell')
 def test_WHEN_UsageReport_get_confirmation_AND_yes_THEN_as_expected(mock_shell):
     # Set up the test
-    cluster_plan = cap.ClusterPlan(
+    prev_plan = cap.ClusterPlan(
+        cap.CaptureNodesPlan(None, None, None, None),
+        cap.CaptureVpcPlan(None),
+        cap.EcsSysResourcePlan(None, None),
+        cap.OSDomainPlan(cap.DataNodesPlan(None, None, None), cap.MasterNodesPlan(None, None)),
+        cap.S3Plan(None, None)
+    )
+    next_plan = cap.ClusterPlan(
         cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
         cap.CaptureVpcPlan(1),
         cap.EcsSysResourcePlan(1, 1),
@@ -221,7 +235,7 @@ def test_WHEN_UsageReport_get_confirmation_AND_yes_THEN_as_expected(mock_shell):
     mock_input.return_value = "yes"
 
     # Run the test
-    actual_value = cap.UsageReport(cluster_plan).get_confirmation()
+    actual_value = cap.UsageReport(prev_plan, next_plan).get_confirmation()
 
     # Check the results
     expected_value = True
@@ -230,7 +244,14 @@ def test_WHEN_UsageReport_get_confirmation_AND_yes_THEN_as_expected(mock_shell):
 @mock.patch('core.capacity_planning.shell')
 def test_WHEN_UsageReport_get_confirmation_AND_no_THEN_as_expected(mock_shell):
     # Set up the test
-    cluster_plan = cap.ClusterPlan(
+    prev_plan = cap.ClusterPlan(
+        cap.CaptureNodesPlan(None, None, None, None),
+        cap.CaptureVpcPlan(None),
+        cap.EcsSysResourcePlan(None, None),
+        cap.OSDomainPlan(cap.DataNodesPlan(None, None, None), cap.MasterNodesPlan(None, None)),
+        cap.S3Plan(None, None)
+    )
+    next_plan = cap.ClusterPlan(
         cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
         cap.CaptureVpcPlan(1),
         cap.EcsSysResourcePlan(1, 1),
@@ -242,7 +263,7 @@ def test_WHEN_UsageReport_get_confirmation_AND_no_THEN_as_expected(mock_shell):
     mock_input.return_value = "no"
 
     # Run the test
-    actual_value = cap.UsageReport(cluster_plan).get_confirmation()
+    actual_value = cap.UsageReport(prev_plan, next_plan).get_confirmation()
 
     # Check the results
     expected_value = False

--- a/test_manage_arkime/core/test_capacity_planning.py
+++ b/test_manage_arkime/core/test_capacity_planning.py
@@ -1,4 +1,5 @@
 import pytest
+import unittest.mock as mock
 
 import core.capacity_planning as cap
 
@@ -171,6 +172,80 @@ def test_WHEN_get_os_domain_plan_called_THEN_as_expected():
         cap.DataNodesPlan(64, cap.R6G_4XLARGE_SEARCH.type, cap.R6G_4XLARGE_SEARCH.vol_size),
         cap.MasterNodesPlan(3, "r6g.2xlarge.search")
     )
+    assert expected_value == actual_value
+
+def test_WHEN_UsageReport_get_report_THEN_as_expected():
+    # Set up the test
+    cluster_plan = cap.ClusterPlan(
+        cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
+        cap.CaptureVpcPlan(1),
+        cap.EcsSysResourcePlan(1, 1),
+        cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
+        cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30)
+    )
+
+    # Run the test
+    actual_report = cap.UsageReport(cluster_plan).get_report()
+
+    # Check the results
+    expected_report = (
+        "Capture Nodes:\n"
+        + "    Max Count: 2\n"
+        + "    Desired Count: 1\n"
+        + "    Min Count: 1\n"
+        + f"    Type: {cap.INSTANCE_TYPE_CAPTURE_NODE}\n"
+        + "OpenSearch Domain:\n"
+        + "    Master Node Count: 3\n"
+        + "    Master Node Type: m6g.large.search\n"
+        + "    Data Node Count: 2\n"
+        + "    Data Node Type: t3.small.search\n"
+        + "    Data Node Volume Size [GB]: 100\n"
+        + "S3 PCAP:\n"
+        + "    Retention Period [days]: 30\n"                       
+    )
+
+    assert expected_report == actual_report
+
+@mock.patch('core.capacity_planning.shell')
+def test_WHEN_UsageReport_get_confirmation_AND_yes_THEN_as_expected(mock_shell):
+    # Set up the test
+    cluster_plan = cap.ClusterPlan(
+        cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
+        cap.CaptureVpcPlan(1),
+        cap.EcsSysResourcePlan(1, 1),
+        cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
+        cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30)
+    )
+
+    mock_input = mock_shell.louder_input
+    mock_input.return_value = "yes"
+
+    # Run the test
+    actual_value = cap.UsageReport(cluster_plan).get_confirmation()
+
+    # Check the results
+    expected_value = True
+    assert expected_value == actual_value
+
+@mock.patch('core.capacity_planning.shell')
+def test_WHEN_UsageReport_get_confirmation_AND_no_THEN_as_expected(mock_shell):
+    # Set up the test
+    cluster_plan = cap.ClusterPlan(
+        cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
+        cap.CaptureVpcPlan(1),
+        cap.EcsSysResourcePlan(1, 1),
+        cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
+        cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30)
+    )
+
+    mock_input = mock_shell.louder_input
+    mock_input.return_value = "no"
+
+    # Run the test
+    actual_value = cap.UsageReport(cluster_plan).get_confirmation()
+
+    # Check the results
+    expected_value = False
     assert expected_value == actual_value
 
     

--- a/test_manage_arkime/core/test_usage_report.py
+++ b/test_manage_arkime/core/test_usage_report.py
@@ -1,0 +1,110 @@
+
+import unittest.mock as mock
+
+import core.capacity_planning as cap
+from core.usage_report import UsageReport
+from core.user_config import UserConfig
+
+def test_WHEN_UsageReport_get_report_THEN_as_expected():
+    # Set up the test
+    prev_plan = cap.ClusterPlan(
+        cap.CaptureNodesPlan(None, None, None, None),
+        cap.CaptureVpcPlan(None),
+        cap.EcsSysResourcePlan(None, None),
+        cap.OSDomainPlan(cap.DataNodesPlan(None, None, None), cap.MasterNodesPlan(None, None)),
+        cap.S3Plan(None, None)
+    )
+    next_plan = cap.ClusterPlan(
+        cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
+        cap.CaptureVpcPlan(1),
+        cap.EcsSysResourcePlan(1, 1),
+        cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
+        cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30)
+    )
+    prev_config = UserConfig(None, None, None, None, None)
+    next_config = UserConfig(0.5, 30, 365, 1, 120)
+
+    # Run the test
+    actual_report = UsageReport(prev_plan, next_plan, prev_config, next_config).get_report()
+
+    # Check the results
+    expected_report = (
+        "Arkime Metadata:\n"
+        + f"    Session Retention [days]: None -> 30\n"
+        + f"    User History Retention [days]: None -> 365\n"
+        + "Capture Nodes:\n"
+        + "    Max Count: None -> 2\n"
+        + "    Desired Count: None -> 1\n"
+        + "    Min Count: None -> 1\n"
+        + f"    Type: None -> {cap.INSTANCE_TYPE_CAPTURE_NODE}\n"
+        + "OpenSearch Domain:\n"
+        + "    Master Node Count: None -> 3\n"
+        + "    Master Node Type: None -> m6g.large.search\n"
+        + "    Data Node Count: None -> 2\n"
+        + "    Data Node Type: None -> t3.small.search\n"
+        + "    Data Node Volume Size [GB]: None -> 100\n"
+        + "S3:\n"
+        + "    PCAP Retention [days]: None -> 30\n"                       
+    )
+
+    assert expected_report == actual_report
+
+@mock.patch('core.usage_report.shell')
+def test_WHEN_UsageReport_get_confirmation_AND_yes_THEN_as_expected(mock_shell):
+    # Set up the test
+    prev_plan = cap.ClusterPlan(
+        cap.CaptureNodesPlan(None, None, None, None),
+        cap.CaptureVpcPlan(None),
+        cap.EcsSysResourcePlan(None, None),
+        cap.OSDomainPlan(cap.DataNodesPlan(None, None, None), cap.MasterNodesPlan(None, None)),
+        cap.S3Plan(None, None)
+    )
+    next_plan = cap.ClusterPlan(
+        cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
+        cap.CaptureVpcPlan(1),
+        cap.EcsSysResourcePlan(1, 1),
+        cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
+        cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30)
+    )
+    prev_config = UserConfig(None, None, None, None, None)
+    next_config = UserConfig(0.5, 30, 365, 1, 120)
+
+    mock_input = mock_shell.louder_input
+    mock_input.return_value = "yes"
+
+    # Run the test
+    actual_value = UsageReport(prev_plan, next_plan, prev_config, next_config).get_confirmation()
+
+    # Check the results
+    expected_value = True
+    assert expected_value == actual_value
+
+@mock.patch('core.usage_report.shell')
+def test_WHEN_UsageReport_get_confirmation_AND_no_THEN_as_expected(mock_shell):
+    # Set up the test
+    prev_plan = cap.ClusterPlan(
+        cap.CaptureNodesPlan(None, None, None, None),
+        cap.CaptureVpcPlan(None),
+        cap.EcsSysResourcePlan(None, None),
+        cap.OSDomainPlan(cap.DataNodesPlan(None, None, None), cap.MasterNodesPlan(None, None)),
+        cap.S3Plan(None, None)
+    )
+    next_plan = cap.ClusterPlan(
+        cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
+        cap.CaptureVpcPlan(1),
+        cap.EcsSysResourcePlan(1, 1),
+        cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
+        cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30)
+    )
+    prev_config = UserConfig(None, None, None, None, None)
+    next_config = UserConfig(0.5, 30, 365, 1, 120)
+
+    mock_input = mock_shell.louder_input
+    mock_input.return_value = "no"
+
+    # Run the test
+    actual_value = UsageReport(prev_plan, next_plan, prev_config, next_config).get_confirmation()
+
+    # Check the results
+    expected_value = False
+    assert expected_value == actual_value


### PR DESCRIPTION
## Description
* When the user invokes `create-cluster`, they are presented with a usage report containing the high-level details of their cluster's capacity.  This can be used for estimating cost, among other things.  They must approve the usage before continuing with the command.
* The usage report shows the difference between the previous and next plans.  If there wasn't a previous capacity plan (e.g. previsioning a new cluster), then the "previous" values will be listed as `None`.
* Users can bypass this manual confirmation with the `--preconfirm-usage` flag

## Tasks
* https://github.com/arkime/aws-aio/issues/64

## Testing
* Unit tests
* Ran the `create-cluster` command for new/existing clusters, with and without the bypass flag:
```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py create-cluster --name MyCluster2
2023-06-23 11:28:41 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime.log
2023-06-23 11:28:41 - Using AWS Credential Profile: default
2023-06-23 11:28:41 - Using AWS Region: default from AWS Config settings
2023-06-23 11:28:42 - ================================================================================
2023-06-23 11:28:42 - USER ACTION REQUIRED:
2023-06-23 11:28:42 - --------------------------------------------------------------------------------
Your settings will result in the follow AWS Resource usage:
Arkime Metadata:
    Session Retention [days]: None -> 30
    User History Retention [days]: None -> 365
Capture Nodes:
    Max Count: None -> 2
    Desired Count: None -> 1
    Min Count: None -> 1
    Type: None -> m5.xlarge
OpenSearch Domain:
    Master Node Count: None -> 3
    Master Node Type: None -> m5.large.search
    Data Node Count: None -> 2
    Data Node Type: None -> t3.small.search
    Data Node Volume Size [GB]: None -> 100
S3:
    PCAP Retention [days]: None -> 30

Do you approve this usage (y/yes or n/no)? n
2023-06-23 11:28:49 - Aborting per user response
```

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py create-cluster --name MyCluster3
2023-06-23 11:31:09 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime.log
2023-06-23 11:31:09 - Using AWS Credential Profile: default
2023-06-23 11:31:09 - Using AWS Region: default from AWS Config settings
2023-06-23 11:31:10 - ================================================================================
2023-06-23 11:31:10 - USER ACTION REQUIRED:
2023-06-23 11:31:10 - --------------------------------------------------------------------------------
Your settings will result in the follow AWS Resource usage:
Arkime Metadata:
    Session Retention [days]: 30 -> 30
    User History Retention [days]: 120 -> 120
Capture Nodes:
    Max Count: 2 -> 2
    Desired Count: 1 -> 1
    Min Count: 1 -> 1
    Type: m5.xlarge -> m5.xlarge
OpenSearch Domain:
    Master Node Count: 3 -> 3
    Master Node Type: m6g.large.search -> m6g.large.search
    Data Node Count: 2 -> 2
    Data Node Type: r6g.large.search -> r6g.large.search
    Data Node Volume Size [GB]: 1024 -> 1024
S3:
    PCAP Retention [days]: 30 -> 30

Do you approve this usage (y/yes or n/no)? y
2023-06-23 11:31:13 - Executing command: deploy MyCluster3-CaptureBucket MyCluster3-CaptureNodes MyCluster3-CaptureVPC MyCluster3-OSDomain MyCluster3-ViewerNodes
2023-06-23 11:31:13 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-06-23 11:31:43 - Deployment succeeded
```

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py create-cluster --name MyCluster3 --preconfirm-usage
2023-06-23 11:29:39 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime.log
2023-06-23 11:29:39 - Using AWS Credential Profile: default
2023-06-23 11:29:39 - Using AWS Region: default from AWS Config settings
2023-06-23 11:29:40 - Usage report:
Arkime Metadata:
    Session Retention [days]: 30 -> 30
    User History Retention [days]: 120 -> 120
Capture Nodes:
    Max Count: 2 -> 2
    Desired Count: 1 -> 1
    Min Count: 1 -> 1
    Type: m5.xlarge -> m5.xlarge
OpenSearch Domain:
    Master Node Count: 3 -> 3
    Master Node Type: m6g.large.search -> m6g.large.search
    Data Node Count: 2 -> 2
    Data Node Type: r6g.large.search -> r6g.large.search
    Data Node Volume Size [GB]: 1024 -> 1024
S3:
    PCAP Retention [days]: 30 -> 30

2023-06-23 11:29:41 - Executing command: deploy MyCluster3-CaptureBucket MyCluster3-CaptureNodes MyCluster3-CaptureVPC MyCluster3-OSDomain MyCluster3-ViewerNodes
2023-06-23 11:29:41 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-06-23 11:30:11 - Deployment succeeded
```

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
