### PR TITLE
Updated Mirroring code to handle multi-CIDR VPCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Here are some scaling things that you'll want to consider:
 * The maximum scaling limit of the Capture Nodes ECS Service as well as the scaling conditions
 * The number of availability zones the setup launches in, and whether specific zones are required
 * The max throughput of a single Gateway Load Balancer Endpoint is 100 Gbps, and we provision one per User subnet
+* The max number of CIDR ranges a User VPC can have is 4, due to the hard cap on Traffic Mirroring Filter Rules
 
 Here are some account limits you'll want to watch out for:
 * Number of EIPs per region is small, and we spin up several for each Arkime Cluster

--- a/cdk-lib/cloud-demo.ts
+++ b/cdk-lib/cloud-demo.ts
@@ -83,7 +83,7 @@ switch(params.type) {
             subnetIds: params.listSubnetIds,
             subnetSsmParamNames: params.listSubnetSsmParams,
             vpcId: params.idVpc,
-            vpcCidr: params.vpcCidr,
+            vpcCidrs: params.vpcCidrs,
             vpcSsmParamName: params.nameVpcSsmParam,
             vpceServiceId: params.idVpceService,
             mirrorVni: params.idVni,
@@ -95,7 +95,7 @@ switch(params.type) {
             env: env
         });
         new TrafficGenStack(app, 'DemoTrafficGen02', {
-            cidr: "192.168.0.0/16",
+            cidr: "192.168.0.0/17",
             env: env
         });
         break;
@@ -105,7 +105,7 @@ switch(params.type) {
             env: env
         });
         new TrafficGenStack(app, 'DemoTrafficGen02', {
-            cidr: "192.168.0.0/16",
+            cidr: "192.168.0.0/17",
             env: env
         });
         break;

--- a/cdk-lib/core/command-params.ts
+++ b/cdk-lib/core/command-params.ts
@@ -44,7 +44,7 @@ export interface MirrorMgmtParamsRaw extends CommandParamsRaw {
     idVpceService: string;
     listSubnetIds: string[];
     listSubnetSsmParams: string[];
-    vpcCidr: string;
+    vpcCidrs: string[];
 }
 
 /**
@@ -109,5 +109,5 @@ export interface MirrorMgmtParams extends CommandParams {
     idVpceService: string;
     listSubnetIds: string[];
     listSubnetSsmParams: string[];
-    vpcCidr: string;
+    vpcCidrs: string[];
 }

--- a/cdk-lib/core/context-wrangling.ts
+++ b/cdk-lib/core/context-wrangling.ts
@@ -125,7 +125,7 @@ function validateArgs(args: ValidateArgs) : (prms.ClusterMgmtParams | prms.Deplo
                 idVpceService: rawMirrorMgmtParamsObj.idVpceService,
                 listSubnetIds: rawMirrorMgmtParamsObj.listSubnetIds,
                 listSubnetSsmParams: rawMirrorMgmtParamsObj.listSubnetSsmParams,
-                vpcCidr: rawMirrorMgmtParamsObj.vpcCidr,
+                vpcCidrs: rawMirrorMgmtParamsObj.vpcCidrs,
             }
             return mirrorMgmtParams;
         default:

--- a/manage_arkime/aws_interactions/ec2_interactions.py
+++ b/manage_arkime/aws_interactions/ec2_interactions.py
@@ -153,14 +153,14 @@ def delete_eni_mirroring(traffic_session: str, aws_provider: AwsClientProvider) 
 class VpcDetails:
     vpc_id: str
     owner_id: str
-    cidr_block: str
+    cidr_blocks: List[str]
     tenancy: str
 
-    def to_dict(self) -> Dict[str, str]:
+    def to_dict(self) -> Dict[str, any]:
         return {
             'vpc_id': self.vpc_id,
             'owner_id': self.owner_id,
-            'cidr_block': self.cidr_block,
+            'cidr_blocks': self.cidr_blocks,
             'tenancy': self.tenancy,
         }
 
@@ -175,9 +175,11 @@ def get_vpc_details(vpc_id: str, aws_provider: AwsClientProvider) -> VpcDetails:
         raise VpcDoesNotExist(vpc_id=vpc_id)
 
     vpc_details = describe_vpc_response["Vpcs"][0]
+    cidr_blocks = [item["CidrBlock"] for item in vpc_details["CidrBlockAssociationSet"] if item["CidrBlockState"]["State"] in ["associating", "associated"]]
+
     return VpcDetails(
         vpc_id=vpc_details["VpcId"],
         owner_id=vpc_details["OwnerId"],
-        cidr_block=vpc_details["CidrBlock"],
+        cidr_blocks=cidr_blocks,
         tenancy=vpc_details["InstanceTenancy"]
     )

--- a/manage_arkime/commands/add_vpc.py
+++ b/manage_arkime/commands/add_vpc.py
@@ -72,7 +72,7 @@ def cmd_add_vpc(profile: str, region: str, cluster_name: str, vpc_id: str, user_
         constants.get_vpc_mirror_setup_stack_name(cluster_name, vpc_id)
     ]
     add_vpc_context = context.generate_add_vpc_context(cluster_name, vpc_id, subnet_ids, vpce_service_id, event_bus_arn,
-                                                       next_vni,vpc_details.cidr_block)
+                                                       next_vni, vpc_details.cidr_blocks)
 
     cdk_client = CdkClient()
     cdk_client.deploy(stacks_to_deploy, aws_profile=profile, aws_region=region, context=add_vpc_context)

--- a/test_manage_arkime/aws_interactions/test_ec2_interactions.py
+++ b/test_manage_arkime/aws_interactions/test_ec2_interactions.py
@@ -54,20 +54,20 @@ def test_WHEN_get_enis_of_instance_called_THEN_returns_them():
     # Set up our mock
     mock_ec2_client = mock.Mock()
     mock_ec2_client.describe_instances.return_value = {
-        'Reservations': [{
-            'Instances': [{
-                'NetworkInterfaces': [
+        "Reservations": [{
+            "Instances": [{
+                "NetworkInterfaces": [
                     {
-                        'NetworkInterfaceId': 'eni-1',
-                        'SubnetId': 'subnet-1',
-                        'VpcId': 'vpc-1',
-                        'InterfaceType': 'type-1'
+                        "NetworkInterfaceId": "eni-1",
+                        "SubnetId": "subnet-1",
+                        "VpcId": "vpc-1",
+                        "InterfaceType": "type-1"
                     },
                     {
-                        'NetworkInterfaceId': 'eni-2',
-                        'SubnetId': 'subnet-1',
-                        'VpcId': 'vpc-1',
-                        'InterfaceType': 'type-2'
+                        "NetworkInterfaceId": "eni-2",
+                        "SubnetId": "subnet-1",
+                        "VpcId": "vpc-1",
+                        "InterfaceType": "type-2"
                     }
                 ]
             }],
@@ -249,6 +249,26 @@ def test_WHEN_get_vpc_details_called_THEN_returns_them():
                 "OwnerId": "12345678910",
                 "CidrBlock": "10.0.0.0/16",
                 "InstanceTenancy": "dedicated",
+                "CidrBlockAssociationSet": [
+                    {
+                        "CidrBlock": "192.168.0.0/24",
+                        "CidrBlockState": {
+                            "State": "associating"
+                        }
+                    },
+                    {
+                        "CidrBlock": "192.168.128.0/24",
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    },
+                    {
+                        "CidrBlock": "192.168.42.0/24",
+                        "CidrBlockState": {
+                            "State": "disassociated"
+                        }
+                    }
+                ],
             }
         ]
     }
@@ -265,7 +285,7 @@ def test_WHEN_get_vpc_details_called_THEN_returns_them():
     ]
     assert expected_describe_calls == mock_ec2_client.describe_vpcs.call_args_list
 
-    expected_result = ec2i.VpcDetails("vpc-1234", "12345678910", "10.0.0.0/16", "dedicated")
+    expected_result = ec2i.VpcDetails("vpc-1234", "12345678910", ["192.168.0.0/24", "192.168.128.0/24"], "dedicated")
     assert expected_result == result
 
 def test_WHEN_get_vpc_details_called_AND_doesnt_exist_THEN_raises():

--- a/test_manage_arkime/commands/test_add_vpc.py
+++ b/test_manage_arkime/commands/test_add_vpc.py
@@ -50,7 +50,7 @@ def test_WHEN_cmd_add_vpc_called_AND_no_user_vni_THEN_sets_up_mirroring(mock_cdk
 
     subnet_ids = ["subnet-1", "subnet-2"]
     mock_ec2i.get_subnets_of_vpc.return_value = ["subnet-1", "subnet-2"]
-    mock_ec2i.get_vpc_details.return_value = ec2i.VpcDetails("vpc-1", "1234", "196.168.0.0/16", "default")
+    mock_ec2i.get_vpc_details.return_value = ec2i.VpcDetails("vpc-1", "1234", ["192.168.0.0/24", "192.168.128.0/24"], "default")
 
     mock_ssm.get_ssm_param_value.return_value = "" # Doesn't matter what this is besides an exception
     mock_ssm.get_ssm_param_json_value.side_effect = ["service-1", "bus-1", "filter-1"]
@@ -81,7 +81,7 @@ def test_WHEN_cmd_add_vpc_called_AND_no_user_vni_THEN_sets_up_mirroring(mock_cdk
                     "idVpceService": "service-1",
                     "listSubnetIds": subnet_ids,
                     "listSubnetSsmParams": [constants.get_subnet_ssm_param_name("cluster-1", "vpc-1", subnet_id) for subnet_id in subnet_ids],
-                    "vpcCidr": "196.168.0.0/16"
+                    "vpcCidrs": ["192.168.0.0/24", "192.168.128.0/24"]
                 }))
             }
         )
@@ -141,7 +141,7 @@ def test_WHEN_cmd_add_vpc_called_AND_is_available_user_vni_THEN_sets_up_mirrorin
 
     subnet_ids = ["subnet-1", "subnet-2"]
     mock_ec2i.get_subnets_of_vpc.return_value = ["subnet-1", "subnet-2"]
-    mock_ec2i.get_vpc_details.return_value = ec2i.VpcDetails("vpc-1", "1234", "196.168.0.0/16", "default")
+    mock_ec2i.get_vpc_details.return_value = ec2i.VpcDetails("vpc-1", "1234", ["192.168.0.0/24", "192.168.128.0/24"], "default")
 
     mock_ssm.get_ssm_param_value.return_value = "" # Doesn't matter what this is besides an exception
     mock_ssm.get_ssm_param_json_value.side_effect = ["service-1", "bus-1", "filter-1"]
@@ -172,7 +172,7 @@ def test_WHEN_cmd_add_vpc_called_AND_is_available_user_vni_THEN_sets_up_mirrorin
                     "idVpceService": "service-1",
                     "listSubnetIds": subnet_ids,
                     "listSubnetSsmParams": [constants.get_subnet_ssm_param_name("cluster-1", "vpc-1", subnet_id) for subnet_id in subnet_ids],
-                    "vpcCidr": "196.168.0.0/16"
+                    "vpcCidrs": ["192.168.0.0/24", "192.168.128.0/24"]
                 }))
             }
         )

--- a/test_manage_arkime/commands/test_remove_vpc.py
+++ b/test_manage_arkime/commands/test_remove_vpc.py
@@ -53,7 +53,7 @@ def test_WHEN_cmd_remove_vpc_called_THEN_removes_mirroring(mock_cdk_client_cls, 
                     "idVpceService": "service-1",
                     "listSubnetIds": ["subnet-1", "subnet-2"],
                     "listSubnetSsmParams": [constants.get_subnet_ssm_param_name("cluster-1", "vpc-1", subnet_id) for subnet_id in ["subnet-1", "subnet-2"]],
-                    "vpcCidr": "0.0.0.0/0"
+                    "vpcCidrs": ["0.0.0.0/0"]
                 }))
             }
         )


### PR DESCRIPTION
## Description
* Updated Python and CDK code to correctly handle setting up mirroring for VPCs with multiple CIDRs
* There's a limit for how many CIDRs we can support due to Traffic Mirror's limit on the number of rules a given filter can have.  It's possible we could find a workaround if we discover this is a major user pain-point.

## Tasks
* https://github.com/arkime/aws-aio/issues/72

## Testing
* Updated unit tests
* Set up a demo VPC with a single CIDR, ran `add-vpc` against it to set up capture, went into the AWS Console and added a second CIDR to it, then ran `add-vpc` again.  Confirmed that the filter rules were updated appropriately.  Screenshots below.
![Screen Shot 2023-06-26 at 1 34 40 PM](https://github.com/arkime/aws-aio/assets/25470211/fdeff531-4360-45eb-a5ac-90d9bff0e15c)
![Screen Shot 2023-06-26 at 1 32 52 PM](https://github.com/arkime/aws-aio/assets/25470211/623a921f-df82-452f-87c2-0e971d4ae1db)

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
