### PR TITLE
Can now get CFN Templates without deploying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ cdk.out
 # Arkime stuff
 manage_arkime.log
 config-*
+cfn-*

--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ You can log into your Viewer Dashboard using credentials from the `get-login-det
 
 We deploy default configuration for the Arkime Capture and Viewer processes that work "out of the box".  However, you can customize the configuration for those processes - and add custom behavior to your Capture and Viewer Nodes.
 
-As part of running `cluster-create`, the CLI will create a new, cluster-specific directory at the root of this repo on-disk that contains the configuration/scripts that will be deployed into your containers (currently at: `./config-YourClusterName`).  This directory contains two sub directories which contain all the scripts/configuration that are copied onto the Capture (`./config-YourClusterName/capture/`) and Viewer (`./config-YourClusterName/viewer/`) Nodes as part of their startup process.  By default, these directories will just contain the aforementioned "default configuration", but you're free to edit the files there or even add new ones.  Any files in the `./config-YourClusterName/capture/` will end copied to your Capture Nodes; any files in the `./config-YourClusterName/viewer/` will end copied to your Viewer Nodes.
+As part of running `cluster-create`, the CLI will create a new, cluster-specific directory at the root of this repo on-disk that contains the configuration/scripts that will be deployed into your containers (currently at: `./config-YourClusterName-AccountNum-AwsRegion`).  This directory contains two sub directories which contain all the scripts/configuration that are copied onto the Capture (`./config-YourClusterName-AccountNum-AwsRegion/capture/`) and Viewer (`./config-YourClusterName-AccountNum-AwsRegion/viewer/`) Nodes as part of their startup process.  By default, these directories will just contain the aforementioned "default configuration", but you're free to edit the files there or even add new ones.  Any files in the `./config-YourClusterName-AccountNum-AwsRegion/capture/` will end copied to your Capture Nodes; any files in the `./config-YourClusterName/viewer/` will end copied to your Viewer Nodes.
 
 ```
-chelma@3c22fba4e266 aws-aio % tree config-YourClusterName
-config-YourClusterName
+chelma@3c22fba4e266 aws-aio % tree config-YourClusterName-111111111111-us-east-2
+config-YourClusterName-111111111111-us-east-2
 ├── capture
 │   ├── config.ini
 │   ├── default.rules

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -94,11 +94,18 @@ cli.add_command(demo_traffic_destroy)
     show_default=True,
     default=False
 )
+@click.option(
+    "--just-print-cfn", 
+    help="Skips a full deployment and just creates a copy of the CloudFormation templates to be deployed in a local directory",
+    is_flag=True,
+    show_default=True,
+    default=False
+)
 @click.pass_context
-def cluster_create(ctx, name, expected_traffic, spi_days, history_days, replicas, pcap_days, preconfirm_usage):
+def cluster_create(ctx, name, expected_traffic, spi_days, history_days, replicas, pcap_days, preconfirm_usage, just_print_cfn):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_cluster_create(profile, region, name, expected_traffic, spi_days, history_days, replicas, pcap_days, preconfirm_usage)
+    cmd_cluster_create(profile, region, name, expected_traffic, spi_days, history_days, replicas, pcap_days, preconfirm_usage, just_print_cfn)
 cli.add_command(cluster_create)
 
 @click.command(help="Tears down the Arkime Cluster in your account; by default, leaves your data intact")
@@ -142,11 +149,18 @@ cli.add_command(clusters_list)
 @click.option("--force-vni", help=("POWER USER OPTION.  Forcefully assign the VPC to use a specific VNI.  This can"
               + " result in multiple VPCs using the same VNI, and VNIs to potentially be re-used long after they are"
               + " relinquished."), default=None, type=int)
+@click.option(
+    "--just-print-cfn", 
+    help="Skips a full deployment and just creates a copy of the CloudFormation templates to be deployed in a local directory",
+    is_flag=True,
+    show_default=True,
+    default=False
+)
 @click.pass_context
-def vpc_add(ctx, cluster_name, vpc_id, force_vni):
+def vpc_add(ctx, cluster_name, vpc_id, force_vni, just_print_cfn):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_vpc_add(profile, region, cluster_name, vpc_id, force_vni)
+    cmd_vpc_add(profile, region, cluster_name, vpc_id, force_vni, just_print_cfn)
 cli.add_command(vpc_add)
 
 @click.command(help="Removes traffic monitoring from the specified VPC being performed by the specified Arkime Cluster")

--- a/manage_arkime/arkime_interactions/config_wrangling.py
+++ b/manage_arkime/arkime_interactions/config_wrangling.py
@@ -6,7 +6,7 @@ import shutil
 from typing import Dict, Type, TypeVar
 
 from aws_interactions.aws_environment import AwsEnvironment
-from core.constants import get_cluster_config_parent_dir, is_valid_cluster_name, InvalidClusterName
+from core.constants import get_repo_root_dir, is_valid_cluster_name, InvalidClusterName
 from core.local_file import LocalFile, ZipDirectory
 from core.versioning import VersionInfo
 
@@ -191,7 +191,7 @@ def set_up_arkime_config_dir(cluster_name: str, aws_env: AwsEnvironment, parent_
         logger.info("Cluster config directory not empty; skipping copy")
 
 def get_capture_config_archive(cluster_name: str, aws_env: AwsEnvironment) -> LocalFile:
-    cluster_config_parent_dir_path = get_cluster_config_parent_dir()
+    cluster_config_parent_dir_path = get_repo_root_dir()
     capture_config_dir_path = get_capture_dir_path(cluster_name, aws_env, cluster_config_parent_dir_path)
     capture_config_archive_path = get_capture_archive_path(cluster_name, aws_env, cluster_config_parent_dir_path)
 
@@ -202,7 +202,7 @@ def get_capture_config_archive(cluster_name: str, aws_env: AwsEnvironment) -> Lo
     return capture_config_archive
 
 def get_viewer_config_archive(cluster_name: str, aws_env: AwsEnvironment) -> LocalFile:
-    cluster_config_parent_dir_path = get_cluster_config_parent_dir()
+    cluster_config_parent_dir_path = get_repo_root_dir()
     viewer_config_dir_path = get_viewer_dir_path(cluster_name, aws_env, cluster_config_parent_dir_path)
     viewer_config_archive_path = get_viewer_archive_path(cluster_name, aws_env, cluster_config_parent_dir_path)
 

--- a/manage_arkime/cdk_interactions/cdk_client.py
+++ b/manage_arkime/cdk_interactions/cdk_client.py
@@ -117,4 +117,21 @@ class CdkClient:
             raise exceptions.CdkDestroyFailedUnknown()
 
         logger.info(f"Destruction succeeded")
+
+    def synthesize(self, stack_names: List[str], context: Dict[str, str] = None) -> None:
+        command_prefix = get_command_prefix(aws_profile=self._aws_env.aws_profile, aws_region=self._aws_env.aws_region, context=context)
+        command_suffix = f"synthesize --quiet {' '.join(stack_names)}"
+        command = f"{command_prefix} {command_suffix}"
+
+        # Execute the command.  
+        logger.info(f"Executing command: {command_suffix}")
+        logger.warning("NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.")
+        exit_code, stdout = shell.call_shell_command(command=command)
+        exceptions.raise_common_exceptions(exit_code, stdout)
+
+        if exit_code != 0:
+            logger.error(f"Synthesize failed")
+            raise exceptions.CdkSynthesizeFailedUnknown()
+
+        logger.info(f"Synthesize succeeded")
         

--- a/manage_arkime/cdk_interactions/cdk_exceptions.py
+++ b/manage_arkime/cdk_interactions/cdk_exceptions.py
@@ -90,3 +90,7 @@ def raise_deploy_exceptions(exit_code: int, stdout: List[str]):
 class CdkDestroyFailedUnknown(Exception):
     def __init__(self):
         super().__init__("The CDK Destroy operation failed for unknown reasons, please check the logs and stdout.")
+
+class CdkSynthesizeFailedUnknown(Exception):
+    def __init__(self):
+        super().__init__("The CDK Synthesize operation failed for unknown reasons, please check the logs and stdout.")

--- a/manage_arkime/cdk_interactions/cfn_wrangling.py
+++ b/manage_arkime/cdk_interactions/cfn_wrangling.py
@@ -1,0 +1,62 @@
+import logging
+import os
+import re
+import shutil
+
+from aws_interactions.aws_environment import AwsEnvironment
+from core.constants import is_valid_cluster_name, InvalidClusterName, get_repo_root_dir
+
+
+logger = logging.getLogger(__name__)
+
+class CdkOutNotPresent(Exception):
+    def __init__(self, cdk_out_dir: str):
+        super().__init__(f"The CDK Output directory is not present at the expected location: {cdk_out_dir}")
+
+def get_cfn_dir_name(cluster_name: str, aws_env: AwsEnvironment) -> str:
+    # We should validate earlier, but practice defense in depth
+    if not is_valid_cluster_name(cluster_name):
+        raise InvalidClusterName(cluster_name)
+    
+    # We want to avoid collisions between Clusters across accounts/regions
+    return f"cfn-{cluster_name}-{aws_env.aws_account}-{aws_env.aws_region}"
+
+def get_cfn_dir_path(cluster_name: str, aws_env: AwsEnvironment, parent_dir: str) -> str:
+    cluster_dir_name = get_cfn_dir_name(cluster_name, aws_env)
+    return os.path.join(parent_dir, cluster_dir_name)
+
+def get_cdk_out_dir_path() -> str:
+    # It's possible for the user to move where the cdk.out directory is created if they tweak the CDK configuration, so
+    # this might return the wrong value.  However, the ways to address that appear to be heavyweight compared to the
+    # (small) risk the user moves the directory.
+    cdk_out_dir = os.path.join(get_repo_root_dir(), "cdk.out")
+
+    if not os.path.isdir(cdk_out_dir):
+        raise CdkOutNotPresent(cdk_out_dir)
+
+    return cdk_out_dir
+
+def _copy_templates_to_cfn_dir(cluster_name: str, cfn_dir_path: str, cdk_out_dir_path: str):
+    template_regex = re.compile(f"^{cluster_name}-.*template\\.json$")
+
+    # Copy over the files that match the Cluster's expected CloudFormation template name scheme
+    for item in os.listdir(cdk_out_dir_path):
+        source_file_path = os.path.join(cdk_out_dir_path, item)
+        if template_regex.match(item) and os.path.isfile(source_file_path):
+            destination_file_path = os.path.join(cfn_dir_path, item)
+            shutil.copyfile(source_file_path, destination_file_path)
+
+def set_up_cloudformation_template_dir(cluster_name: str, aws_env: AwsEnvironment, parent_dir: str):
+    logger.info(f"Setting up the CloudFormation template directory for cluster: {cluster_name}")
+
+    logger.info(f"Removing any existing CloudFormation templates...")
+    cfn_dir_path = get_cfn_dir_path(cluster_name, aws_env, parent_dir)
+    if os.path.exists(cfn_dir_path):
+        shutil.rmtree(cfn_dir_path)
+    
+    logger.info(f"Copying over CloudFormation templates for current command...")
+    os.makedirs(cfn_dir_path)
+    cdk_out_dir_path = get_cdk_out_dir_path()
+    _copy_templates_to_cfn_dir(cluster_name, cfn_dir_path, cdk_out_dir_path)
+
+    logger.info(f"CloudFormation template dir exists at: {cfn_dir_path}")

--- a/manage_arkime/commands/cluster_create.py
+++ b/manage_arkime/commands/cluster_create.py
@@ -200,16 +200,17 @@ def _upload_arkime_config_if_necessary(cluster_name: str, bucket_name: str, s3_k
     )
 
 def _set_up_arkime_config(cluster_name: str, aws_provider: AwsClientProvider):
-    # Create a copy of the the default Arkime config (if necessary)
-    cluster_config_parent_dir_path = constants.get_cluster_config_parent_dir()
-    config_wrangling.set_up_arkime_config_dir(cluster_name, cluster_config_parent_dir_path)
-
-    # Check whether the S3 bucket exists and whether we have access; error and abort if we don't have access
+    # Get constants
     aws_env = aws_provider.get_aws_env()
     bucket_name = constants.get_config_bucket_name(aws_env.aws_account, aws_env.aws_region, cluster_name)
     capture_s3_key = constants.get_capture_config_s3_key("1")
     viewer_s3_key = constants.get_viewer_config_s3_key("1")
 
+    # Create a copy of the the default Arkime config (if necessary)
+    cluster_config_parent_dir_path = constants.get_cluster_config_parent_dir()
+    config_wrangling.set_up_arkime_config_dir(cluster_name, aws_env, cluster_config_parent_dir_path)
+
+    # Check whether the S3 bucket exists and whether we have access; error and abort if we don't have access
     try:
         s3.ensure_bucket_exists(bucket_name, aws_provider)
     except s3.CouldntEnsureBucketExists:

--- a/manage_arkime/core/constants.py
+++ b/manage_arkime/core/constants.py
@@ -147,10 +147,9 @@ def is_valid_cluster_name(cluster_name: str) -> bool:
     # There are no special characters and it's not an empty string
     return bool(no_special_chars.match(cluster_name)) and len(cluster_name) > 0
 
-def get_cluster_config_parent_dir() -> str:
+def get_repo_root_dir() -> str:
     """
-    Returns the path to the location on disk to the directory which will contain the configuration specific to each
-    cluster
+    Returns the path to the location on disk of the repo's root directory
     """
     this_files_path = os.path.abspath(__file__)
     three_levels_up = os.path.dirname(os.path.dirname(os.path.dirname(this_files_path))) # should be repo root

--- a/test_manage_arkime/arkime_interactions/test_config_wrangling.py
+++ b/test_manage_arkime/arkime_interactions/test_config_wrangling.py
@@ -3,17 +3,20 @@ import pytest
 import unittest.mock as mock
 
 import arkime_interactions.config_wrangling as config
+from aws_interactions.aws_environment import AwsEnvironment
 import core.constants as constants
 
 
+TEST_ENV = AwsEnvironment("account", "region", "profile")
+
 def test_WHEN_get_cluster_dir_name_called_THEN_as_expected():
     # TEST: Valid name should give right answer
-    actual_value = config.get_cluster_dir_name("MyCluster01")
-    assert "config-MyCluster01" == actual_value
+    actual_value = config.get_cluster_dir_name("MyCluster01", TEST_ENV)
+    assert f"config-MyCluster01-{TEST_ENV.aws_account}-{TEST_ENV.aws_region}" == actual_value
 
     # TEST: Invalid name should raise
     with pytest.raises(constants.InvalidClusterName):
-        config.get_cluster_dir_name("My Cluster 01")
+        config.get_cluster_dir_name("My Cluster 01", TEST_ENV)
 
 @mock.patch("arkime_interactions.config_wrangling.os.makedirs")
 @mock.patch("arkime_interactions.config_wrangling.os.path.exists")
@@ -21,14 +24,14 @@ def test_WHEN_create_config_dir_called_AND_doesnt_exist_THEN_as_expected(mock_ex
     # Set up our mock
     cluster_name = "MyCluster01"
     parent_dir = "/my/path"
-    dir_name = config.get_cluster_dir_name(cluster_name)
+    dir_name = config.get_cluster_dir_name(cluster_name, TEST_ENV)
     mock_exists.return_value = False
 
     # Run the test
-    actual_value = config._create_config_dir(cluster_name, parent_dir)
+    actual_value = config._create_config_dir(cluster_name, TEST_ENV, parent_dir)
 
     # Check the results
-    assert config.get_cluster_dir_path(cluster_name, parent_dir) == actual_value
+    assert config.get_cluster_dir_path(cluster_name, TEST_ENV, parent_dir) == actual_value
     assert [mock.call(f"{parent_dir}/{dir_name}")] == mock_makedirs.call_args_list
 
 @mock.patch("arkime_interactions.config_wrangling.os.makedirs")
@@ -40,10 +43,10 @@ def test_WHEN_create_config_dir_called_AND_does_exist_THEN_as_expected(mock_exis
     mock_exists.return_value = True
 
     # Run the test
-    actual_value = config._create_config_dir(cluster_name, parent_dir)
+    actual_value = config._create_config_dir(cluster_name, TEST_ENV, parent_dir)
 
     # Check the results
-    assert config.get_cluster_dir_path(cluster_name, parent_dir) == actual_value
+    assert config.get_cluster_dir_path(cluster_name, TEST_ENV, parent_dir) == actual_value
     assert False == mock_makedirs.called
 
 @mock.patch("arkime_interactions.config_wrangling.shutil.copytree")
@@ -52,12 +55,12 @@ def test_WHEN_copy_default_config_to_cluster_dir_called_AND_empty_THEN_as_expect
     # Set up our mock
     cluster_name = "MyCluster01"
     parent_dir = "/my/path"
-    cluster_dir_path = config.get_cluster_dir_path(cluster_name, parent_dir)
+    cluster_dir_path = config.get_cluster_dir_path(cluster_name, TEST_ENV, parent_dir)
 
     mock_listdir.return_value = []
 
     # Run the test
-    config._copy_default_config_to_cluster_dir(cluster_name, parent_dir)
+    config._copy_default_config_to_cluster_dir(cluster_name, TEST_ENV, parent_dir)
 
     # Check the results
     expected_copy_calls = [
@@ -83,7 +86,7 @@ def test_WHEN_copy_default_config_to_cluster_dir_called_AND_not_empty_THEN_raise
 
     # Run the test
     with pytest.raises(config.ConfigDirNotEmpty):
-        config._copy_default_config_to_cluster_dir(cluster_name, parent_dir)
+        config._copy_default_config_to_cluster_dir(cluster_name, TEST_ENV, parent_dir)
 
     # Check the results
     expected_copy_calls = []
@@ -98,16 +101,16 @@ def test_WHEN_set_up_arkime_config_dir_called_THEN_as_expected(mock_create, mock
     parent_dir = "/my/path"
 
     # Run the test
-    config.set_up_arkime_config_dir(cluster_name, parent_dir)
+    config.set_up_arkime_config_dir(cluster_name, TEST_ENV, parent_dir)
 
     # Check the results
     expected_create_calls = [
-        mock.call(cluster_name, parent_dir)
+        mock.call(cluster_name, TEST_ENV, parent_dir)
     ]
     assert expected_create_calls == mock_create.call_args_list
 
     expected_copy_calls = [
-        mock.call(cluster_name, parent_dir)
+        mock.call(cluster_name, TEST_ENV, parent_dir)
     ]
     assert expected_copy_calls == mock_copy.call_args_list
 
@@ -123,15 +126,15 @@ def test_WHEN_get_capture_config_archive_called_THEN_as_expected(mock_zip_class,
     mock_zip_class.return_value = mock_zip_file
 
     # Run the test
-    actual_zip = config.get_capture_config_archive(cluster_name)
+    actual_zip = config.get_capture_config_archive(cluster_name, TEST_ENV)
 
     # Check the results
     assert actual_zip.generate.called
 
     expected_zip_init_calls = [
         mock.call(
-            "/parent/path/config-MyCluster01/capture",
-            "/parent/path/config-MyCluster01/capture.zip"
+            f"/parent/path/config-MyCluster01-{TEST_ENV.aws_account}-{TEST_ENV.aws_region}/capture",
+            f"/parent/path/config-MyCluster01-{TEST_ENV.aws_account}-{TEST_ENV.aws_region}/capture.zip"
         )
     ]
     assert expected_zip_init_calls == mock_zip_class.call_args_list
@@ -148,15 +151,15 @@ def test_WHEN_get_viewer_config_archive_called_THEN_as_expected(mock_zip_class, 
     mock_zip_class.return_value = mock_zip_file
 
     # Run the test
-    actual_zip = config.get_viewer_config_archive(cluster_name)
+    actual_zip = config.get_viewer_config_archive(cluster_name, TEST_ENV)
 
     # Check the results
     assert actual_zip.generate.called
 
     expected_zip_init_calls = [
         mock.call(
-            "/parent/path/config-MyCluster01/viewer",
-            "/parent/path/config-MyCluster01/viewer.zip"
+            f"/parent/path/config-MyCluster01-{TEST_ENV.aws_account}-{TEST_ENV.aws_region}/viewer",
+            f"/parent/path/config-MyCluster01-{TEST_ENV.aws_account}-{TEST_ENV.aws_region}/viewer.zip"
         )
     ]
     assert expected_zip_init_calls == mock_zip_class.call_args_list

--- a/test_manage_arkime/arkime_interactions/test_config_wrangling.py
+++ b/test_manage_arkime/arkime_interactions/test_config_wrangling.py
@@ -114,7 +114,7 @@ def test_WHEN_set_up_arkime_config_dir_called_THEN_as_expected(mock_create, mock
     ]
     assert expected_copy_calls == mock_copy.call_args_list
 
-@mock.patch("arkime_interactions.config_wrangling.get_cluster_config_parent_dir")
+@mock.patch("arkime_interactions.config_wrangling.get_repo_root_dir")
 @mock.patch("arkime_interactions.config_wrangling.ZipDirectory")
 def test_WHEN_get_capture_config_archive_called_THEN_as_expected(mock_zip_class, mock_get_parent_dir):
     # Set up our mock
@@ -139,7 +139,7 @@ def test_WHEN_get_capture_config_archive_called_THEN_as_expected(mock_zip_class,
     ]
     assert expected_zip_init_calls == mock_zip_class.call_args_list
 
-@mock.patch("arkime_interactions.config_wrangling.get_cluster_config_parent_dir")
+@mock.patch("arkime_interactions.config_wrangling.get_repo_root_dir")
 @mock.patch("arkime_interactions.config_wrangling.ZipDirectory")
 def test_WHEN_get_viewer_config_archive_called_THEN_as_expected(mock_zip_class, mock_get_parent_dir):
     # Set up our mock

--- a/test_manage_arkime/cdk_interactions/test_cfn_wrangling.py
+++ b/test_manage_arkime/cdk_interactions/test_cfn_wrangling.py
@@ -1,0 +1,109 @@
+import os
+import pytest
+import unittest.mock as mock
+
+from aws_interactions.aws_environment import AwsEnvironment
+import cdk_interactions.cfn_wrangling as cfn
+import core.constants as constants
+
+
+TEST_ENV = AwsEnvironment("account", "region", "profile")
+
+def test_WHEN_get_cfn_dir_name_called_THEN_as_expected():
+    # TEST: Valid name should give right answer
+    actual_value = cfn.get_cfn_dir_name("MyCluster01", TEST_ENV)
+    assert f"cfn-MyCluster01-{TEST_ENV.aws_account}-{TEST_ENV.aws_region}" == actual_value
+
+    # TEST: Invalid name should raise
+    with pytest.raises(constants.InvalidClusterName):
+        cfn.get_cfn_dir_name("My Cluster 01", TEST_ENV)
+
+@mock.patch("cdk_interactions.cfn_wrangling.os.path.isdir")
+@mock.patch("cdk_interactions.cfn_wrangling.get_repo_root_dir")
+def test_WHEN_get_cdk_out_path_called_AND_happy_path_THEN_as_expected(mock_get_repo_root, mock_isdir):
+    # Set up our mock
+    mock_get_repo_root.return_value = "/my/path"
+    mock_isdir.return_value = True
+
+    # Run the test
+    actual_value = cfn.get_cdk_out_dir_path()
+
+    # Check the result
+    assert "/my/path/cdk.out" == actual_value
+
+@mock.patch("cdk_interactions.cfn_wrangling.os.path.isdir")
+@mock.patch("cdk_interactions.cfn_wrangling.get_repo_root_dir")
+def test_WHEN_get_cdk_out_path_called_AND_doesnt_exist_THEN_raises(mock_get_repo_root, mock_isdir):
+    # Set up our mock
+    mock_get_repo_root.return_value = "/my/path"
+    mock_isdir.return_value = False
+
+    # Run the test
+    with pytest.raises(cfn.CdkOutNotPresent):
+        cfn.get_cdk_out_dir_path()
+
+@mock.patch("cdk_interactions.cfn_wrangling.shutil.copyfile")
+@mock.patch("cdk_interactions.cfn_wrangling.os.path.isfile")
+@mock.patch("cdk_interactions.cfn_wrangling.os.listdir")
+def test_WHEN_copy_templates_to_cfn_dir_called_THEN_as_expected(mock_listdir, mock_isfile, mock_copyfile):
+    # Set up our mock
+    mock_listdir.return_value = [
+        "MyCluster-CaptureBucket.assets.json",
+        "MyCluster-CaptureBucket.template.json",
+        "MyCluster3-CaptureBucket.assets.json",
+        "MyCluster3-CaptureBucket.template.json",
+        "MyCluster3-CaptureNodes.assets.json",
+        "MyCluster3-CaptureNodes.template.json",
+        "asset.13fd643b69301bb29b4aea4ad8a3b85f158c70674d7081b9af08eaea02188af5",
+        "cdk.out",
+        "unexpected_directory"
+    ]
+    mock_isfile.return_value = True
+
+    # Run the test
+    actual_value = cfn._copy_templates_to_cfn_dir("MyCluster3", "/path/cfn", "path/cdk.out")
+
+    # Check the result
+    expected_copy_calls = [
+        mock.call("path/cdk.out/MyCluster3-CaptureBucket.template.json", "/path/cfn/MyCluster3-CaptureBucket.template.json"),
+        mock.call("path/cdk.out/MyCluster3-CaptureNodes.template.json", "/path/cfn/MyCluster3-CaptureNodes.template.json")
+    ]
+    assert expected_copy_calls == mock_copyfile.call_args_list
+
+
+@mock.patch("cdk_interactions.cfn_wrangling._copy_templates_to_cfn_dir")
+@mock.patch("cdk_interactions.cfn_wrangling.get_cdk_out_dir_path")
+@mock.patch("cdk_interactions.cfn_wrangling.os.makedirs")
+@mock.patch("cdk_interactions.cfn_wrangling.shutil.rmtree")
+@mock.patch("cdk_interactions.cfn_wrangling.os.path.exists")
+def test_WHEN_set_up_cloudformation_template_dir_called_THEN_as_expected(mock_exists, mock_rmtree, mock_mkdirs, mock_get_cdk_path, mock_copy):
+    # Set up our mock
+    test_env = AwsEnvironment("account", "region", "profile")
+    cluster_name = "MyCluster01"
+    parent_dir = "/my/path"
+    
+    mock_exists.return_value = True
+    mock_get_cdk_path.return_value = "/path/cdk.out"
+
+    # Run the test
+    cfn.set_up_cloudformation_template_dir(cluster_name, test_env, parent_dir)
+
+    # Check the result
+    expected_rmtree_calls = [
+        mock.call(cfn.get_cfn_dir_path(cluster_name, test_env, parent_dir))
+    ]
+    assert expected_rmtree_calls == mock_rmtree.call_args_list
+
+    expected_mkdirs_calls = [
+        mock.call(cfn.get_cfn_dir_path(cluster_name, test_env, parent_dir))
+    ]
+    assert expected_mkdirs_calls == mock_mkdirs.call_args_list
+
+    expected_copy_calls = [
+        mock.call(
+            cluster_name,
+            cfn.get_cfn_dir_path(cluster_name, test_env, parent_dir),
+            "/path/cdk.out"
+        )
+    ]
+    assert expected_copy_calls == mock_copy.call_args_list

--- a/test_manage_arkime/commands/test_cluster_create.py
+++ b/test_manage_arkime/commands/test_cluster_create.py
@@ -595,7 +595,7 @@ def test_WHEN_set_up_arkime_config_called_AND_happy_path_THEN_as_expected(mock_s
 
     # Check our results
     expected_set_up_config_dir_calls = [
-        mock.call("cluster-name", constants.get_cluster_config_parent_dir())
+        mock.call("cluster-name", test_env, constants.get_cluster_config_parent_dir())
     ]
     assert expected_set_up_config_dir_calls == mock_set_up_config_dir.call_args_list
 
@@ -686,7 +686,7 @@ def test_WHEN_set_up_arkime_config_called_AND_config_exists_THEN_as_expected(moc
 
     # Check our results
     expected_set_up_config_dir_calls = [
-        mock.call("cluster-name", constants.get_cluster_config_parent_dir())
+        mock.call("cluster-name", test_env, constants.get_cluster_config_parent_dir())
     ]
     assert expected_set_up_config_dir_calls == mock_set_up_config_dir.call_args_list
 


### PR DESCRIPTION
## Description
* Added a `--just-print-cfn` option to the `cluster-create` and `vpc-add`, which skips CloudFormation deployments and (most) AWS Operations that create resources.  We can't skip *all* AWS operations because some are required in order to generate the CloudFormation templates.
* The CloudFormation templates are written to the repo root in a cluster/account/region specific directory.
* Also renamed the Cluster Arkime Configuration directory to use the same suffixes as the Cfn template directories.  This will prevent users from seeing collisions when specifying Arkime configuration for Clusters with the same name in different accounts/regions

## Tasks
* https://github.com/arkime/aws-aio/issues/97

## Testing
* Added unit tests
* Ran the `cluster-create` and `vpc-add` commands locally
```
```

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
