### PR TITLE
Provide a cost estimate for cluster-create

### DIFF
--- a/manage_arkime/core/price_report.py
+++ b/manage_arkime/core/price_report.py
@@ -1,0 +1,79 @@
+from core.capacity_planning import ClusterPlan
+from core.user_config import UserConfig
+from typing import Dict
+from dataclasses import dataclass
+import math
+
+AWS_HOURS_PER_MONTH=730
+AWS_SECS_PER_MONTH=60*60*AWS_HOURS_PER_MONTH
+
+us_east_1_prices: Dict[str, float] = {
+    "t3.small.search": 0.0360 * AWS_HOURS_PER_MONTH,
+    "m5.large.search": 0.1420 * AWS_HOURS_PER_MONTH,
+    "m6g.large.search": 0.1280  * AWS_HOURS_PER_MONTH,
+    "c6g.2xlarge.search": 0.4520 * AWS_HOURS_PER_MONTH,
+    "r6g.large.search": 0.1670 * AWS_HOURS_PER_MONTH,
+    "r6g.2xlarge.search": 0.6690 * AWS_HOURS_PER_MONTH,
+    "r6g.4xlarge.search": 1.3390 * AWS_HOURS_PER_MONTH,
+    "r6g.12xlarge.search": 4.0160 * AWS_HOURS_PER_MONTH,
+    "m5.xlarge": 0.1920 * AWS_HOURS_PER_MONTH,
+
+    "s3-STANDARD-50-GB": 0.023, # https://aws.amazon.com/s3/pricing/
+    "s3-STANDARD-450-GB": 0.022,
+    "s3-STANDARD-REST-GB": 0.021,
+    "ebs-GB": 0.10, # https://aws.amazon.com/ebs/pricing/
+    "gwlb-GB": 0.004, # https://aws.amazon.com/elasticloadbalancing/pricing/?nc=sn&loc=3
+    "gwlbe-GB": 0.0035, # https://aws.amazon.com/privatelink/pricing/
+
+    "fargate": 0.04048 * AWS_HOURS_PER_MONTH, # https://aws.amazon.com/fargate/pricing/
+
+    "trafficmirror": 0.015 * AWS_HOURS_PER_MONTH, # https://aws.amazon.com/vpc/pricing/
+}
+
+
+@dataclass
+class PriceReport:
+    plan: ClusterPlan
+    config: UserConfig
+    prices = us_east_1_prices # ALW - Not sure how to do type hint, was getting errors
+
+    total: float = 0 # ALW - Not sure how to do a class variable that isn't passed in
+
+    def _line(self, name: str, key: str, num: float) -> str:
+        if key == "total":
+            return f"   {name:23}                             ${self.total:10.2f}/mo\n"
+
+        if num <= 0:
+            return ""
+
+        cost: float = self.prices[key]
+        self.total += cost * num
+        if key.endswith("-GB"):
+            return f"   {name:23} {num:9,} * ${cost:9.4f}/GB = ${cost * num:10.2f}/mo\n"
+        else:
+            return f"   {name:23} {num:9,} * ${cost:9.4f}/mo = ${cost * num:10.2f}/mo\n"
+
+    def get_report(self) -> str:
+        expectedTraffic = self.config.expectedTraffic/8
+        # Expect to only saving 25% of pcap because of TLS and zlib
+        s3 = math.ceil(self.plan.s3.pcapStorageDays * expectedTraffic * 0.25 * 60 * 60 * 24)
+        report_text = (
+            "OnDemand us-east-1 cost estimate, your cost may be different based on region, discounts or reserve instances:\n"
+            + "Fixed:\n"
+            + self._line("Capture", self.plan.captureNodes.instanceType, self.plan.captureNodes.desiredCount)
+            + self._line("Viewer", "fargate", 2) # ALW - Not sure where to get number of viewer nodes from
+            + self._line("OS Master Node", self.plan.osDomain.masterNodes.instanceType, self.plan.osDomain.masterNodes.count)
+            + self._line("OS Data Node", self.plan.osDomain.dataNodes.instanceType, self.plan.osDomain.dataNodes.count)
+            + self._line("OS Storage", "ebs-GB", self.plan.osDomain.dataNodes.count*self.plan.osDomain.dataNodes.volumeSize)
+            + "Variable:\n"
+            + self._line("PCAP Storage first 50TB", "s3-STANDARD-50-GB", min(s3, 50000))
+            + self._line("PCAP Storage next 450TB", "s3-STANDARD-450-GB", min(s3 - 50000, 450000))
+            + self._line("PCAP Storage", "s3-STANDARD-REST-GB", s3 - 500000)
+            + self._line("GWLB", "gwlb-GB", math.ceil(expectedTraffic * AWS_SECS_PER_MONTH))
+            + self._line("GWLBE", "gwlbe-GB", math.ceil(expectedTraffic * AWS_SECS_PER_MONTH))
+            + self._line("Traffic Mirror/ENI", "trafficmirror", 1)
+            + "Total:\n"
+            + self._line("", "total", 0)
+
+        )
+        return report_text

--- a/test_manage_arkime/commands/test_cluster_create.py
+++ b/test_manage_arkime/commands/test_cluster_create.py
@@ -159,7 +159,7 @@ def test_WHEN_cmd_cluster_create_called_AND_abort_usage_THEN_as_expected(mock_cd
 
     expected_set_up_calls = []
     assert expected_set_up_calls == mock_set_up.call_args_list
-    
+
     expected_configure_calls = []
     assert expected_configure_calls == mock_configure.call_args_list
 
@@ -416,7 +416,8 @@ def test_WHEN_get_next_capacity_plan_called_THEN_as_expected(mock_ssm_ops, mock_
     assert expected_get_os_calls == mock_get_os.call_args_list
 
 @mock.patch("commands.cluster_create.UsageReport")
-def test_WHEN_confirm_usage_called_THEN_as_expected(mock_report_cls):
+@mock.patch("commands.cluster_create.PriceReport")
+def test_WHEN_confirm_usage_called_THEN_as_expected(mock_price_report_cls, mock_report_cls):
     # Shared Setup
     mock_plan_prev = mock.Mock()
     mock_plan_next = mock.Mock()
@@ -424,12 +425,15 @@ def test_WHEN_confirm_usage_called_THEN_as_expected(mock_report_cls):
     mock_config_next = mock.Mock()
     mock_report = mock.Mock()
     mock_report_cls.return_value = mock_report
-    
+    mock_price_report = mock.Mock()
+    mock_price_report_cls.return_value = mock_price_report
+
     # TEST: pre-confirm is true
     actual_value = _confirm_usage(mock_plan_prev, mock_plan_next, mock_config_prev, mock_config_next, True)
 
     assert True == actual_value
     assert not mock_report.get_confirmation.called
+    assert mock_price_report.get_report.called
 
     # TEST: pre-confirm is false, user says yes
     mock_report.get_confirmation.return_value = True
@@ -570,7 +574,7 @@ def test_WHEN_set_up_arkime_config_called_AND_happy_path_THEN_as_expected(mock_s
     test_viewer_tarball = local_file.TarGzDirectory("/viewer", "/viewer.tgz")
     test_viewer_tarball._exists = True
     mock_get_viewer_archive.return_value = test_viewer_tarball
-    
+
     capture_metadata = config_wrangling.ConfigDetails(
         s3=config_wrangling.S3Details(bucket_name, capture_s3_key),
         version=VersionInfo("1", "1", "abcd1234", "v1-1-12312", "2023-01-01 01:01:01")
@@ -661,7 +665,7 @@ def test_WHEN_set_up_arkime_config_called_AND_config_exists_THEN_as_expected(moc
     test_viewer_tarball = local_file.TarGzDirectory("/viewer", "/viewer.tgz")
     test_viewer_tarball._exists = True
     mock_get_viewer_archive.return_value = test_viewer_tarball
-    
+
     capture_metadata = config_wrangling.ConfigDetails(
         s3=config_wrangling.S3Details(bucket_name, capture_s3_key),
         version=VersionInfo("1", "1", "abcd1234", "v1-1-12312", "2023-01-01 01:01:01")

--- a/test_manage_arkime/core/test_price_report.py
+++ b/test_manage_arkime/core/test_price_report.py
@@ -1,0 +1,40 @@
+
+import unittest.mock as mock
+
+import core.capacity_planning as cap
+from core.price_report import PriceReport
+from core.user_config import UserConfig
+
+def test_WHEN_PriceReport_get_report_THEN_as_expected():
+    # Set up the test
+    plan = cap.ClusterPlan(
+        cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
+        cap.CaptureVpcPlan(1),
+        cap.EcsSysResourcePlan(1, 1),
+        cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
+        cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30)
+    )
+    config = UserConfig(0.5, 30, 365, 1, 120)
+
+    # Run the test
+    actual_report = PriceReport(plan, config).get_report()
+
+    # Check the results
+    expected_report = (
+      "OnDemand us-east-1 cost estimate, your cost may be different based on region, discounts or reserve instances:\n"
+      + "Fixed:\n"
+      + "   Capture                         1 * $ 140.1600/mo = $    140.16/mo\n"
+      + "   Viewer                          2 * $  29.5504/mo = $     59.10/mo\n"
+      + "   OS Master Node                  3 * $  93.4400/mo = $    280.32/mo\n"
+      + "   OS Data Node                    2 * $  26.2800/mo = $     52.56/mo\n"
+      + "   OS Storage                    200 * $   0.1000/GB = $     20.00/mo\n"
+      + "Variable:\n"
+      + "   PCAP Storage first 50TB    40,500 * $   0.0230/GB = $    931.50/mo\n"
+      + "   GWLB                      164,250 * $   0.0040/GB = $    657.00/mo\n"
+      + "   GWLBE                     164,250 * $   0.0035/GB = $    574.88/mo\n"
+      + "   Traffic Mirror/ENI              1 * $  10.9500/mo = $     10.95/mo\n"
+      + "Total:\n"
+      + "                                                       $   2726.47/mo\n"
+    )
+
+    assert expected_report == actual_report


### PR DESCRIPTION
This is an initial version of providing a cost estimate when doing a cluster-create. It uses hard coded ondemand us-east-1 prices. The class allows you to pass in prices for the future where we query the pricing api.

`./manage_arkime.py cluster-create --replicas 1 --name MyCluster --spi-days 30 --expected-traffic 1 --history-days 120 --pcap-days 30`

```
2023-07-31 14:32:30 - Cost estimate report:
OnDemand us-east-1 cost estimate, your cost may be different based on region, discounts or reserve instances:
Fixed:
   Capture                         1 * $ 140.1600/mo = $    140.16/mo
   Viewer                          2 * $  29.5504/mo = $     59.10/mo
   OS Master Node                  3 * $ 329.9600/mo = $    989.88/mo
   OS Data Node                   20 * $ 121.9100/mo = $   2438.20/mo
   OS Storage                 20,480 * $   0.1000/GB = $   2048.00/mo
Variable:
   PCAP Storage first 50TB    50,000 * $   0.0230/GB = $   1150.00/mo
   PCAP Storage next 450TB    31,000 * $   0.0220/GB = $    682.00/mo
   GWLB                      328,500 * $   0.0040/GB = $   1314.00/mo
   GWLBE                     328,500 * $   0.0035/GB = $   1149.75/mo
   Traffic Mirror/ENI              1 * $  10.9500/mo = $     10.95/mo
Total:
                                                       $   9982.04/mo
```

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
