### PR TITLE
bold usage report changes, fixes #70

### DIFF
--- a/manage_arkime/core/usage_report.py
+++ b/manage_arkime/core/usage_report.py
@@ -13,24 +13,30 @@ class UsageReport:
     prev_config: UserConfig
     next_config: UserConfig
 
+    def _line(self, name: str, oldVal, newVal) -> str:
+        if oldVal == None or oldVal == newVal:
+            return f"    {name}: {newVal}\n"
+        else:
+            return f"    {name}: \033[1m{oldVal} -> {newVal}\033[0m\n"
+
     def get_report(self) -> str:
         report_text = (
             "Arkime Metadata:\n"
-            + f"    Session Retention [days]: {self.prev_config.spiDays} -> {self.next_config.spiDays}\n"
-            + f"    User History Retention [days]: {self.prev_config.historyDays} -> {self.next_config.historyDays}\n"
+            + self._line("Session Retention [days]", self.prev_config.spiDays, self.next_config.spiDays)
+            + self._line("User History Retention [days]", self.prev_config.historyDays, self.next_config.historyDays)
             + "Capture Nodes:\n"
-            + f"    Max Count: {self.prev_plan.captureNodes.maxCount} -> {self.next_plan.captureNodes.maxCount}\n"
-            + f"    Desired Count: {self.prev_plan.captureNodes.desiredCount} -> {self.next_plan.captureNodes.desiredCount}\n"
-            + f"    Min Count: {self.prev_plan.captureNodes.minCount} -> {self.next_plan.captureNodes.minCount}\n"
-            + f"    Type: {self.prev_plan.captureNodes.instanceType} -> {self.next_plan.captureNodes.instanceType}\n"
+            + self._line("Max Count", self.prev_plan.captureNodes.maxCount, self.next_plan.captureNodes.maxCount)
+            + self._line("Desired Count", self.prev_plan.captureNodes.desiredCount, self.next_plan.captureNodes.desiredCount)
+            + self._line("Min Count", self.prev_plan.captureNodes.minCount, self.next_plan.captureNodes.minCount)
+            + self._line("Type", self.prev_plan.captureNodes.instanceType, self.next_plan.captureNodes.instanceType)
             + "OpenSearch Domain:\n"
-            + f"    Master Node Count: {self.prev_plan.osDomain.masterNodes.count} -> {self.next_plan.osDomain.masterNodes.count}\n"
-            + f"    Master Node Type: {self.prev_plan.osDomain.masterNodes.instanceType} -> {self.next_plan.osDomain.masterNodes.instanceType}\n"
-            + f"    Data Node Count: {self.prev_plan.osDomain.dataNodes.count} -> {self.next_plan.osDomain.dataNodes.count}\n"
-            + f"    Data Node Type: {self.prev_plan.osDomain.dataNodes.instanceType} -> {self.next_plan.osDomain.dataNodes.instanceType}\n"
-            + f"    Data Node Volume Size [GB]: {self.prev_plan.osDomain.dataNodes.volumeSize} -> {self.next_plan.osDomain.dataNodes.volumeSize}\n"
+            + self._line("Master Node Count", self.prev_plan.osDomain.masterNodes.count, self.next_plan.osDomain.masterNodes.count)
+            + self._line("Master Node Type", self.prev_plan.osDomain.masterNodes.instanceType, self.next_plan.osDomain.masterNodes.instanceType)
+            + self._line("Data Node Count", self.prev_plan.osDomain.dataNodes.count, self.next_plan.osDomain.dataNodes.count)
+            + self._line("Data Node Type", self.prev_plan.osDomain.dataNodes.instanceType, self.next_plan.osDomain.dataNodes.instanceType)
+            + self._line("Data Node Volume Size [GB]", self.prev_plan.osDomain.dataNodes.volumeSize, self.next_plan.osDomain.dataNodes.volumeSize)
             + "S3:\n"
-            + f"    PCAP Retention [days]: {self.prev_plan.s3.pcapStorageDays} -> {self.next_plan.s3.pcapStorageDays}\n"
+            + self._line("PCAP Retention [days]", self.prev_plan.s3.pcapStorageDays, self.next_plan.s3.pcapStorageDays)
         )
         return report_text
 

--- a/manage_arkime/core/usage_report.py
+++ b/manage_arkime/core/usage_report.py
@@ -2,9 +2,10 @@ import shell_interactions as shell
 from core.capacity_planning import ClusterPlan
 from core.user_config import UserConfig
 
-
 from dataclasses import dataclass
 
+from typing import Union
+UserVal = Union[int, str, float]
 
 @dataclass
 class UsageReport:
@@ -13,8 +14,8 @@ class UsageReport:
     prev_config: UserConfig
     next_config: UserConfig
 
-    def _line(self, name: str, oldVal, newVal) -> str:
-        if oldVal == None or oldVal == newVal:
+    def _line(self, name: str, oldVal: UserVal, newVal: UserVal) -> str:
+        if oldVal is None or oldVal == newVal:
             return f"    {name}: {newVal}\n"
         else:
             return f"    {name}: \033[1m{oldVal} -> {newVal}\033[0m\n"

--- a/test_manage_arkime/core/test_usage_report.py
+++ b/test_manage_arkime/core/test_usage_report.py
@@ -30,21 +30,21 @@ def test_WHEN_UsageReport_get_report_THEN_as_expected():
     # Check the results
     expected_report = (
         "Arkime Metadata:\n"
-        + f"    Session Retention [days]: None -> 30\n"
-        + f"    User History Retention [days]: None -> 365\n"
+        + f"    Session Retention [days]: 30\n"
+        + f"    User History Retention [days]: 365\n"
         + "Capture Nodes:\n"
-        + "    Max Count: None -> 2\n"
-        + "    Desired Count: None -> 1\n"
-        + "    Min Count: None -> 1\n"
-        + f"    Type: None -> {cap.INSTANCE_TYPE_CAPTURE_NODE}\n"
+        + "    Max Count: 2\n"
+        + "    Desired Count: 1\n"
+        + "    Min Count: 1\n"
+        + f"    Type: {cap.INSTANCE_TYPE_CAPTURE_NODE}\n"
         + "OpenSearch Domain:\n"
-        + "    Master Node Count: None -> 3\n"
-        + "    Master Node Type: None -> m6g.large.search\n"
-        + "    Data Node Count: None -> 2\n"
-        + "    Data Node Type: None -> t3.small.search\n"
-        + "    Data Node Volume Size [GB]: None -> 100\n"
+        + "    Master Node Count: 3\n"
+        + "    Master Node Type: m6g.large.search\n"
+        + "    Data Node Count: 2\n"
+        + "    Data Node Type: t3.small.search\n"
+        + "    Data Node Volume Size [GB]: 100\n"
         + "S3:\n"
-        + "    PCAP Retention [days]: None -> 30\n"                       
+        + "    PCAP Retention [days]: 30\n"
     )
 
     assert expected_report == actual_report

--- a/test_manage_arkime/core/test_usage_report.py
+++ b/test_manage_arkime/core/test_usage_report.py
@@ -11,7 +11,7 @@ def test_WHEN_UsageReport_get_report_THEN_as_expected():
         cap.CaptureNodesPlan(None, None, None, None),
         cap.CaptureVpcPlan(None),
         cap.EcsSysResourcePlan(None, None),
-        cap.OSDomainPlan(cap.DataNodesPlan(None, None, None), cap.MasterNodesPlan(None, None)),
+        cap.OSDomainPlan(cap.DataNodesPlan(None, None, None), cap.MasterNodesPlan(None, "m6g.before.search")),
         cap.S3Plan(None, None)
     )
     next_plan = cap.ClusterPlan(
@@ -21,7 +21,7 @@ def test_WHEN_UsageReport_get_report_THEN_as_expected():
         cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
         cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30)
     )
-    prev_config = UserConfig(None, None, None, None, None)
+    prev_config = UserConfig(0.1, 10, None, None, None)
     next_config = UserConfig(0.5, 30, 365, 1, 120)
 
     # Run the test
@@ -30,7 +30,7 @@ def test_WHEN_UsageReport_get_report_THEN_as_expected():
     # Check the results
     expected_report = (
         "Arkime Metadata:\n"
-        + f"    Session Retention [days]: 30\n"
+        + f"    Session Retention [days]: \033[1m10 -> 30\033[0m\n"
         + f"    User History Retention [days]: 365\n"
         + "Capture Nodes:\n"
         + "    Max Count: 2\n"
@@ -39,7 +39,7 @@ def test_WHEN_UsageReport_get_report_THEN_as_expected():
         + f"    Type: {cap.INSTANCE_TYPE_CAPTURE_NODE}\n"
         + "OpenSearch Domain:\n"
         + "    Master Node Count: 3\n"
-        + "    Master Node Type: m6g.large.search\n"
+        + "    Master Node Type: \033[1mm6g.before.search -> m6g.large.search\033[0m\n"
         + "    Data Node Count: 2\n"
         + "    Data Node Type: t3.small.search\n"
         + "    Data Node Volume Size [GB]: 100\n"


### PR DESCRIPTION
We now bold changes in the usage report. When it isn't a change or the old value is None we just print the value.

Example:
<img width="481" alt="image" src="https://github.com/arkime/aws-aio/assets/427321/9bec8c54-5720-4fcb-b820-ae325bc3e012">


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
