### PR TITLE
Use VIEWER_PASS instead of ARKIME_PASSWORD

### DIFF
--- a/manage_arkime/arkime_interactions/default_config/viewer/initialize_arkime.sh
+++ b/manage_arkime/arkime_interactions/default_config/viewer/initialize_arkime.sh
@@ -15,7 +15,7 @@ BASE64_AUTH=$(echo -n "admin:$OPENSEARCH_PASS" | base64)
 sed -i'' "s/_OS_AUTH_/$BASE64_AUTH/g" /opt/arkime/etc/config.ini
 
 VIEWER_PASS_OBJ=$(aws secretsmanager get-secret-value --secret-id $VIEWER_PASS_ARN --output text --query SecretString)
-ADMIN_PASSWORD=$(echo $VIEWER_PASS_OBJ | jq -r .adminPassword)
+VIEWER_PASS=$(echo $VIEWER_PASS_OBJ | jq -r .adminPassword)
 AUTH_SECRET=$(echo $VIEWER_PASS_OBJ | jq -r .authSecret)
 PASSWORD_SECRET=$(echo $VIEWER_PASS_OBJ | jq -r .passwordSecret)
 


### PR DESCRIPTION
Use VIEWER_PASS instead of ARMIN_PASSWORD as the environment variable for the password since that is what docker-viewer-node/run_viewer_node.sh is looking for.  If you already have a config directory for your cluster you will need to make the change in viewer/initialize_arkime.sh manually.

Test by having a non working cluster, updating the config manually and then pushing the config using config-update

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
