### PR TITLE
Add more instance types for master and capture nodes

### DIFF
--- a/manage_arkime/cdk_interactions/cdk_context.py
+++ b/manage_arkime/cdk_interactions/cdk_context.py
@@ -3,8 +3,8 @@ import shlex
 from typing import Dict, List
 
 import core.constants as constants
-from core.capacity_planning import (CaptureNodesPlan, CaptureVpcPlan, ClusterPlan, DataNodesPlan, EcsSysResourcePlan, 
-                                    MasterNodesPlan, OSDomainPlan, INSTANCE_TYPE_CAPTURE_NODE, DEFAULT_NUM_AZS, S3Plan,
+from core.capacity_planning import (CaptureNodesPlan, CaptureVpcPlan, ClusterPlan, DataNodesPlan, EcsSysResourcePlan,
+                                    MasterNodesPlan, OSDomainPlan, DEFAULT_NUM_AZS, S3Plan,
                                     DEFAULT_S3_STORAGE_CLASS)
 from core.user_config import UserConfig
 
@@ -26,7 +26,7 @@ def generate_cluster_destroy_context(name: str) -> Dict[str, str]:
     # or it fails/rolls back they are irrelevant.
     fake_arn = "N/A"
     fake_cluster_plan = ClusterPlan(
-        CaptureNodesPlan(INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
+        CaptureNodesPlan("m5.xlarge", 1, 2, 1),
         CaptureVpcPlan(2),
         EcsSysResourcePlan(1, 1),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),

--- a/manage_arkime/commands/cluster_create.py
+++ b/manage_arkime/commands/cluster_create.py
@@ -76,7 +76,7 @@ def _get_previous_user_config(cluster_name: str, aws_provider: AwsClientProvider
             "userConfig",
             aws_provider
         )
-        return UserConfig(**stored_config_json)
+        return UserConfig.from_dict(stored_config_json)
 
     # Existing config doesn't exist; return a blank config
     except ssm_ops.ParamDoesNotExist:

--- a/manage_arkime/core/capacity_planning.py
+++ b/manage_arkime/core/capacity_planning.py
@@ -1,13 +1,12 @@
 from dataclasses import dataclass
 import math
 import logging
+import sys
 from typing import Dict, Type, TypeVar
 
 
 logger = logging.getLogger(__name__)
 
-INSTANCE_TYPE_CAPTURE_NODE = "m5.xlarge" # Arbitrarily chosen
-TRAFFIC_PER_M5_XL = 2 # in Gbps, guestimate, should be updated with experimental data
 MAX_TRAFFIC = 100 # Gbps, scaling limit of a single User Subnet VPC Endpoint
 MINIMUM_NODES = 1 # We'll always have at least one capture node
 MINIMUM_TRAFFIC = 0.01 # Gbps; arbitrarily chosen, but will yield a minimal cluster
@@ -17,6 +16,73 @@ DEFAULT_SPI_DAYS = 30 # How many days of SPI metadata to keep in the OS Domain
 DEFAULT_REPLICAS = 1 # How replicas of metadata to keep in the OS Domain
 DEFAULT_HISTORY_DAYS = 365 # How many days of Arkime Viewer user history to keep in the OS Domain
 DEFAULT_NUM_AZS = 2 # How many AWS Availability zones to utilize
+
+# These are the possible instances types we assign for capture nodes based on maxTraffic
+CAPTURE_INSTANCES = [
+    {
+        "instanceType": "t3.medium",
+        "maxTraffic": 0.5,
+        "trafficPer": 0.25,
+        "ecsCPU": 1536, # 1.5 vCPUs
+        "ecsMemory": 3072 # 3 GiB
+    },
+    {
+        "instanceType": "m5.xlarge",
+        "maxTraffic": MAX_TRAFFIC,
+        "trafficPer": 2.0,
+        "ecsCPU": 3584, # 3.5 vCPUs
+        "ecsMemory": 15360 # 15 GiB
+    }
+]
+
+# These are the possible instances types we assign for master nodes based on isArm, maxShards, maxNodes
+# Can't mix graviton and non-graviton instance types so we have Arm and non Arm instance types.
+MASTER_INSTANCES = [
+### Non-ARM
+    {
+        "instanceType": "t3.small.search",
+        "isArm": False,
+        "maxShards": sys.maxsize,
+        "maxNodes": 3
+    },
+    {
+        "instanceType": "t3.medium.search",
+        "isArm": False,
+        "maxShards": sys.maxsize,
+        "maxNodes": 6
+    },
+    {
+        "instanceType": "m5.large",
+        "isArm": False,
+        "maxShards": sys.maxsize,
+        "maxNodes": sys.maxsize
+    },
+### ARM
+    {
+        "instanceType": "m6g.large.search",
+        "isArm": True,
+        "maxShards": 10000,
+        "maxNodes": 10
+    },
+    {
+        "instanceType": "c6g.2xlarge.search",
+        "isArm": True,
+        "maxShards": 30000,
+        "maxNodes": 30
+    },
+    {
+        "instanceType": "r6g.2xlarge.search",
+        "isArm": True,
+        "maxShards": 75000,
+        "maxNodes": 125
+    },
+    {
+        "instanceType": "r6g.4xlarge.search",
+        "isArm": True,
+        "maxShards": sys.maxsize,
+        "maxNodes": sys.maxsize
+    },
+]
 
 class TooMuchTraffic(Exception):
     def __init__(self, expected_traffic: int):
@@ -51,15 +117,18 @@ def get_capture_node_capacity_plan(expected_traffic: float) -> CaptureNodesPlan:
     expected_traffic: The expected traffic volume for the Arkime cluster, in Gigabits Per Second (Gbps)
     """
 
-    if not expected_traffic or expected_traffic < TRAFFIC_PER_M5_XL:
-        desired_instances = MINIMUM_NODES
-    elif expected_traffic > MAX_TRAFFIC:
+    if not expected_traffic or expected_traffic < MINIMUM_TRAFFIC:
+        expected_traffic = MINIMUM_TRAFFIC
+
+    if expected_traffic > MAX_TRAFFIC:
         raise TooMuchTraffic(expected_traffic)
-    else:
-        desired_instances = math.ceil(expected_traffic/TRAFFIC_PER_M5_XL)
+
+    chosen_instance = next(instance for instance in CAPTURE_INSTANCES if expected_traffic <= instance["maxTraffic"])
+
+    desired_instances = math.ceil(expected_traffic/chosen_instance["trafficPer"])
 
     return CaptureNodesPlan(
-        INSTANCE_TYPE_CAPTURE_NODE,
+        chosen_instance["instanceType"],
         desired_instances,
         math.ceil(desired_instances * CAPACITY_BUFFER_FACTOR),
         MINIMUM_NODES
@@ -90,18 +159,11 @@ def get_ecs_sys_resource_plan(instance_type: str) -> EcsSysResourcePlan:
     instance_type: The instance type to plan for
     """
 
-    if instance_type == INSTANCE_TYPE_CAPTURE_NODE:
-        # We want the full capacity of our m5.xlarge because we're using HOST network type and therefore won't
-        # place multiple containers on a single host.  However, we can't ask for ALL of its resources (ostensibly,
-        # 4 vCPU and 16 GiB) because then ECS placement will fail.  We therefore ask for a slightly reduced
-        # amount.  This is the minimum amount we're requesting ECS to reserve, so it can't reserve more than
-        # exist.
-        return EcsSysResourcePlan(
-            3584, # 3.5 vCPUs
-            15360 # 15 GiB
-        )
-    else:
+    chosen_instance = next((instance for instance in CAPTURE_INSTANCES if instance_type == instance["instanceType"]), None)
+    if chosen_instance == None:
         raise UnknownInstanceType(instance_type)
+    else:
+        return EcsSysResourcePlan(chosen_instance["ecsCPU"], chosen_instance["ecsMemory"])
 
 
 """
@@ -142,7 +204,7 @@ class DataNodesPlan:
             "instanceType": self.instanceType,
             "volumeSize": self.volumeSize
         }
-    
+
 @dataclass
 class MasterNodesPlan:
     count: int
@@ -173,13 +235,13 @@ class OSDomainPlan:
             "dataNodes": self.dataNodes.to_dict(),
             "masterNodes": self.masterNodes.to_dict()
         }
-    
+
     @classmethod
     def from_dict(cls: Type[T_OSDomainPlan], input: Dict[str, any]) -> T_OSDomainPlan:
         data_nodes = DataNodesPlan(**input["dataNodes"])
         master_nodes = MasterNodesPlan(**input["masterNodes"])
         return cls(data_nodes, master_nodes)
-    
+
 def _get_storage_per_replica(expected_traffic: float, spi_days: int) -> float:
     """
     Predict the required OpenSearch domain storage for each replica, in GiB
@@ -206,7 +268,7 @@ def _get_data_node_plan(total_storage: float, num_azs: int) -> DataNodesPlan:
     than 80 of the largest instance type can provide, they'll bump the limit out of band and just keep getting more of
     that largest instance type. There's also an apparent incentive to have more, smaller nodes than fewer, larger
     nodes [2].
-    
+
     We ensure there are at least two data nodes of whichever type is selected for the
     capacity plan.
 
@@ -243,7 +305,7 @@ def _get_data_node_plan(total_storage: float, num_azs: int) -> DataNodesPlan:
 
 def _get_master_node_plan(storage_per_replica: float, data_node_count: int, data_node_type: str) -> MasterNodesPlan:
     """
-    We follow the sizing recommendation in the docs [1].  One complicating 
+    We follow the sizing recommendation in the docs [1].  One complicating
 
     [1] https://docs.aws.amazon.com/opensearch-service/latest/developerguide/managedomains-dedicatedmasternodes.html
 
@@ -252,28 +314,25 @@ def _get_master_node_plan(storage_per_replica: float, data_node_count: int, data
 
     # Arkime is a write-heavy usecase so recommended data/shard is 30-50 GiB, per the docs.
     # See: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/sizing-domains.html#bp-sharding
-    storage_per_shard = 40 # GiB
+    # Although https://docs.aws.amazon.com/opensearch-service/latest/developerguide/petabyte-scale.html
+    # says 100GiB is ok.
+    storage_per_shard = 50 # GiB
     num_shards = math.ceil(storage_per_replica / storage_per_shard)
+    isArm = not data_node_type.startswith("t3")
 
-    if data_node_type == T3_SMALL_SEARCH.type:
-        # You can't mix graviton and non-graviton instance types across the data/master node roles.  Additionally,
-        # there are no "toy"-class graviton data node instance types.  Therefore, we need this (hacky) check to
-        # make sure we're using a compatible type.
-        node_type = "m5.large.search"
-    elif num_shards <= 10000 and data_node_count <= 10:
-        node_type = "m6g.large.search"
-    elif num_shards <= 30000 and data_node_count <= 30:
-        node_type = "c6g.2xlarge.search"
-    elif num_shards <= 75000 and data_node_count <= 125:
-        node_type = "r6g.2xlarge.search"
-    else:
-        node_type = "r6g.4xlarge.search"
+    chosen_instance = next(
+        instance for instance in MASTER_INSTANCES if (
+            isArm == instance["isArm"]
+            and num_shards <= instance["maxShards"]
+            and data_node_count <= instance["maxNodes"]
+        )
+    )
 
     return MasterNodesPlan(
         count = MASTER_NODE_COUNT,
-        instanceType = node_type
+        instanceType = chosen_instance["instanceType"]
     )
-    
+
 def get_os_domain_plan(expected_traffic: float, spi_days: int, replicas: int, num_azs: int) -> OSDomainPlan:
     """
     Get the OpenSearch Domain capacity required to satisify the expected traffic
@@ -298,12 +357,12 @@ class CaptureVpcPlan:
 
     def __equal__(self, other) -> bool:
         return self.numAzs == other.numAzs
-    
+
     def to_dict(self) -> Dict[str, any]:
         return {
             "numAzs": self.numAzs
         }
-    
+
 DEFAULT_S3_STORAGE_CLASS = "STANDARD"
 DEFAULT_S3_STORAGE_DAYS = 30
 
@@ -314,13 +373,13 @@ class S3Plan:
 
     def __equal__(self, other) -> bool:
         return self.pcapStorageClass == other.pcapStorageClass and self.pcapStorageDays == other.pcapStorageDays
-    
+
     def to_dict(self) -> Dict[str, any]:
         return {
             "pcapStorageClass": self.pcapStorageClass,
             "pcapStorageDays": self.pcapStorageDays
         }
-    
+
 T_ClusterPlan = TypeVar('T_ClusterPlan', bound='ClusterPlan')
 
 @dataclass
@@ -332,7 +391,7 @@ class ClusterPlan:
     s3: S3Plan
 
     def __equal__(self, other) -> bool:
-        return (self.captureNodes == other.captureNodes and self.ecsResources == other.ecsResources 
+        return (self.captureNodes == other.captureNodes and self.ecsResources == other.ecsResources
                 and self.osDomain == other.osDomain and self.captureVpc == other.vpc and self.s3 == other.s3)
 
     def to_dict(self) -> Dict[str, any]:
@@ -343,7 +402,7 @@ class ClusterPlan:
             "osDomain": self.osDomain.to_dict(),
             "s3": self.s3.to_dict(),
         }
-    
+
     @classmethod
     def from_dict(cls: Type[T_ClusterPlan], input: Dict[str, any]) -> T_ClusterPlan:
         capture_nodes = CaptureNodesPlan(**input["captureNodes"])
@@ -353,4 +412,4 @@ class ClusterPlan:
         s3 = S3Plan(**input["s3"])
 
         return cls(capture_nodes, capture_vpc, ecs_resources, os_domain, s3)
-    
+

--- a/manage_arkime/core/capacity_planning.py
+++ b/manage_arkime/core/capacity_planning.py
@@ -44,7 +44,7 @@ MASTER_INSTANCES = [
 ### Non-ARM
     MasterInstance("t3.small.search", False, sys.maxsize, 3),
     MasterInstance("t3.medium.search", False, sys.maxsize, 6),
-    MasterInstance("m5.large", False, sys.maxsize, sys.maxsize),
+    MasterInstance("m5.large.search", False, sys.maxsize, sys.maxsize),
 ### ARM
     MasterInstance("m6g.large.search", True, 10000, 10),
     MasterInstance("c6g.2xlarge.search", True, 30000, 30),

--- a/manage_arkime/core/price_report.py
+++ b/manage_arkime/core/price_report.py
@@ -10,6 +10,7 @@ AWS_SECS_PER_MONTH=60*60*AWS_HOURS_PER_MONTH
 US_EAST_1_PRICES: Dict[str, float] = {
     # https://aws.amazon.com/opensearch-service/pricing/
     "t3.small.search": 0.0360 * AWS_HOURS_PER_MONTH,
+    "t3.medium.search": 0.0730 * AWS_HOURS_PER_MONTH,
     "m5.large.search": 0.1420 * AWS_HOURS_PER_MONTH,
     "m6g.large.search": 0.1280  * AWS_HOURS_PER_MONTH,
     "c6g.2xlarge.search": 0.4520 * AWS_HOURS_PER_MONTH,
@@ -18,11 +19,15 @@ US_EAST_1_PRICES: Dict[str, float] = {
     "r6g.4xlarge.search": 1.3390 * AWS_HOURS_PER_MONTH,
     "r6g.12xlarge.search": 4.0160 * AWS_HOURS_PER_MONTH,
 
+    # https://aws.amazon.com/ec2/pricing/on-demand/
+    "t3.medium": 0.0416 * AWS_HOURS_PER_MONTH,
     "m5.xlarge": 0.1920 * AWS_HOURS_PER_MONTH,
 
-    "s3-STANDARD-50-GB": 0.023, # https://aws.amazon.com/s3/pricing/
+    # https://aws.amazon.com/s3/pricing/
+    "s3-STANDARD-50-GB": 0.023,
     "s3-STANDARD-450-GB": 0.022,
     "s3-STANDARD-REST-GB": 0.021,
+
     "ebs-GB": 0.10, # https://aws.amazon.com/ebs/pricing/
     "gwlb-GB": 0.004, # https://aws.amazon.com/elasticloadbalancing/pricing/?nc=sn&loc=3
     "gwlbe-GB": 0.0035, # https://aws.amazon.com/privatelink/pricing/
@@ -61,7 +66,7 @@ class PriceReport:
         s3 = math.ceil(self._plan.s3.pcapStorageDays * expectedTraffic * 0.25 * 60 * 60 * 24)
         report_text = (
             "OnDemand us-east-1 cost estimate, your cost may be different based on region, discounts or reserve instances:\n"
-            + "Fixed:\n"
+            + "Allocated:\n"
             + self._line("Capture", self._plan.captureNodes.instanceType, self._plan.captureNodes.desiredCount)
             + self._line("Viewer", "fargate", 2)
             + self._line("OS Master Node", self._plan.osDomain.masterNodes.instanceType, self._plan.osDomain.masterNodes.count)
@@ -70,7 +75,7 @@ class PriceReport:
             + "Variable:\n"
             + self._line("PCAP Storage first 50TB", "s3-STANDARD-50-GB", min(s3, 50000))
             + self._line("PCAP Storage next 450TB", "s3-STANDARD-450-GB", min(s3 - 50000, 450000))
-            + self._line("PCAP Storage", "s3-STANDARD-REST-GB", s3 - 500000)
+            + self._line("PCAP Storage remaining", "s3-STANDARD-REST-GB", s3 - 500000)
             + self._line("GWLB", "gwlb-GB", math.ceil(expectedTraffic * AWS_SECS_PER_MONTH))
             + self._line("GWLBE", "gwlbe-GB", math.ceil(expectedTraffic * AWS_SECS_PER_MONTH))
             + self._line("Traffic Mirror/ENI", "trafficmirror", 1)

--- a/manage_arkime/core/user_config.py
+++ b/manage_arkime/core/user_config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 import logging
 from typing import Dict
 
@@ -12,8 +12,15 @@ class UserConfig:
     replicas: int
     pcapDays: int
 
+    """ Only process fields we still need, this allows us to ignore config no longer used """
+    @classmethod
+    def from_dict(cls, d):
+        valid_keys = {f.name for f in fields(cls)}
+        valid_kwargs = {key: value for key, value in d.items() if key in valid_keys}
+        return cls(**valid_kwargs)
+
     def __equal__(self, other):
-        return (self.expectedTraffic == other.expectedTraffic and self.spiDays == other.spiDays 
+        return (self.expectedTraffic == other.expectedTraffic and self.spiDays == other.spiDays
                 and self.replicas == other.replicas and self.pcapDays == other.pcapDays and self.historyDays == other.historyDays)
 
     def to_dict(self) -> Dict[str, any]:

--- a/test_manage_arkime/core/test_capacity_planning.py
+++ b/test_manage_arkime/core/test_capacity_planning.py
@@ -2,33 +2,35 @@ import pytest
 
 import core.capacity_planning as cap
 
+INSTANCE_TYPE_CAPTURE_NODE = "m5.xlarge";
+
 
 def test_WHEN_get_capture_node_capacity_plan_called_THEN_as_expected():
     # TEST 1: No expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(None)
-    expected_value = cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1)
+    expected_value = cap.CaptureNodesPlan(cap.CAPTURE_INSTANCES[0]["instanceType"], 1, 2, 1)
 
     assert expected_value == actual_value
-    
+
     # TEST 2: Small expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(0.001)
-    expected_value = cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1)
+    expected_value = cap.CaptureNodesPlan(cap.CAPTURE_INSTANCES[0]["instanceType"], 1, 2, 1)
 
     assert expected_value == actual_value
 
     # TEST 3: Mid-range expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(20)
-    expected_value = cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 10, 13, 1)
+    expected_value = cap.CaptureNodesPlan(INSTANCE_TYPE_CAPTURE_NODE, 10, 13, 1)
 
     assert expected_value == actual_value
 
     # TEST 4: Max expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(cap.MAX_TRAFFIC)
-    expected_value = cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 50, 63, 1)
+    expected_value = cap.CaptureNodesPlan(INSTANCE_TYPE_CAPTURE_NODE, 50, 63, 1)
 
     assert expected_value == actual_value
 
@@ -40,7 +42,7 @@ def test_WHEN_get_capture_node_capacity_plan_called_THEN_as_expected():
 
 def test_WHEN_get_ecs_sys_resource_plan_called_THEN_as_expected():
     # TEST 1: Get an m5.xlarge instance
-    actual_value = cap.get_ecs_sys_resource_plan(cap.INSTANCE_TYPE_CAPTURE_NODE)
+    actual_value = cap.get_ecs_sys_resource_plan(INSTANCE_TYPE_CAPTURE_NODE)
     expected_value = cap.EcsSysResourcePlan(3584, 15360)
 
     assert expected_value == actual_value
@@ -122,7 +124,7 @@ def test_WHEN_get_data_node_plan_called_THEN_as_expected():
 def test_WHEN_get_master_node_plan_called_THEN_as_expected():
     # TEST: Non-graviton
     actual_value = cap._get_master_node_plan(5, 2, cap.T3_SMALL_SEARCH.type)
-    expected_value = cap.MasterNodesPlan(3, "m5.large.search")
+    expected_value = cap.MasterNodesPlan(3, "t3.small.search")
     assert expected_value == actual_value
 
     # TEST: Small data
@@ -155,13 +157,13 @@ def test_WHEN_get_master_node_plan_called_THEN_as_expected():
     expected_value = cap.MasterNodesPlan(3, "r6g.2xlarge.search")
     assert expected_value == actual_value
 
-    # TEST: Large data w/ lots of data nodes
+    # TEST: Large data w/ lots of data nodes (trigger nodes)
     actual_value = cap._get_master_node_plan(1250000, 130, "blah")
     expected_value = cap.MasterNodesPlan(3, "r6g.4xlarge.search")
     assert expected_value == actual_value
 
-    # TEST: Enormous data w/ lots of data nodes
-    actual_value = cap._get_master_node_plan(3010000, 120, "blah")
+    # TEST: Enormous data w/ lots of data nodes (trigger data)
+    actual_value = cap._get_master_node_plan(4010000, 120, "blah")
     expected_value = cap.MasterNodesPlan(3, "r6g.4xlarge.search")
     assert expected_value == actual_value
 
@@ -173,4 +175,4 @@ def test_WHEN_get_os_domain_plan_called_THEN_as_expected():
     )
     assert expected_value == actual_value
 
-    
+

--- a/test_manage_arkime/core/test_capacity_planning.py
+++ b/test_manage_arkime/core/test_capacity_planning.py
@@ -9,14 +9,14 @@ def test_WHEN_get_capture_node_capacity_plan_called_THEN_as_expected():
     # TEST 1: No expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(None)
-    expected_value = cap.CaptureNodesPlan(cap.CAPTURE_INSTANCES[0]["instanceType"], 1, 2, 1)
+    expected_value = cap.CaptureNodesPlan(cap.CAPTURE_INSTANCES[0].instanceType, 1, 2, 1)
 
     assert expected_value == actual_value
 
     # TEST 2: Small expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(0.001)
-    expected_value = cap.CaptureNodesPlan(cap.CAPTURE_INSTANCES[0]["instanceType"], 1, 2, 1)
+    expected_value = cap.CaptureNodesPlan(cap.CAPTURE_INSTANCES[0].instanceType, 1, 2, 1)
 
     assert expected_value == actual_value
 

--- a/test_manage_arkime/core/test_price_report.py
+++ b/test_manage_arkime/core/test_price_report.py
@@ -5,10 +5,12 @@ import core.capacity_planning as cap
 from core.price_report import PriceReport
 from core.user_config import UserConfig
 
+INSTANCE_TYPE_CAPTURE_NODE = "m5.xlarge";
+
 def test_WHEN_PriceReport_get_report_THEN_as_expected():
     # Set up the test
     plan = cap.ClusterPlan(
-        cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
+        cap.CaptureNodesPlan(INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
         cap.CaptureVpcPlan(1),
         cap.EcsSysResourcePlan(1, 1),
         cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
@@ -22,7 +24,7 @@ def test_WHEN_PriceReport_get_report_THEN_as_expected():
     # Check the results
     expected_report = (
       "OnDemand us-east-1 cost estimate, your cost may be different based on region, discounts or reserve instances:\n"
-      + "Fixed:\n"
+      + "Allocated:\n"
       + "   Capture                         1 * $ 140.1600/mo = $    140.16/mo\n"
       + "   Viewer                          2 * $  29.5504/mo = $     59.10/mo\n"
       + "   OS Master Node                  3 * $  93.4400/mo = $    280.32/mo\n"

--- a/test_manage_arkime/core/test_usage_report.py
+++ b/test_manage_arkime/core/test_usage_report.py
@@ -5,6 +5,8 @@ import core.capacity_planning as cap
 from core.usage_report import UsageReport
 from core.user_config import UserConfig
 
+INSTANCE_TYPE_CAPTURE_NODE = "m5.xlarge";
+
 def test_WHEN_UsageReport_get_report_THEN_as_expected():
     # Set up the test
     prev_plan = cap.ClusterPlan(
@@ -15,7 +17,7 @@ def test_WHEN_UsageReport_get_report_THEN_as_expected():
         cap.S3Plan(None, None)
     )
     next_plan = cap.ClusterPlan(
-        cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
+        cap.CaptureNodesPlan(INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
         cap.CaptureVpcPlan(1),
         cap.EcsSysResourcePlan(1, 1),
         cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
@@ -36,7 +38,7 @@ def test_WHEN_UsageReport_get_report_THEN_as_expected():
         + "    Max Count: 2\n"
         + "    Desired Count: 1\n"
         + "    Min Count: 1\n"
-        + f"    Type: {cap.INSTANCE_TYPE_CAPTURE_NODE}\n"
+        + f"    Type: {INSTANCE_TYPE_CAPTURE_NODE}\n"
         + "OpenSearch Domain:\n"
         + "    Master Node Count: 3\n"
         + "    Master Node Type: \033[1mm6g.before.search -> m6g.large.search\033[0m\n"
@@ -60,7 +62,7 @@ def test_WHEN_UsageReport_get_confirmation_AND_yes_THEN_as_expected(mock_shell):
         cap.S3Plan(None, None)
     )
     next_plan = cap.ClusterPlan(
-        cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
+        cap.CaptureNodesPlan(INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
         cap.CaptureVpcPlan(1),
         cap.EcsSysResourcePlan(1, 1),
         cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
@@ -90,7 +92,7 @@ def test_WHEN_UsageReport_get_confirmation_AND_no_THEN_as_expected(mock_shell):
         cap.S3Plan(None, None)
     )
     next_plan = cap.ClusterPlan(
-        cap.CaptureNodesPlan(cap.INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
+        cap.CaptureNodesPlan(INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
         cap.CaptureVpcPlan(1),
         cap.EcsSysResourcePlan(1, 1),
         cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),


### PR DESCRIPTION
Focus - Allow creation of smaller Arkime clusters
* Added another capture instance type: t3.medium
* Added master instance types: t3.small.search, t3.medium.search
* Switch to using a sorted array of dicts to find best capture & master instance types instead of ifs
* Changed storage_per_shard to 50G in calculations

Bonus:
* prev user_config when loaded uses from_dict so we can ignore unneeded keys
* editor auto removes trailing spaces (sorry)

Notes:
* Can not specify just 1 master node, so didn't continue with --lab-mode

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
