### PR TITLE
Checkpoint: `create-cluster` uploads Arkime Config tarballs to s3 w/ version info

### DIFF
--- a/manage_arkime/commands/create_cluster.py
+++ b/manage_arkime/commands/create_cluster.py
@@ -19,6 +19,7 @@ from core.usage_report import UsageReport
 from core.capacity_planning import (get_capture_node_capacity_plan, get_ecs_sys_resource_plan, get_os_domain_plan, ClusterPlan,
                                     CaptureVpcPlan, MINIMUM_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_REPLICAS, DEFAULT_NUM_AZS,
                                     S3Plan, DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS, DEFAULT_HISTORY_DAYS, CaptureNodesPlan, DataNodesPlan, EcsSysResourcePlan, MasterNodesPlan, OSDomainPlan)
+from core.versioning import get_version_info
 from core.user_config import UserConfig
 
 logger = logging.getLogger(__name__)
@@ -174,20 +175,19 @@ def _set_up_arkime_config(cluster_name: str, aws_provider: AwsClientProvider):
     viewer_config_tarball = config_wrangling.get_viewer_config_tarball(cluster_name)
 
     # Generate their hashes, config version, and aws-aio versions
-    # TODO
-    capture_metadata = {"config_version": "1"}
-    viewer_metadata = {"config_version": "1"}
+    capture_version_info = get_version_info(capture_config_tarball)
+    viewer_version_info = get_version_info(capture_config_tarball)
     
     # Upload the tarballs to S3
     logger.info(f"Uploading config tarballs to S3 bucket: {bucket_name}")
     s3.put_file_to_bucket(
-        S3File(capture_config_tarball, metadata=capture_metadata),
+        S3File(capture_config_tarball, metadata=capture_version_info),
         bucket_name,
         "capture/1/config.tgz",
         aws_provider
     )
     s3.put_file_to_bucket(
-        S3File(viewer_config_tarball, metadata=viewer_metadata),
+        S3File(viewer_config_tarball, metadata=viewer_version_info),
         bucket_name,
         "viewer/1/config.tgz",
         aws_provider

--- a/manage_arkime/commands/create_cluster.py
+++ b/manage_arkime/commands/create_cluster.py
@@ -14,6 +14,7 @@ from cdk_interactions.cdk_client import CdkClient
 from aws_interactions.aws_environment import AwsEnvironment
 import cdk_interactions.cdk_context as context
 import core.constants as constants
+from core.local_file import TarGzDirectory, S3File
 from core.usage_report import UsageReport
 from core.capacity_planning import (get_capture_node_capacity_plan, get_ecs_sys_resource_plan, get_os_domain_plan, ClusterPlan,
                                     CaptureVpcPlan, MINIMUM_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_REPLICAS, DEFAULT_NUM_AZS,
@@ -151,7 +152,8 @@ def _confirm_usage(prev_capacity_plan: ClusterPlan, next_capacity_plan: ClusterP
 
 def _set_up_arkime_config(cluster_name: str, aws_provider: AwsClientProvider):
     # Create a copy of the the default Arkime config (if necessary)
-    config_wrangling.set_up_arkime_config_dir(cluster_name, constants.get_cluster_config_parent_dir())
+    cluster_config_parent_dir_path = constants.get_cluster_config_parent_dir()
+    config_wrangling.set_up_arkime_config_dir(cluster_name, cluster_config_parent_dir_path)
 
     # Check if the Arkime config info exists in Param Store to see if we need to do any other work.
     # If it does exists, we can return.
@@ -163,16 +165,33 @@ def _set_up_arkime_config(cluster_name: str, aws_provider: AwsClientProvider):
 
     try:
         s3.ensure_bucket_exists(bucket_name, aws_provider)
-    except s3.CouldntEnsureBucketExists as ex:
+    except s3.CouldntEnsureBucketExists:
         logger.error(f"Couldn't ensure S3 bucket {bucket_name} exists; aborting operation")
         sys.exit(1)
 
-    # Create the Capture and Viewer tarballs
+    # Create the Capture and Viewer config tarballs
+    capture_config_tarball = config_wrangling.get_capture_config_tarball(cluster_name)
+    viewer_config_tarball = config_wrangling.get_viewer_config_tarball(cluster_name)
+
     # Generate their hashes, config version, and aws-aio versions
     # TODO
+    capture_metadata = {"config_version": "1"}
+    viewer_metadata = {"config_version": "1"}
     
-    # Upload the tarball to S3
-    # TODO
+    # Upload the tarballs to S3
+    logger.info(f"Uploading config tarballs to S3 bucket: {bucket_name}")
+    s3.put_file_to_bucket(
+        S3File(capture_config_tarball, metadata=capture_metadata),
+        bucket_name,
+        "capture/1/config.tgz",
+        aws_provider
+    )
+    s3.put_file_to_bucket(
+        S3File(viewer_config_tarball, metadata=viewer_metadata),
+        bucket_name,
+        "viewer/1/config.tgz",
+        aws_provider
+    )
 
     # Update Parameter Store
     # TODO

--- a/manage_arkime/core/constants.py
+++ b/manage_arkime/core/constants.py
@@ -144,5 +144,5 @@ def get_cluster_config_parent_dir() -> str:
     cluster
     """
     this_files_path = os.path.abspath(__file__)
-    two_levels_up = os.path.dirname(os.path.dirname(this_files_path)) # should be repo root
-    return two_levels_up
+    three_levels_up = os.path.dirname(os.path.dirname(os.path.dirname(this_files_path))) # should be repo root
+    return three_levels_up

--- a/manage_arkime/core/local_file.py
+++ b/manage_arkime/core/local_file.py
@@ -1,0 +1,75 @@
+from abc import ABC, abstractmethod
+import os
+import tarfile
+from typing import Dict, List
+
+
+class FileNotGenerated(Exception):
+    def __init__(self, file_path: str):
+        self.file_path = file_path
+        super().__init__(f"The file {file_path} does not yet exist.  Have you generated it yet?")
+
+class LocalFile(ABC):
+    """
+    Encapsulates a file on the local disk and a way to get a path to it
+    """
+    @property
+    @abstractmethod
+    def local_path(self) -> str:
+        pass
+
+class TarGzDirectory(LocalFile):
+    """
+    Encapsulates the ability to take a directory on disk, turn it into a gzip-compressed tarball, and provide a
+    reference to the final file afterwards.
+    """
+
+    def __init__(self, source_dir_path: str, tarball_path: str):
+        self._source_dir_path = source_dir_path
+        self._tarball_path = tarball_path
+        self._exists = False
+
+    def __eq__(self, other):
+        return (self._source_dir_path == other._source_dir_path 
+                and self._tarball_path == other._tarball_path
+                and self._exists == other._exists)
+
+    def generate(self):
+        """
+        Turns the source_dir_path into a tarball at tarball_path.  Overwrites tarball_path if it already exists.
+        """
+        with tarfile.open(self._tarball_path, "w:gz") as tar:
+            tar.add(self._source_dir_path, arcname=os.path.basename(self._source_dir_path))
+
+        self._exists = True
+
+    @property
+    def local_path(self) -> str:
+        if not self._exists:
+            raise FileNotGenerated(self._tarball_path)
+
+        return self._tarball_path
+    
+class S3File(LocalFile):
+    """
+    Provides an abstraction for a file on disk that either will be sent to S3 or was pulled from S3.  Provides a
+    reference to the raw file while also providing S3 metadata.
+    """
+    def __init__(self, file: LocalFile, metadata: Dict[str, str] = None):
+        self._file = file
+        self._metadata = metadata if metadata else dict()
+
+    def __eq__(self, other):
+        return self._file == other._file and self._metadata == other._metadata
+
+    @property
+    def local_path(self) -> str:
+        return self._file.local_path
+
+    @property
+    def metadata(self) -> Dict[str, str]:
+        return self._metadata
+
+    
+
+    

--- a/manage_arkime/core/versioning.py
+++ b/manage_arkime/core/versioning.py
@@ -1,0 +1,47 @@
+import hashlib
+from typing import Dict
+
+from core.local_file import LocalFile
+from core.shell_interactions import call_shell_command
+
+"""
+Manually updated/managed version number.  Increment if/when a backwards incompatible change is made.
+"""
+AWS_AIO_VERSION=1
+
+class CouldntReadSourceVersion(Exception):
+    def __init__(self):
+        super().__init__("Could not read the source version for unknown reason; check the logs")
+
+def get_md5_of_file(file: LocalFile) -> str:
+    hash_md5 = hashlib.md5()
+
+    # Read the file as bytes in 4096-byte chunks and write to a buffer until we hit end of file
+    with open(file.local_path, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_md5.update(chunk)
+    
+    # Turn the buffer into the md5
+    return hash_md5.hexdigest()
+
+def get_source_version() -> str:
+    """
+    Gets the version string for the AWS AIO source code.  This is used to correlate behavior (bugs or otherwise) to a
+    specific change version.
+    """
+    exit_code, stdout = call_shell_command("git describe --tags")
+
+    if exit_code != 0:
+        raise CouldntReadSourceVersion()
+    
+    return stdout[0]
+
+def get_version_info(config_file: LocalFile, config_version: str = None) -> Dict[str, str]:
+    return {
+        "aws_aio_version": str(AWS_AIO_VERSION),
+        "config_version": config_version if config_version else "1",
+        "md5_version": get_md5_of_file(config_file),
+        "source_version": get_source_version(),
+    }
+
+

--- a/manage_arkime/setup.py
+++ b/manage_arkime/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="manage_arkime",
-    version="0.1",
+    version="0.1.1",
     description=("Tooling and configuration to install/manage Arkime Clusters in an AWS account"),
     author="Chris Helma",
     package_dir={"": "."},

--- a/test_manage_arkime/arkime_interactions/test_config_wrangling.py
+++ b/test_manage_arkime/arkime_interactions/test_config_wrangling.py
@@ -110,3 +110,53 @@ def test_WHEN_set_up_arkime_config_dir_called_THEN_as_expected(mock_create, mock
         mock.call(cluster_name, parent_dir)
     ]
     assert expected_copy_calls == mock_copy.call_args_list
+
+@mock.patch("arkime_interactions.config_wrangling.get_cluster_config_parent_dir")
+@mock.patch("arkime_interactions.config_wrangling.TarGzDirectory")
+def test_WHEN_get_capture_config_tarball_called_THEN_as_expected(mock_tgz_class, mock_get_parent_dir):
+    # Set up our mock
+    cluster_name = "MyCluster01"
+
+    mock_get_parent_dir.return_value = "/parent/path"
+
+    mock_tgz_file = mock.Mock()
+    mock_tgz_class.return_value = mock_tgz_file
+
+    # Run the test
+    actual_tgz = config.get_capture_config_tarball(cluster_name)
+
+    # Check the results
+    assert actual_tgz.generate.called
+
+    expected_tgz_init_calls = [
+        mock.call(
+            "/parent/path/config-MyCluster01/capture",
+            "/parent/path/config-MyCluster01/capture.tgz"
+        )
+    ]
+    assert expected_tgz_init_calls == mock_tgz_class.call_args_list
+
+@mock.patch("arkime_interactions.config_wrangling.get_cluster_config_parent_dir")
+@mock.patch("arkime_interactions.config_wrangling.TarGzDirectory")
+def test_WHEN_get_viewer_config_tarball_called_THEN_as_expected(mock_tgz_class, mock_get_parent_dir):
+    # Set up our mock
+    cluster_name = "MyCluster01"
+
+    mock_get_parent_dir.return_value = "/parent/path"
+
+    mock_tgz_file = mock.Mock()
+    mock_tgz_class.return_value = mock_tgz_file
+
+    # Run the test
+    actual_tgz = config.get_viewer_config_tarball(cluster_name)
+
+    # Check the results
+    assert actual_tgz.generate.called
+
+    expected_tgz_init_calls = [
+        mock.call(
+            "/parent/path/config-MyCluster01/viewer",
+            "/parent/path/config-MyCluster01/viewer.tgz"
+        )
+    ]
+    assert expected_tgz_init_calls == mock_tgz_class.call_args_list

--- a/test_manage_arkime/core/test_local_file.py
+++ b/test_manage_arkime/core/test_local_file.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+import unittest.mock as mock
+
+import core.local_file as lf
+
+
+@mock.patch("core.local_file.tarfile")
+def test_WHEN_TarGzDirectory_THEN_lifecycle_as_expected(mock_tarfile):
+    # Set up our tests
+    source = "/my/source/dir"
+    tarball = "/test/file.tgz"
+    tgz_dir = lf.TarGzDirectory(source, tarball)
+
+    # TEST: Raises when you try to get the path before generating
+    with pytest.raises(lf.FileNotGenerated):
+        tgz_dir.local_path
+
+    # TEST: When generate called, then file is created
+    tar_obj = mock.MagicMock()
+    mock_tarfile.open.return_value.__enter__.return_value = tar_obj
+
+    tgz_dir.generate()
+
+    assert [mock.call(tarball, "w:gz")] == mock_tarfile.open.call_args_list
+    assert [mock.call(source, arcname=os.path.basename(source))] == tar_obj.add.call_args_list
+
+    # TEST: After generate is called, you can get the path
+    actual_value = tgz_dir.local_path
+    assert tarball == actual_value
+
+@mock.patch("core.local_file.tarfile", mock.MagicMock())
+def test_WHEN_S3File_THEN_lifecycle_as_expected():
+    # Set up our tests
+    source = "/my/source/dir"
+    tarball = "/test/file.tgz"
+    tgz_dir = lf.TarGzDirectory(source, tarball)
+
+    metadata = {"aws_aio_version": "1.1"}
+
+    # TEST: Members as expected (1)
+    s3_file_1 = lf.S3File(tgz_dir)
+
+    with pytest.raises(lf.FileNotGenerated):
+        s3_file_1.local_path
+
+    # TEST: Members as expected (2)
+    tgz_dir.generate()
+    s3_file_2 = lf.S3File(tgz_dir, metadata)
+
+    assert tarball == s3_file_2.local_path
+    assert metadata == s3_file_2.metadata

--- a/test_manage_arkime/core/test_versioning.py
+++ b/test_manage_arkime/core/test_versioning.py
@@ -1,0 +1,71 @@
+import py
+import pytest
+import unittest.mock as mock
+
+import core.constants as constants
+import core.local_file as lf
+import core.versioning as ver
+
+
+@pytest.fixture
+def local_test_file_path(tmpdir):
+    temp_file_path = tmpdir.join("test.txt")
+    with open(temp_file_path, "w") as file_handle:
+        file_handle.write("Aure entuluva!" * 1000) # larger than 4096 bytes
+    return str(temp_file_path)
+
+def test_WHEN_get_md5_of_file_called_THEN_as_expected(local_test_file_path):
+    # Set up our mock
+    mock_file = mock.Mock()
+    mock_file.local_path = local_test_file_path
+
+    # Run our test
+    actual_md5 = ver.get_md5_of_file(mock_file)
+
+    # Check the results
+    assert "ffc2c982c7363a318de4b18ee1357402" == actual_md5
+
+@mock.patch("core.versioning.call_shell_command")
+def test_WHEN_get_source_version_called_THEN_as_expected(mock_shell):
+    # TEST: Happy Path
+    mock_shell.return_value = [0, ["v0.1.1-1-gd8e1200"]]
+    actual_version = ver.get_source_version()
+    assert "v0.1.1-1-gd8e1200" == actual_version
+
+    expected_shell_call = [mock.call("git describe --tags")]
+    assert expected_shell_call == mock_shell.call_args_list
+
+    # TEST: Problem with command then raises
+    mock_shell.return_value = [1, ["ERROR"]]
+    with pytest.raises(ver.CouldntReadSourceVersion):
+        ver.get_source_version()
+
+@mock.patch("core.versioning.get_source_version")
+@mock.patch("core.versioning.get_md5_of_file")
+def test_WHEN_get_version_info_called_THEN_as_expected(mock_get_md5, mock_get_source_v):
+    # Set up our mock
+    mock_file = mock.Mock()
+    mock_get_md5.return_value = "86d3f3a95c324c9479bd8986968f4327"
+    mock_get_source_v.return_value = "v0.1.1-1-gd8e1200"
+
+    # TEST: Config version default is 1
+    actual_versions = ver.get_version_info(mock_file)
+
+    expected_versions = {
+        "aws_aio_version": "1",
+        "config_version": "1",
+        "md5_version": "86d3f3a95c324c9479bd8986968f4327",
+        "source_version": "v0.1.1-1-gd8e1200",
+    }
+    assert expected_versions == actual_versions
+
+    # TEST: Config version is non-default
+    actual_versions = ver.get_version_info(mock_file, config_version="3")
+
+    expected_versions = {
+        "aws_aio_version": "1",
+        "config_version": "3",
+        "md5_version": "86d3f3a95c324c9479bd8986968f4327",
+        "source_version": "v0.1.1-1-gd8e1200",
+    }
+    assert expected_versions == actual_versions


### PR DESCRIPTION
## Description
* Another checkpoint commit.  Still need to update `destroy-cluster` and add logic to track config versions in Parameter Store.
* New behavior includes turning the Arkime config directories for capture and viewer into tarballs and uploading them to S3, with version info in the object metadata

## Tasks
* https://github.com/arkime/aws-aio/issues/83

## Testing
* Added unit tests
* Ran the command against my account
```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py create-cluster --name MyCluster3 --preconfirm-usage
2023-07-18 13:53:13 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-07-18 13:53:13 - Using AWS Credential Profile: default
2023-07-18 13:53:13 - Using AWS Region: default from AWS Config settings
2023-07-18 13:53:15 - Usage report:
Arkime Metadata:
    Session Retention [days]: 30
    User History Retention [days]: 120
Capture Nodes:
    Max Count: 2
    Desired Count: 1
    Min Count: 1
    Type: m5.xlarge
OpenSearch Domain:
    Master Node Count: 3
    Master Node Type: m6g.large.search
    Data Node Count: 2
    Data Node Type: r6g.large.search
    Data Node Volume Size [GB]: 1024
S3:
    PCAP Retention [days]: 30

2023-07-18 13:53:15 - Ensuring Arkime Config dir exists for cluster: MyCluster3
2023-07-18 13:53:15 - Arkime Config dir exists at: /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster3
2023-07-18 13:53:15 - Copying default Arkime Config to dir: /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster3
2023-07-18 13:53:16 - Determining the status of S3 bucket: arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster3
2023-07-18 13:53:16 - S3 Bucket arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster3 does not exist; creating it to hold Arkime Configuration
2023-07-18 13:53:17 - Turning Capture configuration at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster3/capture into tarball at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster3/capture.tgz
2023-07-18 13:53:17 - Turning Viewer configuration at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster3/viewer into tarball at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster3/viewer.tgz
2023-07-18 13:53:18 - Uploading config tarballs to S3 bucket: arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster3
2023-07-18 13:53:21 - Executing command: deploy MyCluster3-CaptureBucket MyCluster3-CaptureNodes MyCluster3-CaptureVPC MyCluster3-OSDomain MyCluster3-ViewerNodes
2023-07-18 13:53:21 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-07-18 13:56:03 - Deployment succeeded
```
![Screen Shot 2023-07-18 at 1 55 56 PM](https://github.com/arkime/aws-aio/assets/25470211/e494287e-1565-4163-b164-9f57891f196b)

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
