### PR TITLE
OIDC support

### DIFF
--- a/cdk-lib/viewer-stacks/viewer-nodes-stack.ts
+++ b/cdk-lib/viewer-stacks/viewer-nodes-stack.ts
@@ -37,7 +37,10 @@ export class ViewerNodesStack extends cdk.Stack {
 
         const viewerPass = new secretsmanager.Secret(this, 'ViewerPassword', {
             generateSecretString: {
-                secretStringTemplate: JSON.stringify({ authSecret: "" }), // Changing value here causes cdk to generate new secrets
+                secretStringTemplate: JSON.stringify({
+                    authSecret: "",
+                    passwordSecret: "ignore"
+                }), // Changing value here causes cdk to generate new secrets
                 generateStringKey: 'adminPassword',
                 excludeCharacters: '\\$:()[]&\'"<>`|;*?# ' // Characters likely to cause problems in shells
             }

--- a/cdk-lib/viewer-stacks/viewer-nodes-stack.ts
+++ b/cdk-lib/viewer-stacks/viewer-nodes-stack.ts
@@ -34,8 +34,11 @@ export class ViewerNodesStack extends cdk.Stack {
         // Some configuration values
         const viewerPort = 8005; // Arkime default
         const viewerUser = "admin";
+
         const viewerPass = new secretsmanager.Secret(this, 'ViewerPassword', {
             generateSecretString: {
+                secretStringTemplate: JSON.stringify({ authSecret: "" }), // Changing value here causes cdk to generate new secrets
+                generateStringKey: 'adminPassword',
                 excludeCharacters: '\\$:()[]&\'"<>`|;*?# ' // Characters likely to cause problems in shells
             }
         });

--- a/manage_arkime/arkime_interactions/default_config/viewer/config.ini
+++ b/manage_arkime/arkime_interactions/default_config/viewer/config.ini
@@ -19,3 +19,20 @@ viewPort=_VIEWER_PORT_
 ### PCAP Config
 pcapDir=/opt/arkime/raw
 pcapWriteMethod=s3
+
+### OIDC Config
+# To configure OIDC you will need to
+# 1) Before activating OIDC create a user with the usersAdmin role assigned with their OIDC userId
+# 2) Uncomment the following configuration
+# 3) Fill in the <URL> and <ID>
+# 4) Edit the ViewerPassword secret in AWS SecretsManager updating the password in the authSecret key
+# 5) Run the manage_arkime.py config-update command
+# 6) Update your OIDC server configuration with the redirect URL, it will be the same as authRedirectURIs
+#authTrustProxy=true
+#userNameHeader=oidc
+#authDiscoverURL=<URL>
+#authClientId=<ID>
+#authClientSecret=_AUTH_SECRET_
+#authUserIdField=email
+#authRedirectURIs=https://_VIEWER_DNS_/auth/login/callback
+#userAutoCreateTmpl={"userId": "${this.preferred_username}", "userName": "${this.name}", "enabled": true, "webEnabled": true, "headerAuthEnabled": true, "emailSearch": true, "createEnabled": false, "removeEnabled": false, "packetSearch": true, "roles": ["arkimeUser", "cont3xtUser"] }

--- a/manage_arkime/arkime_interactions/default_config/viewer/config.ini
+++ b/manage_arkime/arkime_interactions/default_config/viewer/config.ini
@@ -7,7 +7,7 @@ elasticsearch=https://_OS_ENDPOINT_
 elasticsearchBasicAuth=_OS_AUTH_
 rotateIndex=daily
 
-passwordSecret=ignore
+passwordSecret=_PASSWORD_SECRET_
 
 cronQueries=auto
 
@@ -22,17 +22,24 @@ pcapWriteMethod=s3
 
 ### OIDC Config
 # To configure OIDC you will need to
-# 1) Before activating OIDC create a user with the usersAdmin role assigned with their OIDC userId
-# 2) Uncomment the following configuration
-# 3) Fill in the <URL> and <ID>
-# 4) Edit the ViewerPassword secret in AWS SecretsManager updating the password in the authSecret key
-# 5) Run the manage_arkime.py config-update command
-# 6) Update your OIDC server configuration with the redirect URL, it will be the same as authRedirectURIs
-#authTrustProxy=true
-#userNameHeader=oidc
+# 0) Make sure Arkime is working in basic auth mode and you can authenticate with the admin user
+# 1) Using Arkime, create a user with the usersAdmin role assigned and a userId matching their OIDC
+#    authUserIdField value, this will allow that user to assign roles and such
+# 2) Fill in the <URL>, <ID>, <FIELD> in the config below
+#      For cognito they might look something like
+#        authDiscoverURL=https://cognito-idp.REGION.amazonaws.com/REGION_xxxxxxxxx
+#        authClientId=xxxxxxxxxxxxxxxxxxxxxxxxxx
+#        authUserIdField=email
+# 3) Verify that userAutoCreateTmpl is creating the user using the correct fields and setting
+# 4) Edit the ViewerPassword secret in AWS SecretsManager updating the authSecret key to match the OIDC client secret
+# 5) Uncomment the following configuration
+# 6) Update your OIDC server configuration with the redirect URL, it will be _VIEWER_DNS_/auth/login/callback
+# 7) Run the manage_arkime.py config-update command which will deploy the new config files
 #authDiscoverURL=<URL>
 #authClientId=<ID>
-#authClientSecret=_AUTH_SECRET_
-#authUserIdField=email
-#authRedirectURIs=https://_VIEWER_DNS_/auth/login/callback
+#authUserIdField=<FIELD>
 #userAutoCreateTmpl={"userId": "${this.preferred_username}", "userName": "${this.name}", "enabled": true, "webEnabled": true, "headerAuthEnabled": true, "emailSearch": true, "createEnabled": false, "removeEnabled": false, "packetSearch": true, "roles": ["arkimeUser", "cont3xtUser"] }
+#authTrustProxy=true
+#userNameHeader=oidc
+#authClientSecret=_AUTH_SECRET_
+#authRedirectURIs=https://_VIEWER_DNS_/auth/login/callback

--- a/manage_arkime/arkime_interactions/default_config/viewer/initialize_arkime.sh
+++ b/manage_arkime/arkime_interactions/default_config/viewer/initialize_arkime.sh
@@ -17,10 +17,17 @@ sed -i'' "s/_OS_AUTH_/$BASE64_AUTH/g" /opt/arkime/etc/config.ini
 VIEWER_PASS_OBJ=$(aws secretsmanager get-secret-value --secret-id $VIEWER_PASS_ARN --output text --query SecretString)
 ADMIN_PASSWORD=$(echo $VIEWER_PASS_OBJ | jq -r .adminPassword)
 AUTH_SECRET=$(echo $VIEWER_PASS_OBJ | jq -r .authSecret)
+PASSWORD_SECRET=$(echo $VIEWER_PASS_OBJ | jq -r .passwordSecret)
 
-sed -i'' "s/_VIEWER_PORT_/$VIEWER_PORT/g" /opt/arkime/etc/config.ini
 sed -i'' "s/_AUTH_SECRET_/$AUTH_SECRET/g" /opt/arkime/etc/config.ini
+sed -i'' "s/_PASSWORD_SECRET_/$PASSWORD_SECRET/g" /opt/arkime/etc/config.ini
+
+# Items from run_viewer_node.sh
 sed -i'' "s/_VIEWER_DNS_/$VIEWER_DNS/g" /opt/arkime/etc/config.ini
+sed -i'' "s/_VIEWER_PORT_/$VIEWER_PORT/g" /opt/arkime/etc/config.ini
+sed -i'' "s/_VIEWER_USER_/$VIEWER_USER/g" /opt/arkime/etc/config.ini
+sed -i'' "s/_CLUSTER_NAME_/$CLUSTER_NAME/g" /opt/arkime/etc/config.ini
+
 echo "Successfully configured /opt/arkime/etc/config.ini"
 
 echo "Testing connection/creds to OpenSearch domain $OPENSEARCH_ENDPOINT ..."

--- a/manage_arkime/arkime_interactions/default_config/viewer/initialize_arkime.sh
+++ b/manage_arkime/arkime_interactions/default_config/viewer/initialize_arkime.sh
@@ -14,9 +14,13 @@ OPENSEARCH_PASS=$(aws secretsmanager get-secret-value --secret-id $OPENSEARCH_SE
 BASE64_AUTH=$(echo -n "admin:$OPENSEARCH_PASS" | base64)
 sed -i'' "s/_OS_AUTH_/$BASE64_AUTH/g" /opt/arkime/etc/config.ini
 
-VIEWER_PASS=$(aws secretsmanager get-secret-value --secret-id $VIEWER_PASS_ARN --output text --query SecretString)
+VIEWER_PASS_OBJ=$(aws secretsmanager get-secret-value --secret-id $VIEWER_PASS_ARN --output text --query SecretString)
+ADMIN_PASSWORD=$(echo $VIEWER_PASS_OBJ | jq -r .adminPassword)
+AUTH_SECRET=$(echo $VIEWER_PASS_OBJ | jq -r .authSecret)
 
 sed -i'' "s/_VIEWER_PORT_/$VIEWER_PORT/g" /opt/arkime/etc/config.ini
+sed -i'' "s/_AUTH_SECRET_/$AUTH_SECRET/g" /opt/arkime/etc/config.ini
+sed -i'' "s/_VIEWER_DNS_/$VIEWER_DNS/g" /opt/arkime/etc/config.ini
 echo "Successfully configured /opt/arkime/etc/config.ini"
 
 echo "Testing connection/creds to OpenSearch domain $OPENSEARCH_ENDPOINT ..."

--- a/manage_arkime/commands/get_login_details.py
+++ b/manage_arkime/commands/get_login_details.py
@@ -40,12 +40,12 @@ def cmd_get_login_details(profile: str, region: str, name: str) -> LoginDetails:
     username = viewer_details.user
     login_url = viewer_details.dns
     secrets_client = aws_provider.get_secretsmanager()
-    password = secrets_client.get_secret_value(SecretId=viewer_details.passwordArn)["SecretString"]
+    password = json.loads(secrets_client.get_secret_value(SecretId=viewer_details.passwordArn)["SecretString"])
 
     # Display the result without logging it
-    login_details = LoginDetails(password=password, username=username, url=login_url)
+    login_details = LoginDetails(password=password['adminPassword'], username=username, url=login_url)
     print(f"Log-in Details for Cluster '{name}'\n==============================\n{login_details}")
 
     return login_details
 
-    
+

--- a/test_manage_arkime/commands/test_get_login_details.py
+++ b/test_manage_arkime/commands/test_get_login_details.py
@@ -10,7 +10,7 @@ import core.constants as constants
 def test_WHEN_cmd_get_login_details_called_THEN_retrieves_them(mock_ssm_ops, mock_provider_cls):
     # Set up our mock
     mock_secrets_client = mock.Mock()
-    mock_secrets_client.get_secret_value.return_value = {"SecretString": "password"}
+    mock_secrets_client.get_secret_value.return_value = {"SecretString": "{\"adminPassword\": \"password\"}"}
     mock_provider = mock.Mock()
     mock_provider.get_secretsmanager.return_value = mock_secrets_client
     mock_provider_cls.return_value = mock_provider


### PR DESCRIPTION
The ViewerPassword secret is now a compound secret.
- adminPassword has the password used for the admin user that cdk generates
- authSecret is a placeholder that a user can fill in
- passwordSecret is a placeholder that a user might change in the future if they need to merge onprem & aws hosted

NOTE if the secretStringTemplate value is changed then CDK will
regenerate the secrets, otherwise it won't, so rerunning will not
replace authSecret with "" by default.

Added default sed replacements for VIEWER_DNS, VIEWER_USER, and CLUSTER_NAME
Added sed replacements for new AUTH_SECRET and PASSWORD_SECRET

The sample config.ini now has oidc section commented out with directions for setup

**Testing**
* Updated the test case since json secret now
* Deployed and used cognito on my own cluster


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
