### PR TITLE
create-cluster allows Capture VPC CIDR to be user-set

### DIFF
--- a/cdk-lib/capture-stacks/capture-nodes-stack.ts
+++ b/cdk-lib/capture-stacks/capture-nodes-stack.ts
@@ -124,7 +124,8 @@ export class CaptureNodesStack extends cdk.Stack {
         });
 
         const capacityProvider = new ecs.AsgCapacityProvider(this, 'AsgCapacityProvider', {
-            autoScalingGroup,
+            autoScalingGroup: autoScalingGroup,
+            enableManagedTerminationProtection: false
         });
         cluster.addAsgCapacityProvider(capacityProvider);
 

--- a/cdk-lib/capture-stacks/capture-vpc-stack.ts
+++ b/cdk-lib/capture-stacks/capture-vpc-stack.ts
@@ -18,17 +18,17 @@ export class CaptureVpcStack extends Stack {
     super(scope, id, props);
 
     this.vpc = new ec2.Vpc(this, 'VPC', {
+        ipAddresses: ec2.IpAddresses.cidr(props.planCluster.captureVpc.cidr.block),
         maxAzs: props.planCluster.captureVpc.numAzs,
         subnetConfiguration: [
             {
                 subnetType: ec2.SubnetType.PUBLIC,
                 name: 'Ingress',
-                cidrMask: 24
+                cidrMask: 28 // minimum size allowed
             },
             {
                 subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
-                name: 'CaptureNodes',
-                cidrMask: 24
+                name: 'CaptureNodes'
             }
         ]
     });

--- a/cdk-lib/capture-stacks/capture-vpc-stack.ts
+++ b/cdk-lib/capture-stacks/capture-vpc-stack.ts
@@ -24,7 +24,7 @@ export class CaptureVpcStack extends Stack {
             {
                 subnetType: ec2.SubnetType.PUBLIC,
                 name: 'Ingress',
-                cidrMask: 28 // minimum size allowed
+                cidrMask: props.planCluster.captureVpc.publicSubnetMask
             },
             {
                 subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,

--- a/cdk-lib/core/context-types.ts
+++ b/cdk-lib/core/context-types.ts
@@ -42,9 +42,19 @@ export interface OSDomainPlan {
 }
 
 /**
+ * Structure to hold CIDR details
+ */
+export interface Cidr {
+    block: string;
+    prefix: string;
+    mask: string;
+}
+
+/**
  * Structure to hold the details of the cluster's Capture VPC
  */
 export interface CaptureVpcPlan {
+    cidr: Cidr;
     numAzs: number;
 }
 

--- a/cdk-lib/core/context-types.ts
+++ b/cdk-lib/core/context-types.ts
@@ -56,6 +56,7 @@ export interface Cidr {
 export interface CaptureVpcPlan {
     cidr: Cidr;
     numAzs: number;
+    publicSubnetMask: number;
 }
 
 /**

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -105,11 +105,21 @@ cli.add_command(demo_traffic_destroy)
     show_default=True,
     default=False
 )
+@click.option(
+    "--capture-cidr", 
+    help=("CAN ONLY BE SET ON INITIAL CLUSTER CREATION!  The CIDR to use for the Capture VPC, including the Capture"
+          " Nodes and OS Domain.  Includes the Viewer Nodes and the Viewer LB unless you specify a separate CIDR for"
+          " them.  Changing this requires deleting/recreating the Cluster."),
+    default=None,
+    type=click.STRING,
+    required=False)
 @click.pass_context
-def cluster_create(ctx, name, expected_traffic, spi_days, history_days, replicas, pcap_days, preconfirm_usage, just_print_cfn):
+def cluster_create(ctx, name, expected_traffic, spi_days, history_days, replicas, pcap_days, preconfirm_usage,
+                   just_print_cfn, capture_cidr):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_cluster_create(profile, region, name, expected_traffic, spi_days, history_days, replicas, pcap_days, preconfirm_usage, just_print_cfn)
+    cmd_cluster_create(profile, region, name, expected_traffic, spi_days, history_days, replicas, pcap_days,
+                       preconfirm_usage, just_print_cfn, capture_cidr)
 cli.add_command(cluster_create)
 
 @click.command(help="Tears down the Arkime Cluster in your account; by default, leaves your data intact")

--- a/manage_arkime/cdk_interactions/cdk_context.py
+++ b/manage_arkime/cdk_interactions/cdk_context.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 import core.constants as constants
 from core.capacity_planning import (CaptureNodesPlan, ViewerNodesPlan, CaptureVpcPlan, ClusterPlan, DataNodesPlan, EcsSysResourcePlan,
                                     MasterNodesPlan, OSDomainPlan, DEFAULT_NUM_AZS, S3Plan, DEFAULT_S3_STORAGE_CLASS,
-                                    DEFAULT_VPC_CIDR)
+                                    DEFAULT_VPC_CIDR, DEFAULT_CAPTURE_PUBLIC_MASK)
 from core.user_config import UserConfig
 
 def generate_cluster_create_context(name: str, viewer_cert_arn: str, cluster_plan: ClusterPlan,
@@ -27,7 +27,7 @@ def generate_cluster_destroy_context(name: str) -> Dict[str, str]:
     fake_arn = "N/A"
     fake_cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 1, 2, 1),
-        CaptureVpcPlan(DEFAULT_VPC_CIDR, 2),
+        CaptureVpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK),
         EcsSysResourcePlan(1, 1),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, 1),

--- a/manage_arkime/cdk_interactions/cdk_context.py
+++ b/manage_arkime/cdk_interactions/cdk_context.py
@@ -4,8 +4,8 @@ from typing import Dict, List
 
 import core.constants as constants
 from core.capacity_planning import (CaptureNodesPlan, ViewerNodesPlan, CaptureVpcPlan, ClusterPlan, DataNodesPlan, EcsSysResourcePlan,
-                                    MasterNodesPlan, OSDomainPlan, DEFAULT_NUM_AZS, S3Plan,
-                                    DEFAULT_S3_STORAGE_CLASS)
+                                    MasterNodesPlan, OSDomainPlan, DEFAULT_NUM_AZS, S3Plan, DEFAULT_S3_STORAGE_CLASS,
+                                    DEFAULT_VPC_CIDR)
 from core.user_config import UserConfig
 
 def generate_cluster_create_context(name: str, viewer_cert_arn: str, cluster_plan: ClusterPlan,
@@ -27,7 +27,7 @@ def generate_cluster_destroy_context(name: str) -> Dict[str, str]:
     fake_arn = "N/A"
     fake_cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 1, 2, 1),
-        CaptureVpcPlan(2),
+        CaptureVpcPlan(DEFAULT_VPC_CIDR, 2),
         EcsSysResourcePlan(1, 1),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, 1),

--- a/manage_arkime/commands/cluster_create.py
+++ b/manage_arkime/commands/cluster_create.py
@@ -52,6 +52,13 @@ def cmd_cluster_create(profile: str, region: str, name: str, expected_traffic: f
         logger.info("Aborting per user response")
         return
 
+    if not next_capacity_plan.will_capture_plan_fit():
+        available_ips = next_capacity_plan.captureVpc.get_usable_ips()
+        required_ips = next_capacity_plan.get_required_capture_ips()
+        logger.error(f"Your specified Capture capacity plan does not fit in the VPC; there are {available_ips} usable IPs in your VPC"
+                     f" and your plan requires {required_ips} IPs.  Aborting...")
+        return
+
     # Set up the cert the Viewers use for HTTPS
     cert_arn = _set_up_viewer_cert(name, aws_provider)
 
@@ -155,7 +162,7 @@ def _get_previous_capacity_plan(cluster_name: str, aws_provider: AwsClientProvid
     except ssm_ops.ParamDoesNotExist:
         return ClusterPlan(
             CaptureNodesPlan(None, None, None, None),
-            CaptureVpcPlan(None, None),
+            CaptureVpcPlan(None, None, None),
             EcsSysResourcePlan(None, None),
             OSDomainPlan(DataNodesPlan(None, None, None), MasterNodesPlan(None, None)),
             S3Plan(None, None),

--- a/manage_arkime/core/cross_account_wrangling.py
+++ b/manage_arkime/core/cross_account_wrangling.py
@@ -22,7 +22,7 @@ class CrossAccountAssociation:
     vpcId: str
     vpceServiceId: str
 
-    def __equal__(self, other) -> bool:
+    def __eq__(self, other) -> bool:
         return (self.clusterAccount == other.clusterAccount
                 and self.clusterName == other.clusterName
                 and self.roleName == other.roleName
@@ -175,7 +175,7 @@ class CrossAccountVpcDetail:
     vpcAccount: str
     vpcId: str
 
-    def __equal__(self, other) -> bool:
+    def __eq__(self, other) -> bool:
         return (self.busArn == other.busArn
                 and self.mirrorFilterId == other.mirrorFilterId
                 and self.mirrorVni == other.mirrorVni

--- a/manage_arkime/core/user_config.py
+++ b/manage_arkime/core/user_config.py
@@ -19,7 +19,7 @@ class UserConfig:
         valid_kwargs = {key: value for key, value in d.items() if key in valid_keys}
         return cls(**valid_kwargs)
 
-    def __equal__(self, other):
+    def __eq__(self, other):
         return (self.expectedTraffic == other.expectedTraffic and self.spiDays == other.spiDays
                 and self.replicas == other.replicas and self.pcapDays == other.pcapDays and self.historyDays == other.historyDays)
 

--- a/manage_arkime/opensearch_interactions/opensearch_client.py
+++ b/manage_arkime/opensearch_interactions/opensearch_client.py
@@ -14,7 +14,7 @@ class OpenSearchClient:
         self.port = port
         self.auth = auth
 
-    def __equal__(self, other) -> bool:
+    def __eq__(self, other) -> bool:
         return self.endpoint == other.endpoint and self.port == other.port and self.auth == other.auth
 
     def get_ism_policy(self, policy_id: str) -> ops.RESTResponse:

--- a/test_manage_arkime/commands/test_cluster_create.py
+++ b/test_manage_arkime/commands/test_cluster_create.py
@@ -15,7 +15,7 @@ from commands.cluster_create import (cmd_cluster_create, _set_up_viewer_cert, _g
 import core.constants as constants
 from core.capacity_planning import (CaptureNodesPlan, ViewerNodesPlan, EcsSysResourcePlan, MINIMUM_TRAFFIC, OSDomainPlan, DataNodesPlan, MasterNodesPlan,
                                     CaptureVpcPlan, ClusterPlan, DEFAULT_SPI_DAYS, DEFAULT_REPLICAS, DEFAULT_NUM_AZS, S3Plan,
-                                    DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS, DEFAULT_HISTORY_DAYS, Cidr, DEFAULT_VPC_CIDR)
+                                    DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS, DEFAULT_HISTORY_DAYS, Cidr, DEFAULT_VPC_CIDR, DEFAULT_CAPTURE_PUBLIC_MASK)
 import core.local_file as local_file
 from core.user_config import UserConfig
 from core.versioning import VersionInfo
@@ -51,7 +51,7 @@ def test_WHEN_cmd_cluster_create_called_THEN_cdk_command_correct(mock_cdk_client
 
     cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 20, 25, 1),
-        CaptureVpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS),
+        CaptureVpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK),
         EcsSysResourcePlan(3584, 15360),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS),
@@ -150,7 +150,7 @@ def test_WHEN_cmd_cluster_create_called_AND_change_capture_cidr_THEN_as_expected
 
     cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 20, 25, 1),
-        CaptureVpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS),
+        CaptureVpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK),
         EcsSysResourcePlan(3584, 15360),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS),
@@ -205,7 +205,7 @@ def test_WHEN_cmd_cluster_create_called_AND_abort_usage_THEN_as_expected(mock_cd
 
     cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 20, 25, 1),
-        CaptureVpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS),
+        CaptureVpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK),
         EcsSysResourcePlan(3584, 15360),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS),
@@ -214,6 +214,54 @@ def test_WHEN_cmd_cluster_create_called_AND_abort_usage_THEN_as_expected(mock_cd
     mock_get_plans.return_value = cluster_plan
 
     mock_confirm.return_value = False
+
+    # Run our test
+    cmd_cluster_create("profile", "region", "my-cluster", None, None, None, None, None, True, False, None)
+
+    # Check our results
+    expected_calls = []
+    assert expected_calls == mock_client.deploy.call_args_list
+
+    expected_set_up_calls = []
+    assert expected_set_up_calls == mock_set_up.call_args_list
+
+    expected_configure_calls = []
+    assert expected_configure_calls == mock_configure.call_args_list
+
+    expected_tag_calls = []
+    assert expected_tag_calls == mock_tag.call_args_list
+
+    expected_set_up_arkime_conf_calls = []
+    assert expected_set_up_arkime_conf_calls == mock_set_up_arkime_conf.call_args_list
+
+@mock.patch("commands.cluster_create.AwsClientProvider", mock.Mock())
+@mock.patch("commands.cluster_create._tag_domain")
+@mock.patch("commands.cluster_create._set_up_arkime_config")
+@mock.patch("commands.cluster_create._configure_ism")
+@mock.patch("commands.cluster_create._get_previous_user_config")
+@mock.patch("commands.cluster_create._get_previous_capacity_plan")
+@mock.patch("commands.cluster_create._confirm_usage")
+@mock.patch("commands.cluster_create._get_next_user_config")
+@mock.patch("commands.cluster_create._get_next_capacity_plan")
+@mock.patch("commands.cluster_create._set_up_viewer_cert")
+@mock.patch("commands.cluster_create.CdkClient")
+def test_WHEN_cmd_cluster_create_called_AND_plan_doesnt_fit_THEN_as_expected(mock_cdk_client_cls, mock_set_up, mock_get_plans, mock_get_config,
+                                                                         mock_confirm, mock_get_prev_plan, mock_get_prev_config, mock_configure,
+                                                                         mock_set_up_arkime_conf, mock_tag):
+    # Set up our mock
+    mock_set_up.return_value = "arn"
+
+    mock_client = mock.Mock()
+    mock_cdk_client_cls.return_value = mock_client
+
+    user_config = UserConfig(1, 30, 365, 2, 30)
+    mock_get_config.return_value = user_config
+
+    mock_cluster_plan = mock.Mock()
+    mock_cluster_plan.will_capture_plan_fit.return_value = False
+    mock_get_plans.return_value = mock_cluster_plan
+
+    mock_confirm.return_value = True
 
     # Run our test
     cmd_cluster_create("profile", "region", "my-cluster", None, None, None, None, None, True, False, None)
@@ -270,7 +318,7 @@ def test_WHEN_cmd_cluster_create_called_AND_just_print_THEN_as_expected(mock_cdk
 
     cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 20, 25, 1),
-        CaptureVpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS),
+        CaptureVpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK),
         EcsSysResourcePlan(3584, 15360),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS),
@@ -513,7 +561,8 @@ def test_WHEN_get_previous_capacity_plan_called_AND_exists_THEN_as_expected(mock
                 "prefix": "1.2.3.4",
                 "mask": "24",
             },
-            "numAzs": 2
+            "numAzs": 2,
+            "publicSubnetMask": 28,
         },
         "ecsResources": {
             "cpu": 3584,
@@ -544,7 +593,7 @@ def test_WHEN_get_previous_capacity_plan_called_AND_exists_THEN_as_expected(mock
     # Check our results
     expected_value = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 1, 2, 1),
-        CaptureVpcPlan(Cidr("1.2.3.4/24"), 2),
+        CaptureVpcPlan(Cidr("1.2.3.4/24"), DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK),
         EcsSysResourcePlan(3584, 15360),
         OSDomainPlan(DataNodesPlan(2, "r6g.large.search", 1024), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, 30),
@@ -572,7 +621,7 @@ def test_WHEN_get_previous_capacity_plan_called_AND_doesnt_exist_THEN_as_expecte
     # Check our results
     expected_value = ClusterPlan(
         CaptureNodesPlan(None, None, None, None),
-        CaptureVpcPlan(None, None),
+        CaptureVpcPlan(None, None, None),
         EcsSysResourcePlan(None, None),
         OSDomainPlan(DataNodesPlan(None, None, None), MasterNodesPlan(None, None)),
         S3Plan(None, None),
@@ -597,11 +646,11 @@ def test_WHEN_get_next_capacity_plan_called_THEN_as_expected(mock_ssm_ops, mock_
 
     mock_get_cap.return_value = CaptureNodesPlan("m5.xlarge", 1, 2, 1)
     mock_get_os.return_value = OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search"))
-    mock_get_capture.return_value = CaptureVpcPlan(Cidr("1.2.3.4/24"), DEFAULT_NUM_AZS)
+    mock_get_capture.return_value = CaptureVpcPlan(Cidr("1.2.3.4/24"), DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK)
 
     previous_cluster_plan = ClusterPlan(
         CaptureNodesPlan(None, None, None, None),
-        CaptureVpcPlan(None, None),
+        CaptureVpcPlan(None, None, None),
         EcsSysResourcePlan(None, None),
         OSDomainPlan(DataNodesPlan(None, None, None), MasterNodesPlan(None, None)),
         S3Plan(None, None),
@@ -615,7 +664,7 @@ def test_WHEN_get_next_capacity_plan_called_THEN_as_expected(mock_ssm_ops, mock_
 
     # Check our results
     assert mock_get_cap.return_value == actual_value.captureNodes
-    assert CaptureVpcPlan(Cidr("1.2.3.4/24"), DEFAULT_NUM_AZS) == actual_value.captureVpc
+    assert CaptureVpcPlan(Cidr("1.2.3.4/24"), DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK) == actual_value.captureVpc
     assert mock_get_os.return_value == actual_value.osDomain
     assert EcsSysResourcePlan(3584, 15360) == actual_value.ecsResources
     assert S3Plan(DEFAULT_S3_STORAGE_CLASS, 35) == actual_value.s3
@@ -631,7 +680,7 @@ def test_WHEN_get_next_capacity_plan_called_THEN_as_expected(mock_ssm_ops, mock_
     assert expected_get_os_calls == mock_get_os.call_args_list
 
     expected_get_capture_vpc_calls = [
-        mock.call(CaptureVpcPlan(None, None), "1.2.3.4/24")
+        mock.call(CaptureVpcPlan(None, None, None), "1.2.3.4/24")
     ]
     assert expected_get_capture_vpc_calls == mock_get_capture.call_args_list
 

--- a/test_manage_arkime/commands/test_cluster_create.py
+++ b/test_manage_arkime/commands/test_cluster_create.py
@@ -15,7 +15,7 @@ from commands.cluster_create import (cmd_cluster_create, _set_up_viewer_cert, _g
 import core.constants as constants
 from core.capacity_planning import (CaptureNodesPlan, ViewerNodesPlan, EcsSysResourcePlan, MINIMUM_TRAFFIC, OSDomainPlan, DataNodesPlan, MasterNodesPlan,
                                     CaptureVpcPlan, ClusterPlan, DEFAULT_SPI_DAYS, DEFAULT_REPLICAS, DEFAULT_NUM_AZS, S3Plan,
-                                    DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS, DEFAULT_HISTORY_DAYS)
+                                    DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS, DEFAULT_HISTORY_DAYS, Cidr, DEFAULT_VPC_CIDR)
 import core.local_file as local_file
 from core.user_config import UserConfig
 from core.versioning import VersionInfo
@@ -51,7 +51,7 @@ def test_WHEN_cmd_cluster_create_called_THEN_cdk_command_correct(mock_cdk_client
 
     cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 20, 25, 1),
-        CaptureVpcPlan(DEFAULT_NUM_AZS),
+        CaptureVpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS),
         EcsSysResourcePlan(3584, 15360),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS),
@@ -62,7 +62,7 @@ def test_WHEN_cmd_cluster_create_called_THEN_cdk_command_correct(mock_cdk_client
     mock_confirm.return_value = True
 
     # Run our test
-    cmd_cluster_create("profile", "region", "my-cluster", None, None, None, None, None, True, False)
+    cmd_cluster_create("profile", "region", "my-cluster", None, None, None, None, None, True, False, None)
 
     # Check our results
     expected_calls = [
@@ -136,6 +136,61 @@ def test_WHEN_cmd_cluster_create_called_THEN_cdk_command_correct(mock_cdk_client
 @mock.patch("commands.cluster_create._get_next_capacity_plan")
 @mock.patch("commands.cluster_create._set_up_viewer_cert")
 @mock.patch("commands.cluster_create.CdkClient")
+def test_WHEN_cmd_cluster_create_called_AND_change_capture_cidr_THEN_as_expected(mock_cdk_client_cls, mock_set_up, mock_get_plans, mock_get_config,
+                                                                         mock_confirm, mock_get_prev_plan, mock_get_prev_config, mock_configure,
+                                                                         mock_set_up_arkime_conf, mock_tag):
+    # Set up our mock
+    mock_set_up.return_value = "arn"
+
+    mock_client = mock.Mock()
+    mock_cdk_client_cls.return_value = mock_client
+
+    user_config = UserConfig(1, 30, 365, 2, 30)
+    mock_get_config.return_value = user_config
+
+    cluster_plan = ClusterPlan(
+        CaptureNodesPlan("m5.xlarge", 20, 25, 1),
+        CaptureVpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS),
+        EcsSysResourcePlan(3584, 15360),
+        OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
+        S3Plan(DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS),
+        ViewerNodesPlan(20, 5),
+    )
+    mock_get_plans.return_value = cluster_plan
+
+    # Run our test
+    cmd_cluster_create("profile", "region", "my-cluster", None, None, None, None, None, True, False, "1.2.3.4/24")
+
+    # Check our results
+    expected_calls = []
+    assert expected_calls == mock_client.deploy.call_args_list
+
+    expected_confirm_calls = []
+    assert expected_confirm_calls == mock_confirm.call_args_list
+
+    expected_set_up_calls = []
+    assert expected_set_up_calls == mock_set_up.call_args_list
+
+    expected_configure_calls = []
+    assert expected_configure_calls == mock_configure.call_args_list
+
+    expected_tag_calls = []
+    assert expected_tag_calls == mock_tag.call_args_list
+
+    expected_set_up_arkime_conf_calls = []
+    assert expected_set_up_arkime_conf_calls == mock_set_up_arkime_conf.call_args_list
+
+@mock.patch("commands.cluster_create.AwsClientProvider", mock.Mock())
+@mock.patch("commands.cluster_create._tag_domain")
+@mock.patch("commands.cluster_create._set_up_arkime_config")
+@mock.patch("commands.cluster_create._configure_ism")
+@mock.patch("commands.cluster_create._get_previous_user_config")
+@mock.patch("commands.cluster_create._get_previous_capacity_plan")
+@mock.patch("commands.cluster_create._confirm_usage")
+@mock.patch("commands.cluster_create._get_next_user_config")
+@mock.patch("commands.cluster_create._get_next_capacity_plan")
+@mock.patch("commands.cluster_create._set_up_viewer_cert")
+@mock.patch("commands.cluster_create.CdkClient")
 def test_WHEN_cmd_cluster_create_called_AND_abort_usage_THEN_as_expected(mock_cdk_client_cls, mock_set_up, mock_get_plans, mock_get_config,
                                                                          mock_confirm, mock_get_prev_plan, mock_get_prev_config, mock_configure,
                                                                          mock_set_up_arkime_conf, mock_tag):
@@ -150,7 +205,7 @@ def test_WHEN_cmd_cluster_create_called_AND_abort_usage_THEN_as_expected(mock_cd
 
     cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 20, 25, 1),
-        CaptureVpcPlan(DEFAULT_NUM_AZS),
+        CaptureVpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS),
         EcsSysResourcePlan(3584, 15360),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS),
@@ -161,7 +216,7 @@ def test_WHEN_cmd_cluster_create_called_AND_abort_usage_THEN_as_expected(mock_cd
     mock_confirm.return_value = False
 
     # Run our test
-    cmd_cluster_create("profile", "region", "my-cluster", None, None, None, None, None, True, False)
+    cmd_cluster_create("profile", "region", "my-cluster", None, None, None, None, None, True, False, None)
 
     # Check our results
     expected_calls = []
@@ -215,7 +270,7 @@ def test_WHEN_cmd_cluster_create_called_AND_just_print_THEN_as_expected(mock_cdk
 
     cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 20, 25, 1),
-        CaptureVpcPlan(DEFAULT_NUM_AZS),
+        CaptureVpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS),
         EcsSysResourcePlan(3584, 15360),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS),
@@ -229,7 +284,7 @@ def test_WHEN_cmd_cluster_create_called_AND_just_print_THEN_as_expected(mock_cdk
     mock_get_root_dir.return_value = "/path"
 
     # Run our test
-    cmd_cluster_create("profile", "region", "my-cluster", None, None, None, None, None, True, True)
+    cmd_cluster_create("profile", "region", "my-cluster", None, None, None, None, None, True, True, None)
 
     # Check our results
     expected_calls = [
@@ -443,6 +498,8 @@ def test_WHEN_get_next_user_config_called_AND_specify_all_THEN_as_expected(mock_
 @mock.patch("commands.cluster_create.ssm_ops")
 def test_WHEN_get_previous_capacity_plan_called_AND_exists_THEN_as_expected(mock_ssm_ops):
     # Set up our mock
+    mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
+
     mock_ssm_ops.get_ssm_param_json_value.return_value = {
         "captureNodes": {
             "instanceType": "m5.xlarge",
@@ -451,6 +508,11 @@ def test_WHEN_get_previous_capacity_plan_called_AND_exists_THEN_as_expected(mock
             "minCount": 1
         },
         "captureVpc": {
+            "cidr": {
+                "block": "1.2.3.4/24",
+                "prefix": "1.2.3.4",
+                "mask": "24",
+            },
             "numAzs": 2
         },
         "ecsResources": {
@@ -482,7 +544,7 @@ def test_WHEN_get_previous_capacity_plan_called_AND_exists_THEN_as_expected(mock
     # Check our results
     expected_value = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 1, 2, 1),
-        CaptureVpcPlan(2),
+        CaptureVpcPlan(Cidr("1.2.3.4/24"), 2),
         EcsSysResourcePlan(3584, 15360),
         OSDomainPlan(DataNodesPlan(2, "r6g.large.search", 1024), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, 30),
@@ -510,7 +572,7 @@ def test_WHEN_get_previous_capacity_plan_called_AND_doesnt_exist_THEN_as_expecte
     # Check our results
     expected_value = ClusterPlan(
         CaptureNodesPlan(None, None, None, None),
-        CaptureVpcPlan(None),
+        CaptureVpcPlan(None, None),
         EcsSysResourcePlan(None, None),
         OSDomainPlan(DataNodesPlan(None, None, None), MasterNodesPlan(None, None)),
         S3Plan(None, None),
@@ -524,25 +586,36 @@ def test_WHEN_get_previous_capacity_plan_called_AND_doesnt_exist_THEN_as_expecte
     assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
 
 
+@mock.patch("commands.cluster_create.get_capture_vpc_plan")
 @mock.patch("commands.cluster_create.get_os_domain_plan")
 @mock.patch("commands.cluster_create.get_capture_node_capacity_plan")
 @mock.patch("commands.cluster_create.ssm_ops")
-def test_WHEN_get_next_capacity_plan_called_THEN_as_expected(mock_ssm_ops, mock_get_cap, mock_get_os):
+def test_WHEN_get_next_capacity_plan_called_THEN_as_expected(mock_ssm_ops, mock_get_cap, mock_get_os, mock_get_capture):
     # Set up our mock
     mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
     mock_ssm_ops.get_ssm_param_json_value.side_effect = ssm_ops.ParamDoesNotExist("")
 
     mock_get_cap.return_value = CaptureNodesPlan("m5.xlarge", 1, 2, 1)
     mock_get_os.return_value = OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search"))
+    mock_get_capture.return_value = CaptureVpcPlan(Cidr("1.2.3.4/24"), DEFAULT_NUM_AZS)
+
+    previous_cluster_plan = ClusterPlan(
+        CaptureNodesPlan(None, None, None, None),
+        CaptureVpcPlan(None, None),
+        EcsSysResourcePlan(None, None),
+        OSDomainPlan(DataNodesPlan(None, None, None), MasterNodesPlan(None, None)),
+        S3Plan(None, None),
+        ViewerNodesPlan(None, None),
+    )
 
     mock_provider = mock.Mock()
 
     # Run our test
-    actual_value = _get_next_capacity_plan(UserConfig(1, 40, 120, 2, 35))
+    actual_value = _get_next_capacity_plan(UserConfig(1, 40, 120, 2, 35), "1.2.3.4/24", previous_cluster_plan)
 
     # Check our results
     assert mock_get_cap.return_value == actual_value.captureNodes
-    assert CaptureVpcPlan(DEFAULT_NUM_AZS) == actual_value.captureVpc
+    assert CaptureVpcPlan(Cidr("1.2.3.4/24"), DEFAULT_NUM_AZS) == actual_value.captureVpc
     assert mock_get_os.return_value == actual_value.osDomain
     assert EcsSysResourcePlan(3584, 15360) == actual_value.ecsResources
     assert S3Plan(DEFAULT_S3_STORAGE_CLASS, 35) == actual_value.s3
@@ -556,6 +629,11 @@ def test_WHEN_get_next_capacity_plan_called_THEN_as_expected(mock_ssm_ops, mock_
         mock.call(1, 40, 2, DEFAULT_NUM_AZS)
     ]
     assert expected_get_os_calls == mock_get_os.call_args_list
+
+    expected_get_capture_vpc_calls = [
+        mock.call(CaptureVpcPlan(None, None), "1.2.3.4/24")
+    ]
+    assert expected_get_capture_vpc_calls == mock_get_capture.call_args_list
 
 @mock.patch("commands.cluster_create.UsageReport")
 @mock.patch("commands.cluster_create.PriceReport")

--- a/test_manage_arkime/commands/test_cluster_destroy.py
+++ b/test_manage_arkime/commands/test_cluster_destroy.py
@@ -7,7 +7,7 @@ from aws_interactions.ssm_operations import ParamDoesNotExist
 from commands.cluster_destroy import cmd_cluster_destroy, _destroy_viewer_cert, _delete_arkime_config_from_datastore
 import core.constants as constants
 from core.capacity_planning import (CaptureNodesPlan, ViewerNodesPlan, EcsSysResourcePlan, OSDomainPlan, DataNodesPlan, MasterNodesPlan,
-                                    ClusterPlan, CaptureVpcPlan, S3Plan, DEFAULT_S3_STORAGE_CLASS)
+                                    ClusterPlan, CaptureVpcPlan, S3Plan, DEFAULT_S3_STORAGE_CLASS, DEFAULT_VPC_CIDR)
 from core.user_config import UserConfig
 
 TEST_CLUSTER = "my-cluster"
@@ -35,7 +35,7 @@ def test_WHEN_cmd_cluster_destroy_called_AND_dont_destroy_everything_THEN_expect
 
     cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 1, 2, 1),
-        CaptureVpcPlan(2),
+        CaptureVpcPlan(DEFAULT_VPC_CIDR, 2),
         EcsSysResourcePlan(1, 1),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, 1),
@@ -124,7 +124,7 @@ def test_WHEN_cmd_cluster_destroy_called_AND_destroy_everything_THEN_expected_cm
 
     cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 1, 2, 1),
-        CaptureVpcPlan(2),
+        CaptureVpcPlan(DEFAULT_VPC_CIDR, 2),
         EcsSysResourcePlan(1, 1),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, 1),

--- a/test_manage_arkime/commands/test_cluster_destroy.py
+++ b/test_manage_arkime/commands/test_cluster_destroy.py
@@ -7,7 +7,7 @@ from aws_interactions.ssm_operations import ParamDoesNotExist
 from commands.cluster_destroy import cmd_cluster_destroy, _destroy_viewer_cert, _delete_arkime_config_from_datastore
 import core.constants as constants
 from core.capacity_planning import (CaptureNodesPlan, ViewerNodesPlan, EcsSysResourcePlan, OSDomainPlan, DataNodesPlan, MasterNodesPlan,
-                                    ClusterPlan, CaptureVpcPlan, S3Plan, DEFAULT_S3_STORAGE_CLASS, DEFAULT_VPC_CIDR)
+                                    ClusterPlan, CaptureVpcPlan, S3Plan, DEFAULT_S3_STORAGE_CLASS, DEFAULT_VPC_CIDR, DEFAULT_CAPTURE_PUBLIC_MASK)
 from core.user_config import UserConfig
 
 TEST_CLUSTER = "my-cluster"
@@ -35,7 +35,7 @@ def test_WHEN_cmd_cluster_destroy_called_AND_dont_destroy_everything_THEN_expect
 
     cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 1, 2, 1),
-        CaptureVpcPlan(DEFAULT_VPC_CIDR, 2),
+        CaptureVpcPlan(DEFAULT_VPC_CIDR, 2, DEFAULT_CAPTURE_PUBLIC_MASK),
         EcsSysResourcePlan(1, 1),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, 1),
@@ -124,7 +124,7 @@ def test_WHEN_cmd_cluster_destroy_called_AND_destroy_everything_THEN_expected_cm
 
     cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 1, 2, 1),
-        CaptureVpcPlan(DEFAULT_VPC_CIDR, 2),
+        CaptureVpcPlan(DEFAULT_VPC_CIDR, 2, DEFAULT_CAPTURE_PUBLIC_MASK),
         EcsSysResourcePlan(1, 1),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, 1),

--- a/test_manage_arkime/core/test_capacity_planning.py
+++ b/test_manage_arkime/core/test_capacity_planning.py
@@ -181,4 +181,41 @@ def test_WHEN_get_os_domain_plan_called_THEN_as_expected():
     )
     assert expected_value == actual_value
 
+def test_WHEN_cidr_created_THEN_as_expected():
+    # Test: Valid CIDR
+    cap.Cidr("1.2.3.4/19")
 
+    # Test: Wrong CIDR form example 1
+    with pytest.raises(cap.InvalidCidr):
+        cap.Cidr("1.2.3.4 19")
+
+    # Test: Wrong CIDR form example 2
+    with pytest.raises(cap.InvalidCidr):
+        cap.Cidr("1.2.3/19")
+
+    # Test: Invalid prefix
+    with pytest.raises(cap.InvalidCidr):
+        cap.Cidr("1.2.3.256/19")
+
+    # Test: Invalid mask
+    with pytest.raises(cap.InvalidCidr):
+        cap.Cidr("1.2.3.4/33")
+
+def test_WHEN_get_capture_vpc_plan_called_THEN_as_expected():
+    # TEST: There's an existing plan, return it
+    previous_plan = cap.CaptureVpcPlan(cap.Cidr("1.2.3.4/24"), 2)
+    actual_value = cap.get_capture_vpc_plan(previous_plan, "5.5.5.5/16")
+
+    assert previous_plan == actual_value
+
+    # TEST: There's not an existing plan, use defaults
+    previous_plan = cap.CaptureVpcPlan(None, None)
+    actual_value = cap.get_capture_vpc_plan(previous_plan, None)
+
+    assert cap.CaptureVpcPlan(cap.DEFAULT_VPC_CIDR, cap.DEFAULT_NUM_AZS) == actual_value
+
+    # TEST: There's not an existing plan, use specified CIDR
+    previous_plan = cap.CaptureVpcPlan(None, None)
+    actual_value = cap.get_capture_vpc_plan(previous_plan, "5.5.5.5/16")
+
+    assert cap.CaptureVpcPlan(cap.Cidr("5.5.5.5/16"), cap.DEFAULT_NUM_AZS) == actual_value

--- a/test_manage_arkime/core/test_capacity_planning.py
+++ b/test_manage_arkime/core/test_capacity_planning.py
@@ -203,19 +203,59 @@ def test_WHEN_cidr_created_THEN_as_expected():
 
 def test_WHEN_get_capture_vpc_plan_called_THEN_as_expected():
     # TEST: There's an existing plan, return it
-    previous_plan = cap.CaptureVpcPlan(cap.Cidr("1.2.3.4/24"), 2)
+    previous_plan = cap.CaptureVpcPlan(cap.Cidr("1.2.3.4/24"), 2, cap.DEFAULT_CAPTURE_PUBLIC_MASK)
     actual_value = cap.get_capture_vpc_plan(previous_plan, "5.5.5.5/16")
 
     assert previous_plan == actual_value
 
     # TEST: There's not an existing plan, use defaults
-    previous_plan = cap.CaptureVpcPlan(None, None)
+    previous_plan = cap.CaptureVpcPlan(None, None, None)
     actual_value = cap.get_capture_vpc_plan(previous_plan, None)
 
-    assert cap.CaptureVpcPlan(cap.DEFAULT_VPC_CIDR, cap.DEFAULT_NUM_AZS) == actual_value
+    assert cap.CaptureVpcPlan(cap.DEFAULT_VPC_CIDR, cap.DEFAULT_NUM_AZS, cap.DEFAULT_CAPTURE_PUBLIC_MASK) == actual_value
 
     # TEST: There's not an existing plan, use specified CIDR
-    previous_plan = cap.CaptureVpcPlan(None, None)
+    previous_plan = cap.CaptureVpcPlan(None, None, None)
     actual_value = cap.get_capture_vpc_plan(previous_plan, "5.5.5.5/16")
 
-    assert cap.CaptureVpcPlan(cap.Cidr("5.5.5.5/16"), cap.DEFAULT_NUM_AZS) == actual_value
+    assert cap.CaptureVpcPlan(cap.Cidr("5.5.5.5/16"), cap.DEFAULT_NUM_AZS, cap.DEFAULT_CAPTURE_PUBLIC_MASK) == actual_value
+
+def test_WHEN_get_usable_capture_ips_called_THEN_as_expected():
+    # TEST: Example 1
+    test_plan = cap.CaptureVpcPlan(cap.Cidr("1.2.3.4/26"), 2, 28)
+    actual_value = test_plan.get_usable_ips()
+
+    assert 28 == actual_value
+
+    # TEST: Example 2
+    test_plan = cap.CaptureVpcPlan(cap.Cidr("1.2.3.4/24"), 2, 28)
+    actual_value = test_plan.get_usable_ips()
+
+    assert 220 == actual_value
+
+def test_WHEN_will_capture_plan_fit_called_THEN_as_expected():
+    # TEST: The plan fits
+    test_plan = cap.ClusterPlan(
+        cap.CaptureNodesPlan("m5.xlarge", 10, 15, 10),
+        cap.CaptureVpcPlan(cap.Cidr("1.2.3.4/24"), 3, 28),
+        cap.EcsSysResourcePlan(3584, 15360),
+        cap.OSDomainPlan(cap.DataNodesPlan(10, "r6g.large.search", 1024), cap.MasterNodesPlan(3, "m6g.large.search")),
+        cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30),
+        cap.ViewerNodesPlan(4, 2),
+    )
+    actual_value = test_plan.will_capture_plan_fit()
+
+    assert True == actual_value
+
+    # TEST: The plan doesn't fit
+    test_plan = cap.ClusterPlan(
+        cap.CaptureNodesPlan("m5.xlarge", 10, 15, 10),
+        cap.CaptureVpcPlan(cap.Cidr("1.2.3.4/26"), 3, 28),
+        cap.EcsSysResourcePlan(3584, 15360),
+        cap.OSDomainPlan(cap.DataNodesPlan(40, "r6g.large.search", 1024), cap.MasterNodesPlan(3, "m6g.large.search")),
+        cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30),
+        cap.ViewerNodesPlan(4, 2),
+    )
+    actual_value = test_plan.will_capture_plan_fit()
+
+    assert False == actual_value

--- a/test_manage_arkime/core/test_price_report.py
+++ b/test_manage_arkime/core/test_price_report.py
@@ -11,7 +11,7 @@ def test_WHEN_PriceReport_get_report_THEN_as_expected():
     # Set up the test
     plan = cap.ClusterPlan(
         cap.CaptureNodesPlan(INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
-        cap.CaptureVpcPlan(1),
+        cap.CaptureVpcPlan(cap.DEFAULT_VPC_CIDR, 1),
         cap.EcsSysResourcePlan(1, 1),
         cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
         cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30),

--- a/test_manage_arkime/core/test_price_report.py
+++ b/test_manage_arkime/core/test_price_report.py
@@ -11,7 +11,7 @@ def test_WHEN_PriceReport_get_report_THEN_as_expected():
     # Set up the test
     plan = cap.ClusterPlan(
         cap.CaptureNodesPlan(INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
-        cap.CaptureVpcPlan(cap.DEFAULT_VPC_CIDR, 1),
+        cap.CaptureVpcPlan(cap.DEFAULT_VPC_CIDR, 1, cap.DEFAULT_CAPTURE_PUBLIC_MASK),
         cap.EcsSysResourcePlan(1, 1),
         cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
         cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30),

--- a/test_manage_arkime/core/test_usage_report.py
+++ b/test_manage_arkime/core/test_usage_report.py
@@ -11,7 +11,7 @@ def test_WHEN_UsageReport_get_report_THEN_as_expected():
     # Set up the test
     prev_plan = cap.ClusterPlan(
         cap.CaptureNodesPlan(None, None, None, None),
-        cap.CaptureVpcPlan(None, None),
+        cap.CaptureVpcPlan(None, None, None),
         cap.EcsSysResourcePlan(None, None),
         cap.OSDomainPlan(cap.DataNodesPlan(None, None, None), cap.MasterNodesPlan(None, "m6g.before.search")),
         cap.S3Plan(None, None),
@@ -19,7 +19,7 @@ def test_WHEN_UsageReport_get_report_THEN_as_expected():
     )
     next_plan = cap.ClusterPlan(
         cap.CaptureNodesPlan(INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
-        cap.CaptureVpcPlan(cap.DEFAULT_VPC_CIDR, 1),
+        cap.CaptureVpcPlan(cap.DEFAULT_VPC_CIDR, 1, cap.DEFAULT_CAPTURE_PUBLIC_MASK),
         cap.EcsSysResourcePlan(1, 1),
         cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
         cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30),
@@ -61,7 +61,7 @@ def test_WHEN_UsageReport_get_confirmation_AND_yes_THEN_as_expected(mock_shell):
     # Set up the test
     prev_plan = cap.ClusterPlan(
         cap.CaptureNodesPlan(None, None, None, None),
-        cap.CaptureVpcPlan(None, None),
+        cap.CaptureVpcPlan(None, None, None),
         cap.EcsSysResourcePlan(None, None),
         cap.OSDomainPlan(cap.DataNodesPlan(None, None, None), cap.MasterNodesPlan(None, None)),
         cap.S3Plan(None, None),
@@ -69,7 +69,7 @@ def test_WHEN_UsageReport_get_confirmation_AND_yes_THEN_as_expected(mock_shell):
     )
     next_plan = cap.ClusterPlan(
         cap.CaptureNodesPlan(INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
-        cap.CaptureVpcPlan(cap.DEFAULT_VPC_CIDR, 1),
+        cap.CaptureVpcPlan(cap.DEFAULT_VPC_CIDR, 1, cap.DEFAULT_CAPTURE_PUBLIC_MASK),
         cap.EcsSysResourcePlan(1, 1),
         cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
         cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30),
@@ -93,7 +93,7 @@ def test_WHEN_UsageReport_get_confirmation_AND_no_THEN_as_expected(mock_shell):
     # Set up the test
     prev_plan = cap.ClusterPlan(
         cap.CaptureNodesPlan(None, None, None, None),
-        cap.CaptureVpcPlan(None, None),
+        cap.CaptureVpcPlan(None, None, None),
         cap.EcsSysResourcePlan(None, None),
         cap.OSDomainPlan(cap.DataNodesPlan(None, None, None), cap.MasterNodesPlan(None, None)),
         cap.S3Plan(None, None),
@@ -101,7 +101,7 @@ def test_WHEN_UsageReport_get_confirmation_AND_no_THEN_as_expected(mock_shell):
     )
     next_plan = cap.ClusterPlan(
         cap.CaptureNodesPlan(INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
-        cap.CaptureVpcPlan(cap.DEFAULT_VPC_CIDR, 1),
+        cap.CaptureVpcPlan(cap.DEFAULT_VPC_CIDR, 1, cap.DEFAULT_CAPTURE_PUBLIC_MASK),
         cap.EcsSysResourcePlan(1, 1),
         cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
         cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30),

--- a/test_manage_arkime/core/test_usage_report.py
+++ b/test_manage_arkime/core/test_usage_report.py
@@ -5,13 +5,13 @@ import core.capacity_planning as cap
 from core.usage_report import UsageReport
 from core.user_config import UserConfig
 
-INSTANCE_TYPE_CAPTURE_NODE = "m5.xlarge";
+INSTANCE_TYPE_CAPTURE_NODE = "m5.xlarge"
 
 def test_WHEN_UsageReport_get_report_THEN_as_expected():
     # Set up the test
     prev_plan = cap.ClusterPlan(
         cap.CaptureNodesPlan(None, None, None, None),
-        cap.CaptureVpcPlan(None),
+        cap.CaptureVpcPlan(None, None),
         cap.EcsSysResourcePlan(None, None),
         cap.OSDomainPlan(cap.DataNodesPlan(None, None, None), cap.MasterNodesPlan(None, "m6g.before.search")),
         cap.S3Plan(None, None),
@@ -19,7 +19,7 @@ def test_WHEN_UsageReport_get_report_THEN_as_expected():
     )
     next_plan = cap.ClusterPlan(
         cap.CaptureNodesPlan(INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
-        cap.CaptureVpcPlan(1),
+        cap.CaptureVpcPlan(cap.DEFAULT_VPC_CIDR, 1),
         cap.EcsSysResourcePlan(1, 1),
         cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
         cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30),
@@ -61,7 +61,7 @@ def test_WHEN_UsageReport_get_confirmation_AND_yes_THEN_as_expected(mock_shell):
     # Set up the test
     prev_plan = cap.ClusterPlan(
         cap.CaptureNodesPlan(None, None, None, None),
-        cap.CaptureVpcPlan(None),
+        cap.CaptureVpcPlan(None, None),
         cap.EcsSysResourcePlan(None, None),
         cap.OSDomainPlan(cap.DataNodesPlan(None, None, None), cap.MasterNodesPlan(None, None)),
         cap.S3Plan(None, None),
@@ -69,7 +69,7 @@ def test_WHEN_UsageReport_get_confirmation_AND_yes_THEN_as_expected(mock_shell):
     )
     next_plan = cap.ClusterPlan(
         cap.CaptureNodesPlan(INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
-        cap.CaptureVpcPlan(1),
+        cap.CaptureVpcPlan(cap.DEFAULT_VPC_CIDR, 1),
         cap.EcsSysResourcePlan(1, 1),
         cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
         cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30),
@@ -93,7 +93,7 @@ def test_WHEN_UsageReport_get_confirmation_AND_no_THEN_as_expected(mock_shell):
     # Set up the test
     prev_plan = cap.ClusterPlan(
         cap.CaptureNodesPlan(None, None, None, None),
-        cap.CaptureVpcPlan(None),
+        cap.CaptureVpcPlan(None, None),
         cap.EcsSysResourcePlan(None, None),
         cap.OSDomainPlan(cap.DataNodesPlan(None, None, None), cap.MasterNodesPlan(None, None)),
         cap.S3Plan(None, None),
@@ -101,7 +101,7 @@ def test_WHEN_UsageReport_get_confirmation_AND_no_THEN_as_expected(mock_shell):
     )
     next_plan = cap.ClusterPlan(
         cap.CaptureNodesPlan(INSTANCE_TYPE_CAPTURE_NODE, 1, 2, 1),
-        cap.CaptureVpcPlan(1),
+        cap.CaptureVpcPlan(cap.DEFAULT_VPC_CIDR, 1),
         cap.EcsSysResourcePlan(1, 1),
         cap.OSDomainPlan(cap.DataNodesPlan(2, "t3.small.search", 100), cap.MasterNodesPlan(3, "m6g.large.search")),
         cap.S3Plan(cap.DEFAULT_S3_STORAGE_CLASS, 30),


### PR DESCRIPTION
## Description
* Added a new CLI option to `create-cluster` to enable users to set the Capture VPC's CIDR when they first create it.  If they attempt to change it afterwards, they get an error and aren't allowed to proceed.  That's because it's not possible to change the CIDR without deleting/recreating the entire cluster.
* If the user's specified plan won't fit in their VPC, then the command aborts.

## Tasks
* https://github.com/arkime/aws-aio/issues/118

## Testing
* Added/updated unit tests
* Ran `create-cluster` from scratch with a custom CIDR, then confirmed I could update other cluster behavior using the command as long as it wasn't the CIDR.  Also tested with a plan too large for its VPC.

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py cluster-create --name MyCluster --capture-cidr 192.168.0.0/24
2023-08-30 08:01:06 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-08-30 08:01:06 - Using AWS Credential Profile: default
2023-08-30 08:01:06 - Using AWS Region: default from AWS Config settings
2023-08-30 08:01:07 - Cost estimate report:
.
.
.
2023-08-30 08:01:11 - Generating self-signed certificate...
2023-08-30 08:01:11 - Certificate generated
2023-08-30 08:01:12 - Ensuring Arkime Config dir exists for cluster: MyCluster
2023-08-30 08:01:12 - Arkime Config dir exists at: /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster-XXXXXXXXXXXX-us-east-2
2023-08-30 08:01:12 - Copying default Arkime Config to dir: /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster-XXXXXXXXXXXX-us-east-2
2023-08-30 08:01:12 - Determining the status of S3 bucket: arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster
2023-08-30 08:01:13 - S3 Bucket arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster does not exist; creating it to hold Arkime Configuration
2023-08-30 08:01:14 - Uploading Arkime config for Capture Nodes...
2023-08-30 08:01:14 - Turning Capture configuration at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster-XXXXXXXXXXXX-us-east-2/capture into archive at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster-XXXXXXXXXXXX-us-east-2/capture.zip
2023-08-30 08:01:15 - Uploading config archive to S3 bucket: arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster
2023-08-30 08:01:15 - Uploading Arkime config for Viewer Nodes...
2023-08-30 08:01:16 - Turning Viewer configuration at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster-XXXXXXXXXXXX-us-east-2/viewer into archive at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster-XXXXXXXXXXXX-us-east-2/viewer.zip
2023-08-30 08:01:16 - Uploading config archive to S3 bucket: arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster
2023-08-30 08:01:17 - Executing command: deploy MyCluster-CaptureBucket MyCluster-CaptureNodes MyCluster-CaptureVPC MyCluster-OSDomain MyCluster-ViewerNodes
2023-08-30 08:01:17 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-08-30 08:44:31 - Deployment succeeded
```

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py cluster-create --name MyCluster
2023-08-30 09:18:52 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-08-30 09:18:52 - Using AWS Credential Profile: default
2023-08-30 09:18:52 - Using AWS Region: default from AWS Config settings
2023-08-30 09:18:53 - Cost estimate report:
.
.
.
2023-08-30 09:18:56 - Ensuring Arkime Config dir exists for cluster: MyCluster
2023-08-30 09:18:56 - Arkime Config dir exists at: /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster-XXXXXXXXXXXX-us-east-2
2023-08-30 09:18:56 - Copying default Arkime Config to dir: /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster-XXXXXXXXXXXX-us-east-2
2023-08-30 09:18:56 - Cluster config directory not empty; skipping copy
2023-08-30 09:18:56 - Determining the status of S3 bucket: arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster
2023-08-30 09:18:56 - S3 Bucket arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster already exists; no work needed
2023-08-30 09:18:56 - Uploading Arkime config for Capture Nodes...
2023-08-30 09:18:57 - Config has been uploaded previously; skipping
2023-08-30 09:18:57 - Uploading Arkime config for Viewer Nodes...
2023-08-30 09:18:57 - Config has been uploaded previously; skipping
2023-08-30 09:18:57 - Executing command: deploy MyCluster-CaptureBucket MyCluster-CaptureNodes MyCluster-CaptureVPC MyCluster-OSDomain MyCluster-ViewerNodes
2023-08-30 09:18:57 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-08-30 09:22:56 - Deployment succeeded
```

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py cluster-create --name MyCluster --capture-cidr 192.168.0.0/16 --preconfirm-usage
2023-08-30 09:23:18 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-08-30 09:23:18 - Using AWS Credential Profile: default
2023-08-30 09:23:18 - Using AWS Region: default from AWS Config settings
2023-08-30 09:23:20 - You can only set the Capture VPC CIDR when you initially create the Cluster, as changing it requires tearing down the entire Cluster.  Aborting...
```

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py cluster-create --name MyCluster --capture-cidr 192.168.0.0/26 --expected-traffic 20 --spi-days 30 --history-days 365 --replicas 1 --pcap-days 30
2023-08-30 12:33:18 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-08-30 12:33:18 - Using AWS Credential Profile: default
2023-08-30 12:33:18 - Using AWS Region: default from AWS Config settings
.
.
.
2023-08-30 12:33:20 - ================================================================================
2023-08-30 12:33:20 - USER ACTION REQUIRED:
2023-08-30 12:33:20 - --------------------------------------------------------------------------------
Your settings will result in the follow AWS Resource usage:
Arkime Metadata:
    Session Retention [days]: 30
    User History Retention [days]: 365
Capture Nodes:
    Max Count: 13
    Desired Count: 10
    Min Count: 1
    Type: m5.xlarge
Viewer Nodes:
    Max Count: 4
    Min Count: 2
OpenSearch Domain:
    Master Node Count: 3
    Master Node Type: r6g.2xlarge.search
    Data Node Count: 64
    Data Node Type: r6g.4xlarge.search
    Data Node Volume Size [GB]: 6144
S3:
    PCAP Retention [days]: 30

Do you approve this usage (y/yes or n/no)? y
2023-08-30 12:33:21 - Your specified Capture capacity plan does not fit in the VPC; there are 28 usable IPs in your VPC and your plan requires 84 IPs.  Aborting...
```


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
