### PR TITLE
Fixed a us-east-1 specific bug in S3 bucket creation code

### DIFF
--- a/manage_arkime/aws_interactions/s3_interactions.py
+++ b/manage_arkime/aws_interactions/s3_interactions.py
@@ -58,14 +58,17 @@ def create_bucket(bucket_name: str, aws_provider: AwsClientProvider):
     aws_env = aws_provider.get_aws_env()
 
     try:
-        s3_client.create_bucket(
-            ACL="private",
-            Bucket=bucket_name,
-            CreateBucketConfiguration={
+        create_args = {
+            "ACL": "private",
+            "Bucket": bucket_name,
+            "ObjectOwnership": "BucketOwnerPreferred"
+        }
+
+        if aws_env.aws_region != "us-east-1":
+            create_args["CreateBucketConfiguration"] = {
                 "LocationConstraint": aws_env.aws_region
-            },
-            ObjectOwnership="BucketOwnerPreferred"
-        )
+            }
+        s3_client.create_bucket(**create_args)
     except ClientError as ex:
         if "BucketAlreadyOwnedByYou" in str(ex):
             logger.debug(f"Bucket {bucket_name} already exists and is owned by this account")

--- a/test_manage_arkime/aws_interactions/test_s3_interactions.py
+++ b/test_manage_arkime/aws_interactions/test_s3_interactions.py
@@ -37,13 +37,19 @@ def test_WHEN_create_bucket_called_THEN_as_expected():
     # Set up our mock    
     mock_s3_client = mock.Mock()
     test_env = AwsEnvironment("XXXXXXXXXXX", "my-region-1", "profile")
+    test_env_use1 = AwsEnvironment("XXXXXXXXXXX", "us-east-1", "profile")
 
     mock_aws_provider = mock.Mock()
     mock_aws_provider.get_s3.return_value = mock_s3_client
-    mock_aws_provider.get_aws_env.return_value = test_env
 
     # TEST: Bucket doesn't exist and we create it
+    mock_aws_provider.get_aws_env.return_value = test_env
     s3.create_bucket("bucket-name", mock_aws_provider)
+
+    mock_aws_provider.get_aws_env.return_value = test_env_use1
+    s3.create_bucket("bucket-name", mock_aws_provider)
+
+
     create_bucket_calls = [
         mock.call(        
             ACL="private",
@@ -51,6 +57,11 @@ def test_WHEN_create_bucket_called_THEN_as_expected():
             CreateBucketConfiguration={
                 "LocationConstraint": "my-region-1"
             },
+            ObjectOwnership="BucketOwnerPreferred"
+        ),
+        mock.call(        
+            ACL="private",
+            Bucket="bucket-name",
             ObjectOwnership="BucketOwnerPreferred"
         )
     ]


### PR DESCRIPTION
## Description
* The S3 API has a number of quirky behaviors around regionality.  This change fixes a bug in the CLI's bucket creation code when specifically targeting `us-east-1`.

## Tasks
* N/A

## Testing
* Updated unit tests
* Ran `cluster-create` w/ `us-east-1`

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py --region us-east-1 cluster-create --name MyCluster
2023-08-02 08:55:47 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-08-02 08:55:47 - Using AWS Credential Profile: default
2023-08-02 08:55:47 - Using AWS Region: us-east-1
2023-08-02 08:55:48 - ================================================================================
2023-08-02 08:55:48 - USER ACTION REQUIRED:
2023-08-02 08:55:48 - --------------------------------------------------------------------------------
Your settings will result in the follow AWS Resource usage:
Arkime Metadata:
    Session Retention [days]: 30
    User History Retention [days]: 365
Capture Nodes:
    Max Count: 2
    Desired Count: 1
    Min Count: 1
    Type: m5.xlarge
OpenSearch Domain:
    Master Node Count: 3
    Master Node Type: m5.large.search
    Data Node Count: 2
    Data Node Type: t3.small.search
    Data Node Volume Size [GB]: 100
S3:
    PCAP Retention [days]: 30

Do you approve this usage (y/yes or n/no)? y
2023-08-02 08:55:52 - Ensuring Arkime Config dir exists for cluster: MyCluster
2023-08-02 08:55:52 - Arkime Config dir exists at: /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster
2023-08-02 08:55:52 - Copying default Arkime Config to dir: /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster
2023-08-02 08:55:52 - Cluster config directory not empty; skipping copy
2023-08-02 08:55:53 - Determining the status of S3 bucket: arkimeconfig-XXXXXXXXXXXX-us-east-1-mycluster
2023-08-02 08:55:53 - S3 Bucket arkimeconfig-XXXXXXXXXXXX-us-east-1-mycluster does not exist; creating it to hold Arkime Configuration
2023-08-02 08:55:54 - Uploading Arkime config for Capture Nodes...
2023-08-02 08:55:55 - Turning Capture configuration at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster/capture into archive at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster/capture.zip
2023-08-02 08:55:55 - Uploading config archive to S3 bucket: arkimeconfig-XXXXXXXXXXXX-us-east-1-mycluster
2023-08-02 08:55:56 - Uploading Arkime config for Viewer Nodes...
2023-08-02 08:55:56 - Turning Viewer configuration at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster/viewer into archive at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster/viewer.zip
2023-08-02 08:55:56 - Uploading config archive to S3 bucket: arkimeconfig-XXXXXXXXXXXX-us-east-1-mycluster
2023-08-02 08:55:57 - Executing command: deploy MyCluster-CaptureBucket MyCluster-CaptureNodes MyCluster-CaptureVPC MyCluster-OSDomain MyCluster-ViewerNodes
```

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
