### PR TITLE
remove creating flow logs, fixes #124

### DIFF
--- a/cdk-lib/capture-stacks/capture-nodes-stack.ts
+++ b/cdk-lib/capture-stacks/capture-nodes-stack.ts
@@ -255,7 +255,7 @@ export class CaptureNodesStack extends cdk.Stack {
             },
             targets: [new targets.CloudWatchLogGroup(clusterLogGroup)]
         });
-        
+
         /**
          * This SSM parameter will enable us share the details of our Cluster.
          */
@@ -296,7 +296,7 @@ export class CaptureNodesStack extends cdk.Stack {
         /**
          * Create the Lambda set up the ISM policy for the OpenSearch Domain.  It receives events via a rule on the
          * Cluster Event Bus.
-        */ 
+        */
         const configureIsmLambda = new lambda.Function(this, 'ConfigureIsmLambda', {
             vpc: props.captureVpc,
             functionName: `${props.clusterName}-ConfigureIsm`,
@@ -309,7 +309,7 @@ export class CaptureNodesStack extends cdk.Stack {
                     'pip install -r requirements.txt -t /asset-output && cp -au . /asset-output'
                     ],
                 },
-            }),            
+            }),
             handler: 'lambda_handlers.configure_ism_handler',
             timeout:  cdk.Duration.seconds(30), // Something has gone very wrong if this is exceeded,
             environment: {

--- a/cdk-lib/capture-stacks/capture-vpc-stack.ts
+++ b/cdk-lib/capture-stacks/capture-vpc-stack.ts
@@ -12,7 +12,6 @@ export interface CaptureVpcStackProps extends StackProps {
 
 export class CaptureVpcStack extends Stack {
   public readonly vpc: ec2.Vpc;
-  public readonly flowLog: ec2.FlowLog;
 
   constructor(scope: Construct, id: string, props: CaptureVpcStackProps) {
     super(scope, id, props);
@@ -31,17 +30,6 @@ export class CaptureVpcStack extends Stack {
                 name: 'CaptureNodes'
             }
         ]
-    });
-    
-    const flowLogsGroup = new logs.LogGroup(this, 'FlowLogsLogGroup', {
-        logGroupName: `FlowLogs-${id}`,
-        removalPolicy: RemovalPolicy.DESTROY,
-        retention: logs.RetentionDays.TEN_YEARS,
-    });
-
-    this.flowLog = new ec2.FlowLog(this, 'FlowLogs', {
-        resourceType: ec2.FlowLogResourceType.fromVpc(this.vpc),
-        destination: ec2.FlowLogDestination.toCloudWatchLogs(flowLogsGroup),
     });
   }
 }

--- a/cdk-lib/traffic-gen-sample/traffic-gen-stack.ts
+++ b/cdk-lib/traffic-gen-sample/traffic-gen-stack.ts
@@ -19,23 +19,11 @@ export class TrafficGenStack extends cdk.Stack {
         /**
          * Set up our demo Traffic Generator's networking
          */
-        // This is a Stock VPC w/ a Public/Private subnet pair in 1 AZ along with NATGateways providing internet access 
+        // This is a Stock VPC w/ a Public/Private subnet pair in 1 AZ along with NATGateways providing internet access
         // to the private subnet.
         const vpc = new ec2.Vpc(this, 'VPC', {
             ipAddresses: ec2.IpAddresses.cidr(props.cidr),
             maxAzs: 1
-        });
-
-        // Set up VPC Flow Logs to enable visibility of the traffic mirroring on the user-side
-        const flowLogsGroup = new logs.LogGroup(this, 'FlowLogsLogGroup', {
-            logGroupName: `FlowLogs-${id}`,
-            removalPolicy: cdk.RemovalPolicy.DESTROY,
-            retention: logs.RetentionDays.TEN_YEARS,
-        });
-
-        new ec2.FlowLog(this, 'FlowLogs', {
-            resourceType: ec2.FlowLogResourceType.fromVpc(vpc),
-            destination: ec2.FlowLogDestination.toCloudWatchLogs(flowLogsGroup),
         });
 
         /**
@@ -71,7 +59,7 @@ export class TrafficGenStack extends cdk.Stack {
             memoryLimitMiB: 512,
             logging: new ecs.AwsLogDriver({ streamPrefix: 'DemoTrafficGenFargate', mode: ecs.AwsLogDriverMode.NON_BLOCKING })
         });
-        
+
         const fargateService = new ecs.FargateService(this, 'Service', {
             cluster: fargateCluster,
             taskDefinition: fargateTaskDef,
@@ -83,7 +71,7 @@ export class TrafficGenStack extends cdk.Stack {
          * Create an ECS-on-EC2 Cluster that runs our traffic generation image
          */
 
-        // 
+        //
         const ecsAsg = new autoscaling.AutoScalingGroup(this, 'EcsASG', {
             vpc: vpc,
             instanceType: new ec2.InstanceType('t3.micro'), // Arbitrarily chosen

--- a/cdk-lib/viewer-stacks/viewer-vpc-stack.ts
+++ b/cdk-lib/viewer-stacks/viewer-vpc-stack.ts
@@ -14,7 +14,6 @@ export interface ViewerVpcStackProps extends StackProps {
 
 export class ViewerVpcStack extends Stack {
   public readonly vpc: ec2.Vpc;
-  public readonly flowLog: ec2.FlowLog;
 
   constructor(scope: Construct, id: string, props: ViewerVpcStackProps) {
     super(scope, id, props);
@@ -41,7 +40,7 @@ export class ViewerVpcStack extends Stack {
         subnetIds: this.vpc.privateSubnets.map(obj => obj.subnetId),
         transitGatewayId: props.captureTgw.attrId,
         vpcId: this.vpc.vpcId,
-      
+
         // the properties below are optional
         options: {
             "DnsSupport": "enable"
@@ -80,18 +79,6 @@ export class ViewerVpcStack extends Stack {
             destinationCidrBlock: props.viewerVpcPlan.cidr.block
         })
         route.addDependency(tgwAttachment);
-    });
-    
-    // Enable logging
-    const flowLogsGroup = new logs.LogGroup(this, 'FlowLogsLogGroup', {
-        logGroupName: `FlowLogs-${id}`,
-        removalPolicy: RemovalPolicy.DESTROY,
-        retention: logs.RetentionDays.TEN_YEARS,
-    });
-
-    this.flowLog = new ec2.FlowLog(this, 'FlowLogs', {
-        resourceType: ec2.FlowLogResourceType.fromVpc(this.vpc),
-        destination: ec2.FlowLogDestination.toCloudWatchLogs(flowLogsGroup),
     });
   }
 }


### PR DESCRIPTION
No longer create flow logs for our VPC(s). A user could still create on their own.

Tested by reruning cluster-create with no issue.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
