### PR TITLE
Traffic Mirror routing now based on source VPC CIDR

### DIFF
--- a/cdk-lib/cloud-demo.ts
+++ b/cdk-lib/cloud-demo.ts
@@ -83,24 +83,29 @@ switch(params.type) {
             subnetIds: params.listSubnetIds,
             subnetSsmParamNames: params.listSubnetSsmParams,
             vpcId: params.idVpc,
+            vpcCidr: params.vpcCidr,
             vpcSsmParamName: params.nameVpcSsmParam,
             vpceServiceId: params.idVpceService,
-            mirrorVni: params.idVni
+            mirrorVni: params.idVni,
         })
         break;
     case 'DeployDemoTrafficParams':
         new TrafficGenStack(app, 'DemoTrafficGen01', {
+            cidr: "10.0.0.0/16",
             env: env
         });
         new TrafficGenStack(app, 'DemoTrafficGen02', {
+            cidr: "192.168.0.0/16",
             env: env
         });
         break;
     case 'DestroyDemoTrafficParams':
         new TrafficGenStack(app, 'DemoTrafficGen01', {
+            cidr: "10.0.0.0/16",
             env: env
         });
         new TrafficGenStack(app, 'DemoTrafficGen02', {
+            cidr: "192.168.0.0/16",
             env: env
         });
         break;

--- a/cdk-lib/core/command-params.ts
+++ b/cdk-lib/core/command-params.ts
@@ -44,6 +44,7 @@ export interface MirrorMgmtParamsRaw extends CommandParamsRaw {
     idVpceService: string;
     listSubnetIds: string[];
     listSubnetSsmParams: string[];
+    vpcCidr: string;
 }
 
 /**
@@ -108,4 +109,5 @@ export interface MirrorMgmtParams extends CommandParams {
     idVpceService: string;
     listSubnetIds: string[];
     listSubnetSsmParams: string[];
+    vpcCidr: string;
 }

--- a/cdk-lib/core/context-wrangling.ts
+++ b/cdk-lib/core/context-wrangling.ts
@@ -124,7 +124,8 @@ function validateArgs(args: ValidateArgs) : (prms.ClusterMgmtParams | prms.Deplo
                 idVpc: rawMirrorMgmtParamsObj.idVpc,
                 idVpceService: rawMirrorMgmtParamsObj.idVpceService,
                 listSubnetIds: rawMirrorMgmtParamsObj.listSubnetIds,
-                listSubnetSsmParams: rawMirrorMgmtParamsObj.listSubnetSsmParams
+                listSubnetSsmParams: rawMirrorMgmtParamsObj.listSubnetSsmParams,
+                vpcCidr: rawMirrorMgmtParamsObj.vpcCidr,
             }
             return mirrorMgmtParams;
         default:

--- a/cdk-lib/traffic-gen-sample/traffic-gen-stack.ts
+++ b/cdk-lib/traffic-gen-sample/traffic-gen-stack.ts
@@ -8,9 +8,12 @@ import * as logs from 'aws-cdk-lib/aws-logs';
 import * as path from 'path'
 import { Construct } from 'constructs';
 
+export interface TrafficGenStackProps extends cdk.StackProps {
+    readonly cidr: string;
+}
 
 export class TrafficGenStack extends cdk.Stack {
-    constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    constructor(scope: Construct, id: string, props: TrafficGenStackProps) {
         super(scope, id, props);
 
         /**
@@ -18,7 +21,10 @@ export class TrafficGenStack extends cdk.Stack {
          */
         // This is a Stock VPC w/ a Public/Private subnet pair in 1 AZ along with NATGateways providing internet access 
         // to the private subnet.
-        const vpc = new ec2.Vpc(this, 'VPC', {maxAzs: 1});
+        const vpc = new ec2.Vpc(this, 'VPC', {
+            ipAddresses: ec2.IpAddresses.cidr(props.cidr),
+            maxAzs: 1
+        });
 
         // Set up VPC Flow Logs to enable visibility of the traffic mirroring on the user-side
         const flowLogsGroup = new logs.LogGroup(this, 'FlowLogsLogGroup', {

--- a/manage_arkime/cdk_interactions/cdk_context.py
+++ b/manage_arkime/cdk_interactions/cdk_context.py
@@ -54,21 +54,23 @@ def _generate_cluster_context(name: str, viewer_cert_arn: str, cluster_plan: Clu
         constants.CDK_CONTEXT_PARAMS_VAR: shlex.quote(json.dumps(cmd_params))
     }
 
-def generate_add_vpc_context(cluster_name: str, vpc_id: str, subnet_ids: str, vpce_service_id: str, bus_arn: str, vni: int) -> Dict[str, str]:
-    add_context = _generate_mirroring_context(cluster_name, vpc_id, subnet_ids, vpce_service_id, bus_arn, vni)
+def generate_add_vpc_context(cluster_name: str, vpc_id: str, subnet_ids: str, vpce_service_id: str, bus_arn: str, vni: int, cidr: str) -> Dict[str, str]:
+    add_context = _generate_mirroring_context(cluster_name, vpc_id, subnet_ids, vpce_service_id, bus_arn, vni, cidr)
     add_context[constants.CDK_CONTEXT_CMD_VAR] = constants.CMD_ADD_VPC
     return add_context
 
 def generate_remove_vpc_context(cluster_name: str, vpc_id: str, subnet_ids: str, vpce_service_id: str, bus_arn: str) -> Dict[str, str]:
-    # Hardcode this value because it saves us some implementation headaches and it doesn't matter what it is. Since
-    # we're tearing down the Cfn stack in which it would be used, the operation either succeeds and the number is
-    # irrelevant or it fails/rolls back and the number is irrelevant.
+    # Hardcode these values because it saves us some implementation headaches and it doesn't matter what they are. Since
+    # we're tearing down the Cfn stack in which it would be used, the operation either succeeds and the it's
+    # irrelevant or it fails/rolls back and it's irrelevant.
     vni = constants.VNI_DEFAULT
-    remove_context = _generate_mirroring_context(cluster_name, vpc_id, subnet_ids, vpce_service_id, bus_arn, vni)
+    cidr = "0.0.0.0/0"
+    remove_context = _generate_mirroring_context(cluster_name, vpc_id, subnet_ids, vpce_service_id, bus_arn, vni, cidr)
     remove_context[constants.CDK_CONTEXT_CMD_VAR] = constants.CMD_REMOVE_VPC
     return remove_context
 
-def _generate_mirroring_context(cluster_name: str, vpc_id: str, subnet_ids: str, vpce_service_id: str, bus_arn: str, vni: int) -> Dict[str, str]:
+def _generate_mirroring_context(cluster_name: str, vpc_id: str, subnet_ids: str, vpce_service_id: str, bus_arn: str, vni: int,
+                                cidr: str) -> Dict[str, str]:
     cmd_params = {
         "arnEventBus": bus_arn,
         "nameCluster": cluster_name,
@@ -78,7 +80,8 @@ def _generate_mirroring_context(cluster_name: str, vpc_id: str, subnet_ids: str,
         "idVpc": vpc_id,
         "idVpceService": vpce_service_id,
         "listSubnetIds": subnet_ids,
-        "listSubnetSsmParams": [constants.get_subnet_ssm_param_name(cluster_name, vpc_id, subnet_id) for subnet_id in subnet_ids]
+        "listSubnetSsmParams": [constants.get_subnet_ssm_param_name(cluster_name, vpc_id, subnet_id) for subnet_id in subnet_ids],
+        "vpcCidr": cidr
     }
 
     return {

--- a/manage_arkime/commands/add_vpc.py
+++ b/manage_arkime/commands/add_vpc.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 from aws_interactions.aws_client_provider import AwsClientProvider
@@ -54,9 +53,10 @@ def cmd_add_vpc(profile: str, region: str, cluster_name: str, vpc_id: str, user_
         logger.warning("Aborting...")
         return
 
-    # Get all the subnets in the VPC
+    # Get information about the VPC
     try:
         subnet_ids = ec2i.get_subnets_of_vpc(vpc_id, aws_provider)
+        vpc_details = ec2i.get_vpc_details(vpc_id, aws_provider)
     except ec2i.VpcDoesNotExist as ex:
         logger.error(f"The VPC {vpc_id} does not exist in the account/region")
         logger.warning("Aborting...")
@@ -71,7 +71,8 @@ def cmd_add_vpc(profile: str, region: str, cluster_name: str, vpc_id: str, user_
     stacks_to_deploy = [
         constants.get_vpc_mirror_setup_stack_name(cluster_name, vpc_id)
     ]
-    add_vpc_context = context.generate_add_vpc_context(cluster_name, vpc_id, subnet_ids, vpce_service_id, event_bus_arn, next_vni)
+    add_vpc_context = context.generate_add_vpc_context(cluster_name, vpc_id, subnet_ids, vpce_service_id, event_bus_arn,
+                                                       next_vni,vpc_details.cidr_block)
 
     cdk_client = CdkClient()
     cdk_client.deploy(stacks_to_deploy, aws_profile=profile, aws_region=region, context=add_vpc_context)

--- a/manage_arkime/commands/create_cluster.py
+++ b/manage_arkime/commands/create_cluster.py
@@ -43,7 +43,7 @@ def cmd_create_cluster(profile: str, region: str, name: str, expected_traffic: f
     create_context = context.generate_create_cluster_context(name, cert_arn, next_capacity_plan, next_user_config)
     cdk_client.deploy(stacks_to_deploy, aws_profile=profile, aws_region=region, context=create_context)
 
-    _configure_ism(name, user_config.historyDays, user_config.spiDays, user_config.replicas, aws_provider)
+    _configure_ism(name, next_user_config.historyDays, next_user_config.spiDays, next_user_config.replicas, aws_provider)
 
 def _get_previous_user_config(cluster_name: str, aws_provider: AwsClientProvider) -> UserConfig:
     # Pull the existing config, if possible

--- a/test_manage_arkime/commands/test_add_vpc.py
+++ b/test_manage_arkime/commands/test_add_vpc.py
@@ -50,6 +50,7 @@ def test_WHEN_cmd_add_vpc_called_AND_no_user_vni_THEN_sets_up_mirroring(mock_cdk
 
     subnet_ids = ["subnet-1", "subnet-2"]
     mock_ec2i.get_subnets_of_vpc.return_value = ["subnet-1", "subnet-2"]
+    mock_ec2i.get_vpc_details.return_value = ec2i.VpcDetails("vpc-1", "1234", "196.168.0.0/16", "default")
 
     mock_ssm.get_ssm_param_value.return_value = "" # Doesn't matter what this is besides an exception
     mock_ssm.get_ssm_param_json_value.side_effect = ["service-1", "bus-1", "filter-1"]
@@ -79,7 +80,8 @@ def test_WHEN_cmd_add_vpc_called_AND_no_user_vni_THEN_sets_up_mirroring(mock_cdk
                     "idVpc": "vpc-1",
                     "idVpceService": "service-1",
                     "listSubnetIds": subnet_ids,
-                    "listSubnetSsmParams": [constants.get_subnet_ssm_param_name("cluster-1", "vpc-1", subnet_id) for subnet_id in subnet_ids]
+                    "listSubnetSsmParams": [constants.get_subnet_ssm_param_name("cluster-1", "vpc-1", subnet_id) for subnet_id in subnet_ids],
+                    "vpcCidr": "196.168.0.0/16"
                 }))
             }
         )
@@ -139,6 +141,7 @@ def test_WHEN_cmd_add_vpc_called_AND_is_available_user_vni_THEN_sets_up_mirrorin
 
     subnet_ids = ["subnet-1", "subnet-2"]
     mock_ec2i.get_subnets_of_vpc.return_value = ["subnet-1", "subnet-2"]
+    mock_ec2i.get_vpc_details.return_value = ec2i.VpcDetails("vpc-1", "1234", "196.168.0.0/16", "default")
 
     mock_ssm.get_ssm_param_value.return_value = "" # Doesn't matter what this is besides an exception
     mock_ssm.get_ssm_param_json_value.side_effect = ["service-1", "bus-1", "filter-1"]
@@ -168,7 +171,8 @@ def test_WHEN_cmd_add_vpc_called_AND_is_available_user_vni_THEN_sets_up_mirrorin
                     "idVpc": "vpc-1",
                     "idVpceService": "service-1",
                     "listSubnetIds": subnet_ids,
-                    "listSubnetSsmParams": [constants.get_subnet_ssm_param_name("cluster-1", "vpc-1", subnet_id) for subnet_id in subnet_ids]
+                    "listSubnetSsmParams": [constants.get_subnet_ssm_param_name("cluster-1", "vpc-1", subnet_id) for subnet_id in subnet_ids],
+                    "vpcCidr": "196.168.0.0/16"
                 }))
             }
         )

--- a/test_manage_arkime/commands/test_remove_vpc.py
+++ b/test_manage_arkime/commands/test_remove_vpc.py
@@ -52,7 +52,8 @@ def test_WHEN_cmd_remove_vpc_called_THEN_removes_mirroring(mock_cdk_client_cls, 
                     "idVpc": "vpc-1",
                     "idVpceService": "service-1",
                     "listSubnetIds": ["subnet-1", "subnet-2"],
-                    "listSubnetSsmParams": [constants.get_subnet_ssm_param_name("cluster-1", "vpc-1", subnet_id) for subnet_id in ["subnet-1", "subnet-2"]]
+                    "listSubnetSsmParams": [constants.get_subnet_ssm_param_name("cluster-1", "vpc-1", subnet_id) for subnet_id in ["subnet-1", "subnet-2"]],
+                    "vpcCidr": "0.0.0.0/0"
                 }))
             }
         )


### PR DESCRIPTION
## Description
* Updated traffic mirror routing configuration to base itself off of the source VPC's CIDR.  I think the configuration we now have should work for most circumstances, but it's possible we'll over-capture traffic by nabbing packets that are headed to connected VPCs with different CIDRs (such as with VPC Peering).
* Updated the demo traffic stacks to have different CIDRs; one is 10.0.0.0/16 and the other is 192.168.0.0/16.

## Tasks
* https://github.com/arkime/aws-aio/issues/66

## Testing
* Added unit tests
* Tore down/recreated the demo traffic stacks (`destroy-demo-traffic`), then began capturing on both of their VPCs (`add-vpc`).  Logged into the Arkime dashboard to ensure the traffic from both VPCs (with different CIDRs) was being captured.  Saw CURLs coming from the `10.*` and `192.*` IP spaces.  Screenshot below.
![Screen Shot 2023-06-26 at 9 35 36 AM](https://github.com/arkime/aws-aio/assets/25470211/3ea92547-0501-4c68-92b6-633baeb77af4)



## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
