### PR TITLE
Moved to reverse-polish naming for CLI commands

### DIFF
--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -3,15 +3,15 @@ import logging
 
 import click
 
-from commands.add_vpc import cmd_add_vpc
+from commands.vpc_add import cmd_vpc_add
 from commands.config_update import cmd_config_update
-from commands.create_cluster import cmd_create_cluster
-from commands.destroy_cluster import cmd_destroy_cluster
-from commands.deploy_demo_traffic import cmd_deploy_demo_traffic
-from commands.destroy_demo_traffic import cmd_destroy_demo_traffic
+from commands.cluster_create import cmd_cluster_create
+from commands.cluster_destroy import cmd_cluster_destroy
+from commands.demo_traffic_deploy import cmd_demo_traffic_deploy
+from commands.demo_traffic_destroy import cmd_demo_traffic_destroy
 from commands.get_login_details import cmd_get_login_details
-from commands.list_clusters import cmd_list_clusters
-from commands.remove_vpc import cmd_remove_vpc
+from commands.clusters_list import cmd_clusters_list
+from commands.vpc_remove import cmd_vpc_remove
 import core.constants as constants
 from core.capacity_planning import MAX_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_REPLICAS, DEFAULT_S3_STORAGE_DAYS, DEFAULT_HISTORY_DAYS
 from core.logging_wrangler import LoggingWrangler, set_boto_log_level
@@ -40,19 +40,19 @@ def cli(ctx, profile, region):
 
 @click.command(help="Uses CDK to deploy a sample traffic source to your account")
 @click.pass_context
-def deploy_demo_traffic(ctx):
+def demo_traffic_deploy(ctx):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_deploy_demo_traffic(profile, region)
-cli.add_command(deploy_demo_traffic)
+    cmd_demo_traffic_deploy(profile, region)
+cli.add_command(demo_traffic_deploy)
 
 @click.command(help="Uses CDK to destroy previously-deployed sample traffic sources in your account")
 @click.pass_context
-def destroy_demo_traffic(ctx):
+def demo_traffic_destroy(ctx):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_destroy_demo_traffic(profile, region)
-cli.add_command(destroy_demo_traffic)
+    cmd_demo_traffic_destroy(profile, region)
+cli.add_command(demo_traffic_destroy)
 
 @click.command(help="Creates an Arkime Cluster in your account")
 @click.option("--name", help="The name you want your Arkime Cluster and its associated resources to have", required=True)
@@ -95,11 +95,11 @@ cli.add_command(destroy_demo_traffic)
     default=False
 )
 @click.pass_context
-def create_cluster(ctx, name, expected_traffic, spi_days, history_days, replicas, pcap_days, preconfirm_usage):
+def cluster_create(ctx, name, expected_traffic, spi_days, history_days, replicas, pcap_days, preconfirm_usage):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_create_cluster(profile, region, name, expected_traffic, spi_days, history_days, replicas, pcap_days, preconfirm_usage)
-cli.add_command(create_cluster)
+    cmd_cluster_create(profile, region, name, expected_traffic, spi_days, history_days, replicas, pcap_days, preconfirm_usage)
+cli.add_command(cluster_create)
 
 @click.command(help="Tears down the Arkime Cluster in your account; by default, leaves your data intact")
 @click.option("--name", help="The name of the Arkime Cluster to tear down", required=True)
@@ -111,11 +111,11 @@ cli.add_command(create_cluster)
     default=False
 )
 @click.pass_context
-def destroy_cluster(ctx, name, destroy_everything):
+def cluster_destroy(ctx, name, destroy_everything):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_destroy_cluster(profile, region, name, destroy_everything)
-cli.add_command(destroy_cluster)
+    cmd_cluster_destroy(profile, region, name, destroy_everything)
+cli.add_command(cluster_destroy)
 
 @click.command(help="Retrieves the login details of a cluster's the Arkime Viewer(s)")
 @click.option("--name", help="The name of the Arkime Cluster to get the login details for", required=True)
@@ -128,11 +128,11 @@ cli.add_command(get_login_details)
 
 @click.command(help="Lists the currently deployed Arkime Clusters and their VPCs")
 @click.pass_context
-def list_clusters(ctx):
+def clusters_list(ctx):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_list_clusters(profile, region)
-cli.add_command(list_clusters)
+    cmd_clusters_list(profile, region)
+cli.add_command(clusters_list)
 
 @click.command(help=("Sets up the specified VPC to have its traffic monitored by the specified, existing Arkime Cluster."
                     + "  By default, each VPC is assigned a Virtual Network Interface ID (VNI) unused by any other VPC"
@@ -143,21 +143,21 @@ cli.add_command(list_clusters)
               + " result in multiple VPCs using the same VNI, and VNIs to potentially be re-used long after they are"
               + " relinquished."), default=None, type=int)
 @click.pass_context
-def add_vpc(ctx, cluster_name, vpc_id, force_vni):
+def vpc_add(ctx, cluster_name, vpc_id, force_vni):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_add_vpc(profile, region, cluster_name, vpc_id, force_vni)
-cli.add_command(add_vpc)
+    cmd_vpc_add(profile, region, cluster_name, vpc_id, force_vni)
+cli.add_command(vpc_add)
 
 @click.command(help="Removes traffic monitoring from the specified VPC being performed by the specified Arkime Cluster")
 @click.option("--cluster-name", help="The name of the Arkime Cluster performing monitoring", required=True)
 @click.option("--vpc-id", help="The VPC ID to remove monitoring from", required=True)
 @click.pass_context
-def remove_vpc(ctx, cluster_name, vpc_id):
+def vpc_remove(ctx, cluster_name, vpc_id):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_remove_vpc(profile, region, cluster_name, vpc_id)
-cli.add_command(remove_vpc)
+    cmd_vpc_remove(profile, region, cluster_name, vpc_id)
+cli.add_command(vpc_remove)
 
 @click.command(help="Updates specified Arkime Cluster's Capture/Viewer configuration")
 @click.option("--cluster-name", help="The name of the Arkime Cluster to update", required=True)

--- a/manage_arkime/cdk_interactions/cdk_context.py
+++ b/manage_arkime/cdk_interactions/cdk_context.py
@@ -8,7 +8,7 @@ from core.capacity_planning import (CaptureNodesPlan, CaptureVpcPlan, ClusterPla
                                     DEFAULT_S3_STORAGE_CLASS)
 from core.user_config import UserConfig
 
-def generate_create_cluster_context(name: str, viewer_cert_arn: str, cluster_plan: ClusterPlan,
+def generate_cluster_create_context(name: str, viewer_cert_arn: str, cluster_plan: ClusterPlan,
                                     user_config: UserConfig, cluster_config_bucket_name: str) -> Dict[str, str]:
     create_context = _generate_cluster_context(
         name,
@@ -17,10 +17,10 @@ def generate_create_cluster_context(name: str, viewer_cert_arn: str, cluster_pla
         user_config,
         cluster_config_bucket_name
     )
-    create_context[constants.CDK_CONTEXT_CMD_VAR] = constants.CMD_CREATE_CLUSTER
+    create_context[constants.CDK_CONTEXT_CMD_VAR] = constants.CMD_cluster_create
     return create_context
 
-def generate_destroy_cluster_context(name: str) -> Dict[str, str]:
+def generate_cluster_destroy_context(name: str) -> Dict[str, str]:
     # Hardcode these value because it saves us some implementation headaches and it doesn't matter what it is. Since
     # we're tearing down the Cfn stack in which it would be used, the operation either succeeds they are irrelevant
     # or it fails/rolls back they are irrelevant.
@@ -36,7 +36,7 @@ def generate_destroy_cluster_context(name: str) -> Dict[str, str]:
     fake_bucket_name = ""
 
     destroy_context = _generate_cluster_context(name, fake_arn, fake_cluster_plan, fake_user_config, fake_bucket_name)
-    destroy_context[constants.CDK_CONTEXT_CMD_VAR] = constants.CMD_DESTROY_CLUSTER
+    destroy_context[constants.CDK_CONTEXT_CMD_VAR] = constants.CMD_cluster_destroy
     return destroy_context
 
 def _generate_cluster_context(name: str, viewer_cert_arn: str, cluster_plan: ClusterPlan, user_config: UserConfig,
@@ -65,20 +65,20 @@ def _generate_cluster_context(name: str, viewer_cert_arn: str, cluster_plan: Clu
         constants.CDK_CONTEXT_PARAMS_VAR: shlex.quote(json.dumps(cmd_params))
     }
 
-def generate_add_vpc_context(cluster_name: str, vpc_id: str, subnet_ids: str, vpce_service_id: str, bus_arn: str, vni: int,
+def generate_vpc_add_context(cluster_name: str, vpc_id: str, subnet_ids: str, vpce_service_id: str, bus_arn: str, vni: int,
                              cidrs: List[str]) -> Dict[str, str]:
     add_context = _generate_mirroring_context(cluster_name, vpc_id, subnet_ids, vpce_service_id, bus_arn, vni, cidrs)
-    add_context[constants.CDK_CONTEXT_CMD_VAR] = constants.CMD_ADD_VPC
+    add_context[constants.CDK_CONTEXT_CMD_VAR] = constants.CMD_vpc_add
     return add_context
 
-def generate_remove_vpc_context(cluster_name: str, vpc_id: str, subnet_ids: str, vpce_service_id: str, bus_arn: str) -> Dict[str, str]:
+def generate_vpc_remove_context(cluster_name: str, vpc_id: str, subnet_ids: str, vpce_service_id: str, bus_arn: str) -> Dict[str, str]:
     # Hardcode these values because it saves us some implementation headaches and it doesn't matter what they are. Since
     # we're tearing down the Cfn stack in which it would be used, the operation either succeeds and the it's
     # irrelevant or it fails/rolls back and it's irrelevant.
     vni = constants.VNI_DEFAULT
     cidrs = ["0.0.0.0/0"]
     remove_context = _generate_mirroring_context(cluster_name, vpc_id, subnet_ids, vpce_service_id, bus_arn, vni, cidrs)
-    remove_context[constants.CDK_CONTEXT_CMD_VAR] = constants.CMD_REMOVE_VPC
+    remove_context[constants.CDK_CONTEXT_CMD_VAR] = constants.CMD_vpc_remove
     return remove_context
 
 def _generate_mirroring_context(cluster_name: str, vpc_id: str, subnet_ids: str, vpce_service_id: str, bus_arn: str, vni: int,

--- a/manage_arkime/commands/cluster_create.py
+++ b/manage_arkime/commands/cluster_create.py
@@ -23,9 +23,9 @@ from core.user_config import UserConfig
 
 logger = logging.getLogger(__name__)
 
-def cmd_create_cluster(profile: str, region: str, name: str, expected_traffic: float, spi_days: int, history_days: int, replicas: int,
+def cmd_cluster_create(profile: str, region: str, name: str, expected_traffic: float, spi_days: int, history_days: int, replicas: int,
                        pcap_days: int, preconfirm_usage: bool):
-    logger.debug(f"Invoking create-cluster with profile '{profile}' and region '{region}'")
+    logger.debug(f"Invoking cluster-create with profile '{profile}' and region '{region}'")
 
     aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)
     aws_env = aws_provider.get_aws_env()
@@ -55,7 +55,7 @@ def cmd_create_cluster(profile: str, region: str, name: str, expected_traffic: f
         constants.get_opensearch_domain_stack_name(name),
         constants.get_viewer_nodes_stack_name(name)
     ]
-    create_context = context.generate_create_cluster_context(
+    create_context = context.generate_cluster_create_context(
         name,
         cert_arn,
         next_capacity_plan,

--- a/manage_arkime/commands/cluster_destroy.py
+++ b/manage_arkime/commands/cluster_destroy.py
@@ -11,8 +11,8 @@ import cdk_interactions.cdk_context as context
 
 logger = logging.getLogger(__name__)
 
-def cmd_destroy_cluster(profile: str, region: str, name: str, destroy_everything: bool):
-    logger.debug(f"Invoking destroy-cluster with profile '{profile}' and region '{region}'")
+def cmd_cluster_destroy(profile: str, region: str, name: str, destroy_everything: bool):
+    logger.debug(f"Invoking cluster-destroy with profile '{profile}' and region '{region}'")
 
     aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)
     cdk_client = CdkClient(aws_provider.get_aws_env())
@@ -21,7 +21,7 @@ def cmd_destroy_cluster(profile: str, region: str, name: str, destroy_everything
     monitored_vpcs = get_ssm_names_by_path(vpcs_search_path, aws_provider)
     if monitored_vpcs:
         logger.error("Your cluster is currently monitoring VPCs.  Please stop monitoring these VPCs using the"
-            + f" remove-vpc command before destroying your cluster:\n{monitored_vpcs}")
+            + f" vpc-remove command before destroying your cluster:\n{monitored_vpcs}")
         logger.warning("Aborting...")
         return
 
@@ -34,7 +34,7 @@ def cmd_destroy_cluster(profile: str, region: str, name: str, destroy_everything
         destroy_bucket(bucket_name=bucket_name, aws_provider=aws_provider)
 
     if not destroy_everything:
-        # By default, destroy-cluster just tears down the capture/viewer nodes in order to preserve the user's data.  We
+        # By default, cluster-destroy just tears down the capture/viewer nodes in order to preserve the user's data.  We
         # could tear down the OpenSearch Domain and Bucket stacks, but that would leave loose (non-CloudFormation managed)
         # resources in the user's account that they'd likely stumble across later, so it's probably better to leave those
         # stacks intact.  We can't delete the VPC stack because the OpenSearch Domain has the VPC as a dependency, as we're
@@ -52,7 +52,7 @@ def cmd_destroy_cluster(profile: str, region: str, name: str, destroy_everything
             constants.get_opensearch_domain_stack_name(name),
             constants.get_viewer_nodes_stack_name(name)
         ]
-    destroy_context = context.generate_destroy_cluster_context(name)
+    destroy_context = context.generate_cluster_destroy_context(name)
 
     cdk_client.destroy(stacks_to_destroy, context=destroy_context)
 

--- a/manage_arkime/commands/clusters_list.py
+++ b/manage_arkime/commands/clusters_list.py
@@ -8,8 +8,8 @@ import core.constants as constants
 
 logger = logging.getLogger(__name__)
 
-def cmd_list_clusters(profile: str, region: str) -> List[Dict[str, str]]:
-    logger.debug(f"Invoking list-clusters with profile '{profile}' and region '{region}'")
+def cmd_clusters_list(profile: str, region: str) -> List[Dict[str, str]]:
+    logger.debug(f"Invoking clusters-list with profile '{profile}' and region '{region}'")
 
     logger.info("Retrieving cluster details...")
     aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)

--- a/manage_arkime/commands/demo_traffic_deploy.py
+++ b/manage_arkime/commands/demo_traffic_deploy.py
@@ -6,14 +6,14 @@ import core.constants as constants
 
 logger = logging.getLogger(__name__)
 
-def cmd_destroy_demo_traffic(profile: str, region: str):
-    logger.debug(f"Invoking destroy-demo-traffic with profile '{profile}' and region '{region}'")
+def cmd_demo_traffic_deploy(profile: str, region: str):
+    logger.debug(f"Invoking demo-traffic-deploy with profile '{profile}' and region '{region}'")
 
     aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)
     cdk_client = CdkClient(aws_provider.get_aws_env())
 
-    stacks_to_destroy = [constants.NAME_DEMO_STACK_1, constants.NAME_DEMO_STACK_2]
+    stacks_to_deploy = [constants.NAME_DEMO_STACK_1, constants.NAME_DEMO_STACK_2]
     context = {
-        constants.CDK_CONTEXT_CMD_VAR: constants.CMD_DESTROY_DEMO
+        constants.CDK_CONTEXT_CMD_VAR: constants.CMD_DEPLOY_DEMO
     }
-    cdk_client.destroy(stacks_to_destroy, context=context)
+    cdk_client.deploy(stacks_to_deploy, context=context)

--- a/manage_arkime/commands/demo_traffic_destroy.py
+++ b/manage_arkime/commands/demo_traffic_destroy.py
@@ -6,14 +6,14 @@ import core.constants as constants
 
 logger = logging.getLogger(__name__)
 
-def cmd_deploy_demo_traffic(profile: str, region: str):
-    logger.debug(f"Invoking deploy-demo-traffic with profile '{profile}' and region '{region}'")
+def cmd_demo_traffic_destroy(profile: str, region: str):
+    logger.debug(f"Invoking demo-traffic-destroy with profile '{profile}' and region '{region}'")
 
     aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)
     cdk_client = CdkClient(aws_provider.get_aws_env())
 
-    stacks_to_deploy = [constants.NAME_DEMO_STACK_1, constants.NAME_DEMO_STACK_2]
+    stacks_to_destroy = [constants.NAME_DEMO_STACK_1, constants.NAME_DEMO_STACK_2]
     context = {
-        constants.CDK_CONTEXT_CMD_VAR: constants.CMD_DEPLOY_DEMO
+        constants.CDK_CONTEXT_CMD_VAR: constants.CMD_DESTROY_DEMO
     }
-    cdk_client.deploy(stacks_to_deploy, context=context)
+    cdk_client.destroy(stacks_to_destroy, context=context)

--- a/manage_arkime/commands/vpc_add.py
+++ b/manage_arkime/commands/vpc_add.py
@@ -11,8 +11,8 @@ from core.vni_provider import SsmVniProvider, VniAlreadyUsed, VniOutsideRange, V
 
 logger = logging.getLogger(__name__)
 
-def cmd_add_vpc(profile: str, region: str, cluster_name: str, vpc_id: str, user_vni: int):
-    logger.debug(f"Invoking add-vpc with profile '{profile}' and region '{region}'")
+def cmd_vpc_add(profile: str, region: str, cluster_name: str, vpc_id: str, user_vni: int):
+    logger.debug(f"Invoking vpc-add with profile '{profile}' and region '{region}'")
 
     aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)
     cdk_client = CdkClient(aws_provider.get_aws_env())
@@ -33,12 +33,12 @@ def cmd_add_vpc(profile: str, region: str, cluster_name: str, vpc_id: str, user_
 
         try:
             if not vni_provider.is_vni_available(next_vni):
-                logger.error(f"VNI {next_vni} is already in use and cannot be used again.  Use list-clusters to see the VNIs"
+                logger.error(f"VNI {next_vni} is already in use and cannot be used again.  Use clusters-list to see the VNIs"
                             + " assigned to your clusters.")
                 logger.warning("Aborting...")
                 return            
         except VniAlreadyUsed:
-            logger.error(f"VNI {next_vni} is already in use; you can use the list-clusters command to see which VPC it is assigned to.")
+            logger.error(f"VNI {next_vni} is already in use; you can use the clusters-list command to see which VPC it is assigned to.")
             logger.warning("Aborting...")
             return
         except VniOutsideRange:
@@ -50,7 +50,7 @@ def cmd_add_vpc(profile: str, region: str, cluster_name: str, vpc_id: str, user_
     try:
         ssm_ops.get_ssm_param_value(constants.get_cluster_ssm_param_name(cluster_name), aws_provider)
     except ssm_ops.ParamDoesNotExist:
-        logger.error(f"The cluster {cluster_name} does not exist; try using the list-clusters command to see the clusters you have created.")
+        logger.error(f"The cluster {cluster_name} does not exist; try using the clusters-list command to see the clusters you have created.")
         logger.warning("Aborting...")
         return
 
@@ -72,10 +72,10 @@ def cmd_add_vpc(profile: str, region: str, cluster_name: str, vpc_id: str, user_
     stacks_to_deploy = [
         constants.get_vpc_mirror_setup_stack_name(cluster_name, vpc_id)
     ]
-    add_vpc_context = context.generate_add_vpc_context(cluster_name, vpc_id, subnet_ids, vpce_service_id, event_bus_arn,
+    vpc_add_context = context.generate_vpc_add_context(cluster_name, vpc_id, subnet_ids, vpce_service_id, event_bus_arn,
                                                        next_vni, vpc_details.cidr_blocks)
 
-    cdk_client.deploy(stacks_to_deploy, context=add_vpc_context)
+    cdk_client.deploy(stacks_to_deploy, context=vpc_add_context)
 
     # Create the per-ENI Traffic Mirroring Sessions.
     #

--- a/manage_arkime/commands/vpc_remove.py
+++ b/manage_arkime/commands/vpc_remove.py
@@ -12,8 +12,8 @@ from core.vni_provider import SsmVniProvider
 logger = logging.getLogger(__name__)
 
 
-def cmd_remove_vpc(profile: str, region: str, cluster_name: str, vpc_id: str):
-    logger.debug(f"Invoking remove-vpc with profile '{profile}' and region '{region}'")
+def cmd_vpc_remove(profile: str, region: str, cluster_name: str, vpc_id: str):
+    logger.debug(f"Invoking vpc-remove with profile '{profile}' and region '{region}'")
 
     aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)
     cdk_client = CdkClient(aws_provider.get_aws_env())
@@ -23,7 +23,7 @@ def cmd_remove_vpc(profile: str, region: str, cluster_name: str, vpc_id: str):
         vpce_service_id = ssm_ops.get_ssm_param_json_value(constants.get_cluster_ssm_param_name(cluster_name), "vpceServiceId", aws_provider)
         event_bus_arn = ssm_ops.get_ssm_param_json_value(constants.get_cluster_ssm_param_name(cluster_name), "busArn", aws_provider)
     except ssm_ops.ParamDoesNotExist:
-        logger.error(f"The cluster {cluster_name} does not exist; try using the list-clusters command to see the clusters you have created.")
+        logger.error(f"The cluster {cluster_name} does not exist; try using the clusters-list command to see the clusters you have created.")
         logger.warning("Aborting...")
         return
 
@@ -52,6 +52,6 @@ def cmd_remove_vpc(profile: str, region: str, cluster_name: str, vpc_id: str):
     stacks_to_destroy = [
         constants.get_vpc_mirror_setup_stack_name(cluster_name, vpc_id)
     ]
-    add_vpc_context = context.generate_remove_vpc_context(cluster_name, vpc_id, subnet_ids, vpce_service_id, event_bus_arn)
+    vpc_add_context = context.generate_vpc_remove_context(cluster_name, vpc_id, subnet_ids, vpce_service_id, event_bus_arn)
 
-    cdk_client.destroy(stacks_to_destroy, context=add_vpc_context)
+    cdk_client.destroy(stacks_to_destroy, context=vpc_add_context)

--- a/manage_arkime/core/constants.py
+++ b/manage_arkime/core/constants.py
@@ -22,10 +22,10 @@ CDK_CONTEXT_REGION_VAR: str = "ARKIME_REGION"
 # The names of the management operations we can perform; will be received/parsed on the CDK side so needs to match.
 CMD_DEPLOY_DEMO = "DeployDemoTraffic"
 CMD_DESTROY_DEMO = "DestroyDemoTraffic"
-CMD_CREATE_CLUSTER = "CreateCluster"
-CMD_DESTROY_CLUSTER = "DestroyCluster"
-CMD_ADD_VPC = "AddVpc"
-CMD_REMOVE_VPC = "RemoveVpc"
+CMD_cluster_create = "CreateCluster"
+CMD_cluster_destroy = "DestroyCluster"
+CMD_vpc_add = "AddVpc"
+CMD_vpc_remove = "RemoveVpc"
 
 # The names of static CDK Stacks defined in our App
 NAME_DEMO_STACK_1: str = "DemoTrafficGen01"

--- a/test_manage_arkime/commands/test_cluster_create.py
+++ b/test_manage_arkime/commands/test_cluster_create.py
@@ -9,7 +9,7 @@ from aws_interactions.events_interactions import ConfigureIsmEvent
 import aws_interactions.s3_interactions as s3
 import aws_interactions.ssm_operations as ssm_ops
 
-from commands.create_cluster import (cmd_create_cluster, _set_up_viewer_cert, _get_next_capacity_plan, _get_next_user_config, _confirm_usage,
+from commands.cluster_create import (cmd_cluster_create, _set_up_viewer_cert, _get_next_capacity_plan, _get_next_user_config, _confirm_usage,
                                      _get_previous_capacity_plan, _get_previous_user_config, _configure_ism, _set_up_arkime_config)
 import core.constants as constants
 from core.capacity_planning import (CaptureNodesPlan, EcsSysResourcePlan, MINIMUM_TRAFFIC, OSDomainPlan, DataNodesPlan, MasterNodesPlan,
@@ -19,17 +19,17 @@ import core.local_file as local_file
 from core.user_config import UserConfig
 from core.versioning import VersionInfo
 
-@mock.patch("commands.create_cluster.AwsClientProvider")
-@mock.patch("commands.create_cluster._set_up_arkime_config")
-@mock.patch("commands.create_cluster._configure_ism")
-@mock.patch("commands.create_cluster._get_previous_user_config")
-@mock.patch("commands.create_cluster._get_previous_capacity_plan")
-@mock.patch("commands.create_cluster._confirm_usage")
-@mock.patch("commands.create_cluster._get_next_user_config")
-@mock.patch("commands.create_cluster._get_next_capacity_plan")
-@mock.patch("commands.create_cluster._set_up_viewer_cert")
-@mock.patch("commands.create_cluster.CdkClient")
-def test_WHEN_cmd_create_cluster_called_THEN_cdk_command_correct(mock_cdk_client_cls, mock_set_up, mock_get_plans, mock_get_config,
+@mock.patch("commands.cluster_create.AwsClientProvider")
+@mock.patch("commands.cluster_create._set_up_arkime_config")
+@mock.patch("commands.cluster_create._configure_ism")
+@mock.patch("commands.cluster_create._get_previous_user_config")
+@mock.patch("commands.cluster_create._get_previous_capacity_plan")
+@mock.patch("commands.cluster_create._confirm_usage")
+@mock.patch("commands.cluster_create._get_next_user_config")
+@mock.patch("commands.cluster_create._get_next_capacity_plan")
+@mock.patch("commands.cluster_create._set_up_viewer_cert")
+@mock.patch("commands.cluster_create.CdkClient")
+def test_WHEN_cmd_cluster_create_called_THEN_cdk_command_correct(mock_cdk_client_cls, mock_set_up, mock_get_plans, mock_get_config,
                                                                  mock_confirm, mock_get_prev_plan, mock_get_prev_config, mock_configure,
                                                                  mock_set_up_arkime_conf, mock_aws_provider_cls):
     # Set up our mock
@@ -59,7 +59,7 @@ def test_WHEN_cmd_create_cluster_called_THEN_cdk_command_correct(mock_cdk_client
 
 
     # Run our test
-    cmd_create_cluster("profile", "region", "my-cluster", None, None, None, None, None, True)
+    cmd_cluster_create("profile", "region", "my-cluster", None, None, None, None, None, True)
 
     # Check our results
     expected_calls = [
@@ -72,7 +72,7 @@ def test_WHEN_cmd_create_cluster_called_THEN_cdk_command_correct(mock_cdk_client
                 constants.get_viewer_nodes_stack_name("my-cluster"),
             ],
             context={
-                constants.CDK_CONTEXT_CMD_VAR: constants.CMD_CREATE_CLUSTER,
+                constants.CDK_CONTEXT_CMD_VAR: constants.CMD_cluster_create,
                 constants.CDK_CONTEXT_PARAMS_VAR: shlex.quote(json.dumps({
                     "nameCluster": "my-cluster",
                     "nameCaptureBucketStack": constants.get_capture_bucket_stack_name("my-cluster"),
@@ -117,17 +117,17 @@ def test_WHEN_cmd_create_cluster_called_THEN_cdk_command_correct(mock_cdk_client
     ]
     assert expected_set_up_arkime_conf_calls == mock_set_up_arkime_conf.call_args_list
 
-@mock.patch("commands.create_cluster.AwsClientProvider", mock.Mock())
-@mock.patch("commands.create_cluster._set_up_arkime_config")
-@mock.patch("commands.create_cluster._configure_ism")
-@mock.patch("commands.create_cluster._get_previous_user_config")
-@mock.patch("commands.create_cluster._get_previous_capacity_plan")
-@mock.patch("commands.create_cluster._confirm_usage")
-@mock.patch("commands.create_cluster._get_next_user_config")
-@mock.patch("commands.create_cluster._get_next_capacity_plan")
-@mock.patch("commands.create_cluster._set_up_viewer_cert")
-@mock.patch("commands.create_cluster.CdkClient")
-def test_WHEN_cmd_create_cluster_called_AND_abort_usage_THEN_as_expected(mock_cdk_client_cls, mock_set_up, mock_get_plans, mock_get_config,
+@mock.patch("commands.cluster_create.AwsClientProvider", mock.Mock())
+@mock.patch("commands.cluster_create._set_up_arkime_config")
+@mock.patch("commands.cluster_create._configure_ism")
+@mock.patch("commands.cluster_create._get_previous_user_config")
+@mock.patch("commands.cluster_create._get_previous_capacity_plan")
+@mock.patch("commands.cluster_create._confirm_usage")
+@mock.patch("commands.cluster_create._get_next_user_config")
+@mock.patch("commands.cluster_create._get_next_capacity_plan")
+@mock.patch("commands.cluster_create._set_up_viewer_cert")
+@mock.patch("commands.cluster_create.CdkClient")
+def test_WHEN_cmd_cluster_create_called_AND_abort_usage_THEN_as_expected(mock_cdk_client_cls, mock_set_up, mock_get_plans, mock_get_config,
                                                                          mock_confirm, mock_get_prev_plan, mock_get_prev_config, mock_configure,
                                                                          mock_set_up_arkime_conf):
     # Set up our mock
@@ -151,7 +151,7 @@ def test_WHEN_cmd_create_cluster_called_AND_abort_usage_THEN_as_expected(mock_cd
     mock_confirm.return_value = False
 
     # Run our test
-    cmd_create_cluster("profile", "region", "my-cluster", None, None, None, None, None, True)
+    cmd_cluster_create("profile", "region", "my-cluster", None, None, None, None, None, True)
 
     # Check our results
     expected_calls = []
@@ -166,7 +166,7 @@ def test_WHEN_cmd_create_cluster_called_AND_abort_usage_THEN_as_expected(mock_cd
     expected_set_up_arkime_conf_calls = []
     assert expected_set_up_arkime_conf_calls == mock_set_up_arkime_conf.call_args_list
 
-@mock.patch("commands.create_cluster.ssm_ops")
+@mock.patch("commands.cluster_create.ssm_ops")
 def test_WHEN_get_previous_user_config_called_AND_exists_THEN_as_expected(mock_ssm_ops):
     # Set up our mock
     mock_ssm_ops.get_ssm_param_json_value.return_value = {
@@ -192,7 +192,7 @@ def test_WHEN_get_previous_user_config_called_AND_exists_THEN_as_expected(mock_s
     assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
 
 
-@mock.patch("commands.create_cluster.ssm_ops")
+@mock.patch("commands.cluster_create.ssm_ops")
 def test_WHEN_get_previous_user_config_called_AND_doesnt_exist_THEN_as_expected(mock_ssm_ops):
     # Set up our mock
     mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
@@ -212,7 +212,7 @@ def test_WHEN_get_previous_user_config_called_AND_doesnt_exist_THEN_as_expected(
     ]
     assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
 
-@mock.patch("commands.create_cluster.ssm_ops")
+@mock.patch("commands.cluster_create.ssm_ops")
 def test_WHEN_get_next_user_config_called_AND_use_existing_THEN_as_expected(mock_ssm_ops):
     # Set up our mock
     mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
@@ -238,7 +238,7 @@ def test_WHEN_get_next_user_config_called_AND_use_existing_THEN_as_expected(mock
     ]
     assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
 
-@mock.patch("commands.create_cluster.ssm_ops")
+@mock.patch("commands.cluster_create.ssm_ops")
 def test_WHEN_get_next_user_config_called_AND_partial_update_THEN_as_expected(mock_ssm_ops):
     # Set up our mock
     mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
@@ -264,7 +264,7 @@ def test_WHEN_get_next_user_config_called_AND_partial_update_THEN_as_expected(mo
     ]
     assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
 
-@mock.patch("commands.create_cluster.ssm_ops")
+@mock.patch("commands.cluster_create.ssm_ops")
 def test_WHEN_get_next_user_config_called_AND_use_default_THEN_as_expected(mock_ssm_ops):
     # Set up our mock
     mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
@@ -283,7 +283,7 @@ def test_WHEN_get_next_user_config_called_AND_use_default_THEN_as_expected(mock_
     ]
     assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
 
-@mock.patch("commands.create_cluster.ssm_ops")
+@mock.patch("commands.cluster_create.ssm_ops")
 def test_WHEN_get_next_user_config_called_AND_specify_all_THEN_as_expected(mock_ssm_ops):
     # Set up our mock
     mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
@@ -300,7 +300,7 @@ def test_WHEN_get_next_user_config_called_AND_specify_all_THEN_as_expected(mock_
     assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
 
 
-@mock.patch("commands.create_cluster.ssm_ops")
+@mock.patch("commands.cluster_create.ssm_ops")
 def test_WHEN_get_previous_capacity_plan_called_AND_exists_THEN_as_expected(mock_ssm_ops):
     # Set up our mock
     mock_ssm_ops.get_ssm_param_json_value.return_value = {
@@ -355,7 +355,7 @@ def test_WHEN_get_previous_capacity_plan_called_AND_exists_THEN_as_expected(mock
     assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
 
 
-@mock.patch("commands.create_cluster.ssm_ops")
+@mock.patch("commands.cluster_create.ssm_ops")
 def test_WHEN_get_previous_capacity_plan_called_AND_doesnt_exist_THEN_as_expected(mock_ssm_ops):
     # Set up our mock
     mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
@@ -382,9 +382,9 @@ def test_WHEN_get_previous_capacity_plan_called_AND_doesnt_exist_THEN_as_expecte
     assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
 
 
-@mock.patch("commands.create_cluster.get_os_domain_plan")
-@mock.patch("commands.create_cluster.get_capture_node_capacity_plan")
-@mock.patch("commands.create_cluster.ssm_ops")
+@mock.patch("commands.cluster_create.get_os_domain_plan")
+@mock.patch("commands.cluster_create.get_capture_node_capacity_plan")
+@mock.patch("commands.cluster_create.ssm_ops")
 def test_WHEN_get_next_capacity_plan_called_THEN_as_expected(mock_ssm_ops, mock_get_cap, mock_get_os):
     # Set up our mock
     mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
@@ -415,7 +415,7 @@ def test_WHEN_get_next_capacity_plan_called_THEN_as_expected(mock_ssm_ops, mock_
     ]
     assert expected_get_os_calls == mock_get_os.call_args_list
 
-@mock.patch("commands.create_cluster.UsageReport")
+@mock.patch("commands.cluster_create.UsageReport")
 def test_WHEN_confirm_usage_called_THEN_as_expected(mock_report_cls):
     # Shared Setup
     mock_plan_prev = mock.Mock()
@@ -447,8 +447,8 @@ def test_WHEN_confirm_usage_called_THEN_as_expected(mock_report_cls):
     assert False == actual_value
     assert mock_report.get_confirmation.called
 
-@mock.patch("commands.create_cluster.upload_default_elb_cert")
-@mock.patch("commands.create_cluster.ssm_ops")
+@mock.patch("commands.cluster_create.upload_default_elb_cert")
+@mock.patch("commands.cluster_create.ssm_ops")
 def test_WHEN_set_up_viewer_cert_called_THEN_set_up_correctly(mock_ssm_ops, mock_upload):
     # Set up our mock
     mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
@@ -484,9 +484,9 @@ def test_WHEN_set_up_viewer_cert_called_THEN_set_up_correctly(mock_ssm_ops, mock
     ]
     assert expected_put_ssm_calls == mock_ssm_ops.put_ssm_param.call_args_list
 
-@mock.patch("commands.create_cluster.AwsClientProvider", mock.Mock())
-@mock.patch("commands.create_cluster.upload_default_elb_cert")
-@mock.patch("commands.create_cluster.ssm_ops")
+@mock.patch("commands.cluster_create.AwsClientProvider", mock.Mock())
+@mock.patch("commands.cluster_create.upload_default_elb_cert")
+@mock.patch("commands.cluster_create.ssm_ops")
 def test_WHEN_set_up_viewer_cert_called_AND_already_exists_THEN_skips_creation(mock_ssm_ops, mock_upload):
     # Set up our mock
     mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
@@ -512,8 +512,8 @@ def test_WHEN_set_up_viewer_cert_called_AND_already_exists_THEN_skips_creation(m
     assert expected_put_ssm_calls == mock_ssm_ops.put_ssm_param.call_args_list
 
 
-@mock.patch("commands.create_cluster.ssm_ops")
-@mock.patch("commands.create_cluster.events")
+@mock.patch("commands.cluster_create.ssm_ops")
+@mock.patch("commands.cluster_create.events")
 def test_WHEN_configure_ism_called_THEN_as_expected(mock_events, mock_ssm):
     # Set up our mock
     mock_ssm.get_ssm_param_json_value.return_value = "arn"
@@ -543,14 +543,14 @@ def test_WHEN_configure_ism_called_THEN_as_expected(mock_events, mock_ssm):
     ]
     assert expected_put_events_calls == mock_events.put_events.call_args_list
 
-@mock.patch("commands.create_cluster.ssm_ops.get_ssm_param_value")
-@mock.patch("commands.create_cluster.ssm_ops.put_ssm_param")
-@mock.patch("commands.create_cluster.get_version_info")
-@mock.patch("commands.create_cluster.config_wrangling.get_viewer_config_archive")
-@mock.patch("commands.create_cluster.config_wrangling.get_capture_config_archive")
-@mock.patch("commands.create_cluster.s3.put_file_to_bucket")
-@mock.patch("commands.create_cluster.s3.ensure_bucket_exists")
-@mock.patch("commands.create_cluster.config_wrangling.set_up_arkime_config_dir")
+@mock.patch("commands.cluster_create.ssm_ops.get_ssm_param_value")
+@mock.patch("commands.cluster_create.ssm_ops.put_ssm_param")
+@mock.patch("commands.cluster_create.get_version_info")
+@mock.patch("commands.cluster_create.config_wrangling.get_viewer_config_archive")
+@mock.patch("commands.cluster_create.config_wrangling.get_capture_config_archive")
+@mock.patch("commands.cluster_create.s3.put_file_to_bucket")
+@mock.patch("commands.cluster_create.s3.ensure_bucket_exists")
+@mock.patch("commands.cluster_create.config_wrangling.set_up_arkime_config_dir")
 def test_WHEN_set_up_arkime_config_called_AND_happy_path_THEN_as_expected(mock_set_up_config_dir, mock_ensure_bucket, mock_put_file,
                                                                           mock_get_capture_archive, mock_get_viewer_archive,
                                                                           mock_get_version, mock_put_ssm_param, mock_get_ssm_param):
@@ -634,14 +634,14 @@ def test_WHEN_set_up_arkime_config_called_AND_happy_path_THEN_as_expected(mock_s
     ]
     assert expected_put_ssm_param_calls == mock_put_ssm_param.call_args_list
 
-@mock.patch("commands.create_cluster.ssm_ops.get_ssm_param_value")
-@mock.patch("commands.create_cluster.ssm_ops.put_ssm_param")
-@mock.patch("commands.create_cluster.get_version_info")
-@mock.patch("commands.create_cluster.config_wrangling.get_viewer_config_archive")
-@mock.patch("commands.create_cluster.config_wrangling.get_capture_config_archive")
-@mock.patch("commands.create_cluster.s3.put_file_to_bucket")
-@mock.patch("commands.create_cluster.s3.ensure_bucket_exists")
-@mock.patch("commands.create_cluster.config_wrangling.set_up_arkime_config_dir")
+@mock.patch("commands.cluster_create.ssm_ops.get_ssm_param_value")
+@mock.patch("commands.cluster_create.ssm_ops.put_ssm_param")
+@mock.patch("commands.cluster_create.get_version_info")
+@mock.patch("commands.cluster_create.config_wrangling.get_viewer_config_archive")
+@mock.patch("commands.cluster_create.config_wrangling.get_capture_config_archive")
+@mock.patch("commands.cluster_create.s3.put_file_to_bucket")
+@mock.patch("commands.cluster_create.s3.ensure_bucket_exists")
+@mock.patch("commands.cluster_create.config_wrangling.set_up_arkime_config_dir")
 def test_WHEN_set_up_arkime_config_called_AND_config_exists_THEN_as_expected(mock_set_up_config_dir, mock_ensure_bucket, mock_put_file,
                                                                           mock_get_capture_archive, mock_get_viewer_archive,
                                                                           mock_get_version, mock_put_ssm_param, mock_get_ssm_param):
@@ -700,9 +700,9 @@ def test_WHEN_set_up_arkime_config_called_AND_config_exists_THEN_as_expected(moc
 class SysExitCalled(Exception):
     pass
 
-@mock.patch("commands.create_cluster.sys.exit")
-@mock.patch("commands.create_cluster.s3.ensure_bucket_exists")
-@mock.patch("commands.create_cluster.config_wrangling.set_up_arkime_config_dir")
+@mock.patch("commands.cluster_create.sys.exit")
+@mock.patch("commands.cluster_create.s3.ensure_bucket_exists")
+@mock.patch("commands.cluster_create.config_wrangling.set_up_arkime_config_dir")
 def test_WHEN_set_up_arkime_config_called_AND_couldnt_make_bucket_THEN_as_expected(mock_set_up_config_dir, mock_ensure_bucket, mock_exit):
     # Set up our mock
     test_env = AwsEnvironment("XXXXXXXXXXX", "my-region-1", "profile")

--- a/test_manage_arkime/commands/test_clusters_list.py
+++ b/test_manage_arkime/commands/test_clusters_list.py
@@ -1,11 +1,11 @@
 import unittest.mock as mock
 
-from commands.list_clusters import cmd_list_clusters
+from commands.clusters_list import cmd_clusters_list
 import core.constants as constants
 
-@mock.patch("commands.list_clusters.AwsClientProvider", mock.Mock())
-@mock.patch("commands.list_clusters.ssm_ops")
-def test_WHEN_cmd_list_clusters_called_THEN_lists_them(mock_ssm_ops):
+@mock.patch("commands.clusters_list.AwsClientProvider", mock.Mock())
+@mock.patch("commands.clusters_list.ssm_ops")
+def test_WHEN_cmd_clusters_list_called_THEN_lists_them(mock_ssm_ops):
     # Set up our mock
     mock_ssm_ops.get_ssm_param_json_value.side_effect = ["vni-1", "vni-2", "vni-3"]
 
@@ -16,7 +16,7 @@ def test_WHEN_cmd_list_clusters_called_THEN_lists_them(mock_ssm_ops):
     ]
 
     # Run our test
-    result = cmd_list_clusters("profile", "region")
+    result = cmd_clusters_list("profile", "region")
 
     # Check our results
     expected_get_names_calls = [

--- a/test_manage_arkime/commands/test_demo_traffic_deploy.py
+++ b/test_manage_arkime/commands/test_demo_traffic_deploy.py
@@ -1,12 +1,12 @@
 import unittest.mock as mock
 
 from aws_interactions.aws_environment import AwsEnvironment
-from commands.deploy_demo_traffic import cmd_deploy_demo_traffic
+from commands.demo_traffic_deploy import cmd_demo_traffic_deploy
 import core.constants as constants
 
-@mock.patch("commands.deploy_demo_traffic.AwsClientProvider")
-@mock.patch("commands.deploy_demo_traffic.CdkClient")
-def test_WHEN_cmd_deploy_demo_traffic_called_THEN_cdk_command_correct(mock_cdk_client_cls, mock_aws_provider_cls):
+@mock.patch("commands.demo_traffic_deploy.AwsClientProvider")
+@mock.patch("commands.demo_traffic_deploy.CdkClient")
+def test_WHEN_cmd_demo_traffic_deploy_called_THEN_cdk_command_correct(mock_cdk_client_cls, mock_aws_provider_cls):
     # Set up our mock
     mock_client = mock.Mock()
     mock_cdk_client_cls.return_value = mock_client
@@ -17,7 +17,7 @@ def test_WHEN_cmd_deploy_demo_traffic_called_THEN_cdk_command_correct(mock_cdk_c
     mock_aws_provider_cls.return_value = mock_aws_provider
 
     # Run our test
-    cmd_deploy_demo_traffic("profile", "region")
+    cmd_demo_traffic_deploy("profile", "region")
 
     # Check our results
     expected_calls = [

--- a/test_manage_arkime/commands/test_demo_traffic_destroy.py
+++ b/test_manage_arkime/commands/test_demo_traffic_destroy.py
@@ -1,12 +1,12 @@
 import unittest.mock as mock
 
 from aws_interactions.aws_environment import AwsEnvironment
-from commands.destroy_demo_traffic import cmd_destroy_demo_traffic
+from commands.demo_traffic_destroy import cmd_demo_traffic_destroy
 import core.constants as constants
 
-@mock.patch("commands.destroy_demo_traffic.AwsClientProvider")
-@mock.patch("commands.destroy_demo_traffic.CdkClient")
-def test_WHEN_cmd_destroy_demo_traffic_called_THEN_cdk_command_correct(mock_cdk_client_cls, mock_aws_provider_cls):
+@mock.patch("commands.demo_traffic_destroy.AwsClientProvider")
+@mock.patch("commands.demo_traffic_destroy.CdkClient")
+def test_WHEN_cmd_demo_traffic_destroy_called_THEN_cdk_command_correct(mock_cdk_client_cls, mock_aws_provider_cls):
     # Set up our mock
     mock_client = mock.Mock()
     mock_cdk_client_cls.return_value = mock_client
@@ -17,7 +17,7 @@ def test_WHEN_cmd_destroy_demo_traffic_called_THEN_cdk_command_correct(mock_cdk_
     mock_aws_provider_cls.return_value = mock_aws_provider
 
     # Run our test
-    cmd_destroy_demo_traffic("profile", "region")
+    cmd_demo_traffic_destroy("profile", "region")
 
     # Check our results
     expected_calls = [

--- a/test_manage_arkime/commands/test_vpc_remove.py
+++ b/test_manage_arkime/commands/test_vpc_remove.py
@@ -2,19 +2,19 @@ import json
 import shlex
 import unittest.mock as mock
 
-from commands.remove_vpc import cmd_remove_vpc
+from commands.vpc_remove import cmd_vpc_remove
 from aws_interactions.aws_environment import AwsEnvironment
 import aws_interactions.events_interactions as events
 from aws_interactions.ssm_operations import ParamDoesNotExist
 import core.constants as constants
 
 
-@mock.patch("commands.remove_vpc.AwsClientProvider")
-@mock.patch("commands.remove_vpc.SsmVniProvider")
-@mock.patch("commands.remove_vpc.ssm_ops")
-@mock.patch("commands.remove_vpc.events")
-@mock.patch("commands.remove_vpc.CdkClient")
-def test_WHEN_cmd_remove_vpc_called_THEN_removes_mirroring(mock_cdk_client_cls, mock_events, mock_ssm,
+@mock.patch("commands.vpc_remove.AwsClientProvider")
+@mock.patch("commands.vpc_remove.SsmVniProvider")
+@mock.patch("commands.vpc_remove.ssm_ops")
+@mock.patch("commands.vpc_remove.events")
+@mock.patch("commands.vpc_remove.CdkClient")
+def test_WHEN_cmd_vpc_remove_called_THEN_removes_mirroring(mock_cdk_client_cls, mock_events, mock_ssm,
                                                            mock_vni_provider_cls, mock_aws_provider_cls):
     # Set up our mock
     mock_vni_provider = mock.Mock()
@@ -38,7 +38,7 @@ def test_WHEN_cmd_remove_vpc_called_THEN_removes_mirroring(mock_cdk_client_cls, 
     mock_cdk_client_cls.return_value = mock_cdk
 
     # Run our test
-    cmd_remove_vpc("profile", "region", "cluster-1", "vpc-1")
+    cmd_vpc_remove("profile", "region", "cluster-1", "vpc-1")
 
     # Check our results
     expected_cdk_calls = [
@@ -47,7 +47,7 @@ def test_WHEN_cmd_remove_vpc_called_THEN_removes_mirroring(mock_cdk_client_cls, 
                 constants.get_vpc_mirror_setup_stack_name("cluster-1", "vpc-1")
             ],
             context={
-                constants.CDK_CONTEXT_CMD_VAR: constants.CMD_REMOVE_VPC,
+                constants.CDK_CONTEXT_CMD_VAR: constants.CMD_vpc_remove,
                 constants.CDK_CONTEXT_PARAMS_VAR: shlex.quote(json.dumps({
                     "arnEventBus": "bus-1",
                     "nameCluster": "cluster-1",
@@ -79,12 +79,12 @@ def test_WHEN_cmd_remove_vpc_called_THEN_removes_mirroring(mock_cdk_client_cls, 
     expected_vni_calls = [mock.call(1337, "vpc-1")]
     assert expected_vni_calls == mock_vni_provider.relinquish_vni.call_args_list
 
-@mock.patch("commands.remove_vpc.AwsClientProvider", mock.Mock())
-@mock.patch("commands.remove_vpc.SsmVniProvider")
-@mock.patch("commands.remove_vpc.ssm_ops")
-@mock.patch("commands.remove_vpc.events")
-@mock.patch("commands.remove_vpc.CdkClient")
-def test_WHEN_cmd_remove_vpc_called_AND_cluster_doesnt_exist_THEN_aborts(mock_cdk_client_cls, mock_events, mock_ssm, mock_vni_provider_cls):
+@mock.patch("commands.vpc_remove.AwsClientProvider", mock.Mock())
+@mock.patch("commands.vpc_remove.SsmVniProvider")
+@mock.patch("commands.vpc_remove.ssm_ops")
+@mock.patch("commands.vpc_remove.events")
+@mock.patch("commands.vpc_remove.CdkClient")
+def test_WHEN_cmd_vpc_remove_called_AND_cluster_doesnt_exist_THEN_aborts(mock_cdk_client_cls, mock_events, mock_ssm, mock_vni_provider_cls):
     # Set up our mock
     mock_vni_provider = mock.Mock()
     mock_vni_provider_cls.return_value = mock_vni_provider
@@ -96,7 +96,7 @@ def test_WHEN_cmd_remove_vpc_called_AND_cluster_doesnt_exist_THEN_aborts(mock_cd
     mock_cdk_client_cls.return_value = mock_cdk
 
     # Run our test
-    cmd_remove_vpc("profile", "region", "cluster-1", "vpc-1")
+    cmd_vpc_remove("profile", "region", "cluster-1", "vpc-1")
 
     # Check our results
     expected_cdk_calls = []


### PR DESCRIPTION
## Description
* Changed the CLI command names to use reverse-Polish notation

## Tasks
* https://github.com/arkime/aws-aio/issues/86

## Testing
* Ran unit tests
* Ran a couple CLI commands:

```
2023-07-27 15:07:24 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
Usage: manage_arkime.py [OPTIONS] COMMAND [ARGS]...

  Command-line tool to create/manage Arkime clusters in an AWS Account.  Uses
  the credentials in your AWS profile to determine which account it will act
  against.

Options:
  --profile TEXT  The AWS credential profile to perform the operation with.
                  Uses 'default' if not supplied.
  --region TEXT   The AWS Region to perform the operation in.  Uses your AWS
                  Config default if not supplied.
  --help          Show this message and exit.

Commands:
  cluster-create        Creates an Arkime Cluster in your account
  cluster-destroy       Tears down the Arkime Cluster in your account; by...
  clusters-list         Lists the currently deployed Arkime Clusters and...
  config-update         Updates specified Arkime Cluster's Capture/Viewer...
  demo-traffic-deploy   Uses CDK to deploy a sample traffic source to...
  demo-traffic-destroy  Uses CDK to destroy previously-deployed sample...
  get-login-details     Retrieves the login details of a cluster's the...
  vpc-add               Sets up the specified VPC to have its traffic...
  vpc-remove            Removes traffic monitoring from the specified VPC...
```

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py clusters-list
2023-07-27 15:06:41 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-07-27 15:06:41 - Using AWS Credential Profile: default
2023-07-27 15:06:41 - Using AWS Region: default from AWS Config settings
2023-07-27 15:06:41 - Retrieving cluster details...
2023-07-27 15:06:43 - Deployed Clusters:
[
    {
        "cluster_name": "MyCluster",
        "monitored_vpcs": []
    },
    {
        "cluster_name": "MyCluster3",
        "monitored_vpcs": [
            {
                "vpc_id": "vpc-008d258d7c536384b",
                "vni": "15"
            }
        ]
    }
]
```

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
