### PR TITLE
Checkpoint: Arkime Config details uploaded to Parameter Store

### DIFF
--- a/manage_arkime/arkime_interactions/config_wrangling.py
+++ b/manage_arkime/arkime_interactions/config_wrangling.py
@@ -1,12 +1,57 @@
+from dataclasses import dataclass
 import logging
 import os
 import shutil
+from typing import Dict, Type, TypeVar
 
-from core.local_file import LocalFile, TarGzDirectory
 from core.constants import get_cluster_config_parent_dir, is_valid_cluster_name, InvalidClusterName
-
+from core.local_file import LocalFile, TarGzDirectory
+from core.versioning import VersionInfo
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class S3Details:
+    bucket: str
+    key: str
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, S3Details):
+            return False
+
+        return (self.bucket == other.bucket) and (self.key == other.key)
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "bucket": self.bucket,
+            "key": self.key
+        }
+
+T_ConfigDetails = TypeVar('T_ConfigDetails', bound='ConfigDetails')
+
+@dataclass
+class ConfigDetails:
+    s3: S3Details
+    version: VersionInfo
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ConfigDetails):
+            return False
+
+        return (self.s3 == other.s3
+                and self.version == other.version)
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "s3": self.s3.to_dict(),
+            "version": self.version.to_dict()
+        }
+    
+    @classmethod
+    def from_dict(cls: Type[T_ConfigDetails], input: Dict[str, any]) -> T_ConfigDetails:
+        version = VersionInfo(**input["version"])
+        return cls(version)
 
 class ConfigDirNotEmpty(Exception):
     def __init__(self, cluster_dir_path: str):

--- a/manage_arkime/arkime_interactions/config_wrangling.py
+++ b/manage_arkime/arkime_interactions/config_wrangling.py
@@ -50,8 +50,9 @@ class ConfigDetails:
     
     @classmethod
     def from_dict(cls: Type[T_ConfigDetails], input: Dict[str, any]) -> T_ConfigDetails:
+        s3 = S3Details(**input["s3"])
         version = VersionInfo(**input["version"])
-        return cls(version)
+        return cls(s3, version)
 
 class ConfigDirNotEmpty(Exception):
     def __init__(self, cluster_dir_path: str):

--- a/manage_arkime/commands/create_cluster.py
+++ b/manage_arkime/commands/create_cluster.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import sys
+from typing import Callable
 
 import arkime_interactions.arkime_files as arkime_files
 import arkime_interactions.config_wrangling as config_wrangling
@@ -14,7 +15,7 @@ from cdk_interactions.cdk_client import CdkClient
 from aws_interactions.aws_environment import AwsEnvironment
 import cdk_interactions.cdk_context as context
 import core.constants as constants
-from core.local_file import TarGzDirectory, S3File
+from core.local_file import LocalFile, TarGzDirectory, S3File
 from core.usage_report import UsageReport
 from core.capacity_planning import (get_capture_node_capacity_plan, get_ecs_sys_resource_plan, get_os_domain_plan, ClusterPlan,
                                     CaptureVpcPlan, MINIMUM_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_REPLICAS, DEFAULT_NUM_AZS,
@@ -151,14 +152,53 @@ def _confirm_usage(prev_capacity_plan: ClusterPlan, next_capacity_plan: ClusterP
         return True
     return report.get_confirmation()
 
+def _upload_arkime_config_if_necessary(cluster_name: str, bucket_name: str, s3_key: str, ssm_param: str,
+                                       tarball_provider: Callable[[str], LocalFile], aws_provider: AwsClientProvider):
+    """
+    The argument list is a bit ugly, but this allows us to avoid having too much duplicated logic.  Will be looking
+    for a better way to handle the two very similar but annoyingly different logics for the capture/viewer config.
+    """
+
+    # Check if the Arkime config info exists in Param Store to see if we need to do any other work.
+    # If it does exists, we can return.
+    try:
+        ssm_ops.get_ssm_param_value(ssm_param, aws_provider)
+        logger.info("Config has been uploaded previously; skipping")
+        return
+    except ssm_ops.ParamDoesNotExist:
+        pass # We need to actually do work
+
+    # Create the Capture and Viewer config tarballs
+    tarball = tarball_provider(cluster_name)
+
+    # Generate their metadata
+    next_metadata = config_wrangling.ConfigDetails(
+        s3=config_wrangling.S3Details(bucket_name, s3_key),
+        version=get_version_info(tarball)
+    )
+    
+    # Upload the tarballs to S3
+    logger.info(f"Uploading config tarball to S3 bucket: {bucket_name}")
+    s3.put_file_to_bucket(
+        S3File(tarball, metadata=next_metadata.version.to_dict()),
+        bucket_name,
+        s3_key,
+        aws_provider
+    )
+
+    # Update Parameter Store
+    ssm_ops.put_ssm_param(
+        ssm_param,
+        json.dumps(next_metadata.to_dict()),
+        aws_provider,
+        description="The currently deployed configuration details",
+        overwrite=True
+    )
+
 def _set_up_arkime_config(cluster_name: str, aws_provider: AwsClientProvider):
     # Create a copy of the the default Arkime config (if necessary)
     cluster_config_parent_dir_path = constants.get_cluster_config_parent_dir()
     config_wrangling.set_up_arkime_config_dir(cluster_name, cluster_config_parent_dir_path)
-
-    # Check if the Arkime config info exists in Param Store to see if we need to do any other work.
-    # If it does exists, we can return.
-    # TODO
 
     # Check whether the S3 bucket exists and whether we have access; error and abort if we don't have access
     aws_env = aws_provider.get_aws_env()
@@ -172,49 +212,26 @@ def _set_up_arkime_config(cluster_name: str, aws_provider: AwsClientProvider):
         logger.error(f"Couldn't ensure S3 bucket {bucket_name} exists; aborting operation")
         sys.exit(1)
 
-    # Create the Capture and Viewer config tarballs
-    capture_config_tarball = config_wrangling.get_capture_config_tarball(cluster_name)
-    viewer_config_tarball = config_wrangling.get_viewer_config_tarball(cluster_name)
-
-    # Generate their metadata
-    capture_metadata = config_wrangling.ConfigDetails(
-        s3=config_wrangling.S3Details(bucket_name, capture_s3_key),
-        version=get_version_info(capture_config_tarball)
-    )
-    viewer_metadata = config_wrangling.ConfigDetails(
-        s3=config_wrangling.S3Details(bucket_name, viewer_s3_key),
-        version=get_version_info(viewer_config_tarball)
-    )
-    
-    # Upload the tarballs to S3
-    logger.info(f"Uploading config tarballs to S3 bucket: {bucket_name}")
-    s3.put_file_to_bucket(
-        S3File(capture_config_tarball, metadata=capture_metadata.version.to_dict()),
+    # Upload the Capture Config if we need to
+    logger.info("Uploading Arkime config for Capture Nodes...")
+    _upload_arkime_config_if_necessary(
+        cluster_name,
         bucket_name,
         capture_s3_key,
-        aws_provider
-    )
-    s3.put_file_to_bucket(
-        S3File(viewer_config_tarball, metadata=viewer_metadata.version.to_dict()),
-        bucket_name,
-        viewer_s3_key,
+        constants.get_capture_config_details_ssm_param_name(cluster_name),
+        config_wrangling.get_capture_config_tarball,
         aws_provider
     )
 
-    # Update Parameter Store
-    ssm_ops.put_ssm_param(
-        constants.get_capture_config_details_ssm_param_name(cluster_name),
-        json.dumps(capture_metadata.to_dict()),
-        aws_provider,
-        description="The Capture Nodes' currently deployed configuration details",
-        overwrite=True
-    )
-    ssm_ops.put_ssm_param(
+    # Upload the Viewer Config if we need to
+    logger.info("Uploading Arkime config for Viewer Nodes...")
+    _upload_arkime_config_if_necessary(
+        cluster_name,
+        bucket_name,
+        viewer_s3_key,
         constants.get_viewer_config_details_ssm_param_name(cluster_name),
-        json.dumps(viewer_metadata.to_dict()),
-        aws_provider,
-        description="The Viewer Nodes' currently deployed configuration details",
-        overwrite=True
+        config_wrangling.get_viewer_config_tarball,
+        aws_provider
     )
 
 def _write_arkime_config_to_datastore(cluster_name: str, next_capacity_plan: ClusterPlan,

--- a/manage_arkime/core/constants.py
+++ b/manage_arkime/core/constants.py
@@ -50,8 +50,14 @@ def get_capture_bucket_stack_name(cluster_name: str) -> str:
 def get_capture_bucket_ssm_param_name(cluster_name: str) -> str:
     return f"{SSM_CLUSTERS_PREFIX}/{cluster_name}/capture-bucket-name"
 
+def get_capture_config_details_ssm_param_name(cluster_name: str) -> str:
+    return f"{SSM_CLUSTERS_PREFIX}/{cluster_name}/capture-config-details"
+
 def get_capture_config_ini_ssm_param_name(cluster_name: str) -> str:
     return f"{SSM_CLUSTERS_PREFIX}/{cluster_name}/capture-ini"
+
+def get_capture_config_s3_key(config_version: str) -> str:
+    return f"capture/{config_version}/config.tgz"
 
 def get_capture_file_ssm_param_name(cluster_name: str, system_path: str) -> str:
     return f"{SSM_CLUSTERS_PREFIX}/{cluster_name}/capture-files{system_path}"
@@ -83,8 +89,14 @@ def get_subnet_ssm_param_name(cluster_name: str, vpc_id: str, subnet_id: str) ->
 def get_viewer_cert_ssm_param_name(cluster_name: str) -> str:
     return f"/arkime/clusters/{cluster_name}/viewer-cert"
 
+def get_viewer_config_details_ssm_param_name(cluster_name: str) -> str:
+    return f"{SSM_CLUSTERS_PREFIX}/{cluster_name}/viewer-config-details"
+
 def get_viewer_config_ini_ssm_param_name(cluster_name: str) -> str:
     return f"{SSM_CLUSTERS_PREFIX}/{cluster_name}/viewer-ini"
+
+def get_viewer_config_s3_key(config_version: str) -> str:
+    return f"viewer/{config_version}/config.tgz"
 
 def get_viewer_dns_ssm_param_name(cluster_name: str) -> str:
     return f"/arkime/clusters/{cluster_name}/viewer-dns"

--- a/manage_arkime/core/versioning.py
+++ b/manage_arkime/core/versioning.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+from datetime import datetime, timezone
 import hashlib
 from typing import Dict
 
@@ -36,12 +38,40 @@ def get_source_version() -> str:
     
     return stdout[0]
 
-def get_version_info(config_file: LocalFile, config_version: str = None) -> Dict[str, str]:
-    return {
-        "aws_aio_version": str(AWS_AIO_VERSION),
-        "config_version": config_version if config_version else "1",
-        "md5_version": get_md5_of_file(config_file),
-        "source_version": get_source_version(),
-    }
+@dataclass
+class VersionInfo:
+    aws_aio_version: str
+    config_version: str
+    md5_version: str
+    source_version: str
+    time_utc: str
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, VersionInfo):
+            return False
+
+        return (self.aws_aio_version == other.aws_aio_version
+                    and self.config_version == other.config_version
+                    and self.md5_version == other.md5_version
+                    and self.source_version == other.source_version
+                    and self.time_utc == other.time_utc)
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "aws_aio_version": self.aws_aio_version,
+            "config_version": self.config_version,
+            "md5_version": self.md5_version,
+            "source_version": self.source_version,
+            "time_utc": self.time_utc
+        }
+
+def get_version_info(config_file: LocalFile, config_version: str = None) -> VersionInfo:
+    return VersionInfo(
+        str(AWS_AIO_VERSION),
+        config_version if config_version else "1",
+        get_md5_of_file(config_file),
+        get_source_version(),
+        datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+    )
 
 

--- a/test_manage_arkime/commands/test_create_cluster.py
+++ b/test_manage_arkime/commands/test_create_cluster.py
@@ -609,6 +609,7 @@ def test_WHEN_configure_ism_called_THEN_as_expected(mock_events, mock_ssm):
     ]
     assert expected_put_events_calls == mock_events.put_events.call_args_list
 
+@mock.patch("commands.create_cluster.ssm_ops.get_ssm_param_value")
 @mock.patch("commands.create_cluster.ssm_ops.put_ssm_param")
 @mock.patch("commands.create_cluster.get_version_info")
 @mock.patch("commands.create_cluster.config_wrangling.get_viewer_config_tarball")
@@ -618,7 +619,7 @@ def test_WHEN_configure_ism_called_THEN_as_expected(mock_events, mock_ssm):
 @mock.patch("commands.create_cluster.config_wrangling.set_up_arkime_config_dir")
 def test_WHEN_set_up_arkime_config_called_AND_happy_path_THEN_as_expected(mock_set_up_config_dir, mock_ensure_bucket, mock_put_file,
                                                                           mock_get_capture_tarball, mock_get_viewer_tarball,
-                                                                          mock_get_version, mock_put_ssm_param):
+                                                                          mock_get_version, mock_put_ssm_param, mock_get_ssm_param):
     # Set up our mock
     test_env = AwsEnvironment("XXXXXXXXXXX", "my-region-1", "profile")
     bucket_name = constants.get_config_bucket_name(test_env.aws_account, test_env.aws_region, "cluster-name")
@@ -635,7 +636,6 @@ def test_WHEN_set_up_arkime_config_called_AND_happy_path_THEN_as_expected(mock_s
     test_viewer_tarball = local_file.TarGzDirectory("/viewer", "/viewer.tgz")
     test_viewer_tarball._exists = True
     mock_get_viewer_tarball.return_value = test_viewer_tarball
-
     
     capture_metadata = config_wrangling.ConfigDetails(
         s3=config_wrangling.S3Details(bucket_name, capture_s3_key),
@@ -649,6 +649,8 @@ def test_WHEN_set_up_arkime_config_called_AND_happy_path_THEN_as_expected(mock_s
         capture_metadata.version,
         viewer_metadata.version,
     ]
+
+    mock_get_ssm_param.side_effect = ssm_ops.ParamDoesNotExist("param")
 
     # Run our test
     _set_up_arkime_config("cluster-name", mock_provider)
@@ -698,6 +700,68 @@ def test_WHEN_set_up_arkime_config_called_AND_happy_path_THEN_as_expected(mock_s
     ]
     assert expected_put_ssm_param_calls == mock_put_ssm_param.call_args_list
 
+@mock.patch("commands.create_cluster.ssm_ops.get_ssm_param_value")
+@mock.patch("commands.create_cluster.ssm_ops.put_ssm_param")
+@mock.patch("commands.create_cluster.get_version_info")
+@mock.patch("commands.create_cluster.config_wrangling.get_viewer_config_tarball")
+@mock.patch("commands.create_cluster.config_wrangling.get_capture_config_tarball")
+@mock.patch("commands.create_cluster.s3.put_file_to_bucket")
+@mock.patch("commands.create_cluster.s3.ensure_bucket_exists")
+@mock.patch("commands.create_cluster.config_wrangling.set_up_arkime_config_dir")
+def test_WHEN_set_up_arkime_config_called_AND_config_exists_THEN_as_expected(mock_set_up_config_dir, mock_ensure_bucket, mock_put_file,
+                                                                          mock_get_capture_tarball, mock_get_viewer_tarball,
+                                                                          mock_get_version, mock_put_ssm_param, mock_get_ssm_param):
+    # Set up our mock
+    test_env = AwsEnvironment("XXXXXXXXXXX", "my-region-1", "profile")
+    bucket_name = constants.get_config_bucket_name(test_env.aws_account, test_env.aws_region, "cluster-name")
+    capture_s3_key = constants.get_capture_config_s3_key("1")
+    viewer_s3_key = constants.get_viewer_config_s3_key("1")
+
+    mock_provider = mock.Mock()
+    mock_provider.get_aws_env.return_value = test_env
+
+    test_capture_tarball = local_file.TarGzDirectory("/capture", "/capture.tgz")
+    test_capture_tarball._exists = True
+    mock_get_capture_tarball.return_value = test_capture_tarball
+
+    test_viewer_tarball = local_file.TarGzDirectory("/viewer", "/viewer.tgz")
+    test_viewer_tarball._exists = True
+    mock_get_viewer_tarball.return_value = test_viewer_tarball
+    
+    capture_metadata = config_wrangling.ConfigDetails(
+        s3=config_wrangling.S3Details(bucket_name, capture_s3_key),
+        version=VersionInfo("1", "1", "abcd1234", "v1-1-12312", "2023-01-01 01:01:01")
+    )
+    viewer_metadata = config_wrangling.ConfigDetails(
+        s3=config_wrangling.S3Details(bucket_name, viewer_s3_key),
+        version=VersionInfo("2", "1", "2345bcde", "v1-1-12312", "2023-01-01 01:01:01")
+    )
+    mock_get_version.side_effect = [
+        capture_metadata.version,
+        viewer_metadata.version,
+    ]
+
+    mock_get_ssm_param.side_effect = ["blah", "bleh"] # Both configs exist
+
+    # Run our test
+    _set_up_arkime_config("cluster-name", mock_provider)
+
+    # Check our results
+    expected_set_up_config_dir_calls = [
+        mock.call("cluster-name", constants.get_cluster_config_parent_dir())
+    ]
+    assert expected_set_up_config_dir_calls == mock_set_up_config_dir.call_args_list
+
+    expected_mock_ensure_bucket_calls = [
+        mock.call(bucket_name, mock_provider)
+    ]
+    assert expected_mock_ensure_bucket_calls == mock_ensure_bucket.call_args_list
+
+    expected_put_file_calls = []
+    assert expected_put_file_calls == mock_put_file.call_args_list
+
+    expected_put_ssm_param_calls = []
+    assert expected_put_ssm_param_calls == mock_put_ssm_param.call_args_list
 
 class SysExitCalled(Exception):
     pass

--- a/test_manage_arkime/commands/test_create_cluster.py
+++ b/test_manage_arkime/commands/test_create_cluster.py
@@ -5,6 +5,7 @@ import unittest.mock as mock
 
 import arkime_interactions.arkime_files as arkime_files
 import arkime_interactions.generate_config as arkime_conf
+import arkime_interactions.config_wrangling as config_wrangling
 from aws_interactions.aws_environment import AwsEnvironment
 from aws_interactions.events_interactions import ConfigureIsmEvent
 import aws_interactions.s3_interactions as s3
@@ -19,6 +20,7 @@ from core.capacity_planning import (CaptureNodesPlan, EcsSysResourcePlan, MINIMU
                                     DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS, DEFAULT_HISTORY_DAYS)
 import core.local_file as local_file
 from core.user_config import UserConfig
+from core.versioning import VersionInfo
 
 @mock.patch("commands.create_cluster.AwsClientProvider")
 @mock.patch("commands.create_cluster._set_up_arkime_config")
@@ -607,6 +609,7 @@ def test_WHEN_configure_ism_called_THEN_as_expected(mock_events, mock_ssm):
     ]
     assert expected_put_events_calls == mock_events.put_events.call_args_list
 
+@mock.patch("commands.create_cluster.ssm_ops.put_ssm_param")
 @mock.patch("commands.create_cluster.get_version_info")
 @mock.patch("commands.create_cluster.config_wrangling.get_viewer_config_tarball")
 @mock.patch("commands.create_cluster.config_wrangling.get_capture_config_tarball")
@@ -615,10 +618,12 @@ def test_WHEN_configure_ism_called_THEN_as_expected(mock_events, mock_ssm):
 @mock.patch("commands.create_cluster.config_wrangling.set_up_arkime_config_dir")
 def test_WHEN_set_up_arkime_config_called_AND_happy_path_THEN_as_expected(mock_set_up_config_dir, mock_ensure_bucket, mock_put_file,
                                                                           mock_get_capture_tarball, mock_get_viewer_tarball,
-                                                                          mock_get_version):
+                                                                          mock_get_version, mock_put_ssm_param):
     # Set up our mock
     test_env = AwsEnvironment("XXXXXXXXXXX", "my-region-1", "profile")
     bucket_name = constants.get_config_bucket_name(test_env.aws_account, test_env.aws_region, "cluster-name")
+    capture_s3_key = constants.get_capture_config_s3_key("1")
+    viewer_s3_key = constants.get_viewer_config_s3_key("1")
 
     mock_provider = mock.Mock()
     mock_provider.get_aws_env.return_value = test_env
@@ -631,9 +636,18 @@ def test_WHEN_set_up_arkime_config_called_AND_happy_path_THEN_as_expected(mock_s
     test_viewer_tarball._exists = True
     mock_get_viewer_tarball.return_value = test_viewer_tarball
 
+    
+    capture_metadata = config_wrangling.ConfigDetails(
+        s3=config_wrangling.S3Details(bucket_name, capture_s3_key),
+        version=VersionInfo("1", "1", "abcd1234", "v1-1-12312", "2023-01-01 01:01:01")
+    )
+    viewer_metadata = config_wrangling.ConfigDetails(
+        s3=config_wrangling.S3Details(bucket_name, viewer_s3_key),
+        version=VersionInfo("2", "1", "2345bcde", "v1-1-12312", "2023-01-01 01:01:01")
+    )
     mock_get_version.side_effect = [
-        {"version": "1"},
-        {"version": "2"}
+        capture_metadata.version,
+        viewer_metadata.version,
     ]
 
     # Run our test
@@ -652,19 +666,37 @@ def test_WHEN_set_up_arkime_config_called_AND_happy_path_THEN_as_expected(mock_s
 
     expected_put_file_calls = [
         mock.call(
-            local_file.S3File(test_capture_tarball, metadata={"version": "1"}),
+            local_file.S3File(test_capture_tarball, metadata=capture_metadata.version.to_dict()),
             bucket_name,
-            "capture/1/config.tgz",
+            capture_s3_key,
             mock.ANY
         ),
         mock.call(
-            local_file.S3File(test_viewer_tarball, metadata={"version": "2"}),
+            local_file.S3File(test_viewer_tarball, metadata=viewer_metadata.version.to_dict()),
             bucket_name,
-            "viewer/1/config.tgz",
+            viewer_s3_key,
             mock.ANY
         ),
     ]
     assert expected_put_file_calls == mock_put_file.call_args_list
+
+    expected_put_ssm_param_calls = [
+        mock.call(
+            constants.get_capture_config_details_ssm_param_name("cluster-name"),
+            json.dumps(capture_metadata.to_dict()),
+            mock.ANY,
+            description=mock.ANY,
+            overwrite=True,
+        ),
+        mock.call(
+            constants.get_viewer_config_details_ssm_param_name("cluster-name"),
+            json.dumps(viewer_metadata.to_dict()),
+            mock.ANY,
+            description=mock.ANY,
+            overwrite=True,
+        ),
+    ]
+    assert expected_put_ssm_param_calls == mock_put_ssm_param.call_args_list
 
 
 class SysExitCalled(Exception):

--- a/test_manage_arkime/core/test_versioning.py
+++ b/test_manage_arkime/core/test_versioning.py
@@ -40,32 +40,36 @@ def test_WHEN_get_source_version_called_THEN_as_expected(mock_shell):
     with pytest.raises(ver.CouldntReadSourceVersion):
         ver.get_source_version()
 
+@mock.patch("core.versioning.datetime")
 @mock.patch("core.versioning.get_source_version")
 @mock.patch("core.versioning.get_md5_of_file")
-def test_WHEN_get_version_info_called_THEN_as_expected(mock_get_md5, mock_get_source_v):
+def test_WHEN_get_version_info_called_THEN_as_expected(mock_get_md5, mock_get_source_v, mock_datetime):
     # Set up our mock
     mock_file = mock.Mock()
     mock_get_md5.return_value = "86d3f3a95c324c9479bd8986968f4327"
     mock_get_source_v.return_value = "v0.1.1-1-gd8e1200"
+    mock_datetime.now.return_value.strftime.return_value = "2023-05-11 07:13:42"
 
     # TEST: Config version default is 1
     actual_versions = ver.get_version_info(mock_file)
 
-    expected_versions = {
-        "aws_aio_version": "1",
-        "config_version": "1",
-        "md5_version": "86d3f3a95c324c9479bd8986968f4327",
-        "source_version": "v0.1.1-1-gd8e1200",
-    }
+    expected_versions = ver.VersionInfo(
+        "1",
+        "1",
+        "86d3f3a95c324c9479bd8986968f4327",
+        "v0.1.1-1-gd8e1200",
+        "2023-05-11 07:13:42",
+    )
     assert expected_versions == actual_versions
 
     # TEST: Config version is non-default
     actual_versions = ver.get_version_info(mock_file, config_version="3")
 
-    expected_versions = {
-        "aws_aio_version": "1",
-        "config_version": "3",
-        "md5_version": "86d3f3a95c324c9479bd8986968f4327",
-        "source_version": "v0.1.1-1-gd8e1200",
-    }
+    expected_versions = ver.VersionInfo(
+        "1",
+        "3",
+        "86d3f3a95c324c9479bd8986968f4327",
+        "v0.1.1-1-gd8e1200",
+        "2023-05-11 07:13:42",
+    )
     assert expected_versions == actual_versions


### PR DESCRIPTION
## Description
* Checkpoint commit.  Still need to update the in-Container behavior to use the config stored in S3, remove the old config behavior, and update `destroy-cluster` to remove the config bucket.
* This update is a quick PR to cover the behavior to upload the Arkime Config's details to Parameter Store during `create-cluster`

## Tasks
* https://github.com/arkime/aws-aio/issues/83

## Testing
* Added unit tests
* Ran the `create-cluster` command against my account twice to demonstrate the code's ability to create/upload the config on the first pass and skip that logic on the second pass once it saw it was already uploaded.

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py create-cluster --name MyCluster3 --preconfirm-usage
2023-07-19 15:09:32 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-07-19 15:09:32 - Using AWS Credential Profile: default
2023-07-19 15:09:32 - Using AWS Region: default from AWS Config settings
2023-07-19 15:09:34 - Usage report:
Arkime Metadata:
    Session Retention [days]: 30
    User History Retention [days]: 120
Capture Nodes:
    Max Count: 2
    Desired Count: 1
    Min Count: 1
    Type: m5.xlarge
OpenSearch Domain:
    Master Node Count: 3
    Master Node Type: m6g.large.search
    Data Node Count: 2
    Data Node Type: r6g.large.search
    Data Node Volume Size [GB]: 1024
S3:
    PCAP Retention [days]: 30

2023-07-19 15:09:34 - Ensuring Arkime Config dir exists for cluster: MyCluster3
2023-07-19 15:09:34 - Arkime Config dir exists at: /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster3
2023-07-19 15:09:34 - Copying default Arkime Config to dir: /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster3
2023-07-19 15:09:34 - Cluster config directory not empty; skipping copy
2023-07-19 15:09:34 - Determining the status of S3 bucket: arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster3
2023-07-19 15:09:35 - S3 Bucket arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster3 already exists; no work needed
2023-07-19 15:09:35 - Uploading Arkime config for Capture Nodes...
2023-07-19 15:09:35 - Turning Capture configuration at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster3/capture into tarball at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster3/capture.t
gz
2023-07-19 15:09:35 - Uploading config tarball to S3 bucket: arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster3
2023-07-19 15:09:36 - Uploading Arkime config for Viewer Nodes...
2023-07-19 15:09:37 - Turning Viewer configuration at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster3/viewer into tarball at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster3/viewer.tgz
2023-07-19 15:09:37 - Uploading config tarball to S3 bucket: arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster3
2023-07-19 15:09:39 - Executing command: deploy MyCluster3-CaptureBucket MyCluster3-CaptureNodes MyCluster3-CaptureVPC MyCluster3-OSDomain MyCluster3-ViewerNodes
2023-07-19 15:09:39 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-07-19 15:12:12 - Deployment succeeded
```

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py create-cluster --name MyCluster3 --preconfirm-usage
2023-07-19 14:52:24 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-07-19 14:52:24 - Using AWS Credential Profile: default
2023-07-19 14:52:24 - Using AWS Region: default from AWS Config settings
2023-07-19 14:52:26 - Usage report:
Arkime Metadata:
    Session Retention [days]: 30
    User History Retention [days]: 120
Capture Nodes:
    Max Count: 2
    Desired Count: 1
    Min Count: 1
    Type: m5.xlarge
OpenSearch Domain:
    Master Node Count: 3
    Master Node Type: m6g.large.search
    Data Node Count: 2
    Data Node Type: r6g.large.search
    Data Node Volume Size [GB]: 1024
S3:
    PCAP Retention [days]: 30

2023-07-19 14:52:26 - Ensuring Arkime Config dir exists for cluster: MyCluster3                                                                                                                           2023-07-19 14:52:26 - Arkime Config dir exists at: /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster3
2023-07-19 14:52:26 - Copying default Arkime Config to dir: /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster3
2023-07-19 14:52:26 - Cluster config directory not empty; skipping copy
2023-07-19 14:52:27 - Determining the status of S3 bucket: arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster3
2023-07-19 14:52:27 - S3 Bucket arkimeconfig-968674222892-us-east-2-mycluster3 already exists; no work needed
2023-07-19 14:52:27 - Uploading Arkime config for Capture Nodes...
2023-07-19 14:52:28 - Config has been uploaded previously; skipping
2023-07-19 14:52:28 - Uploading Arkime config for Viewer Nodes...
2023-07-19 14:52:28 - Config has been uploaded previously; skipping
2023-07-19 14:52:29 - Executing command: deploy MyCluster3-CaptureBucket MyCluster3-CaptureNodes MyCluster3-CaptureVPC MyCluster3-OSDomain MyCluster3-ViewerNodes
2023-07-19 14:52:29 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-07-19 14:55:01 - Deployment succeeded
```

![Screen Shot 2023-07-19 at 3 19 45 PM](https://github.com/arkime/aws-aio/assets/25470211/fa3cbe73-e4b2-4303-817c-4adbbf175f46)

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
