### PR TITLE
Added a basic config-list command to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,12 @@ After running `cluster-create` and uploading the initial configuration, you'll n
 
 `config-update` will take a look at the local configuration and compare it what is currently deployed on your Nodes.  If the local configuration is different, it will be archived, sent to S3, and your ECS Containers recycled to pull down the new configuration.  If we see that Containers with the new configuration fail to start up correctly, we automatically revert to the previously deployed configuration.
 
+You can list the details of the currently (and previously) deployed configuration using the `config-list` command:
+
+```
+./manage_arkime.py config-list --cluster-name MyCluster --viewer --deployed
+```
+
 ### Viewing the Deployed Clusters
 
 To see the clusters you currently have deployed, you can use the `clusters-list` CLI command.  This will return a list of clusters and their associated details like so:

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -4,6 +4,7 @@ import logging
 import click
 
 from commands.vpc_add import cmd_vpc_add
+from commands.config_list import cmd_config_list
 from commands.config_update import cmd_config_update
 from commands.cluster_create import cmd_cluster_create
 from commands.cluster_deregister_vpc import cmd_cluster_deregister_vpc
@@ -271,6 +272,30 @@ def vpc_deregister_cluster(ctx, cluster_name, vpc_id):
     region = ctx.obj.get("region")
     cmd_vpc_deregister_cluster(profile, region, cluster_name, vpc_id)
 cli.add_command(vpc_deregister_cluster)
+
+@click.command(help="Retrieves metadata about the Arkime Cluster's config deployed to the Capture or Viewer Nodes")
+@click.option("--cluster-name", help="The name of the Arkime Cluster to update", required=True)
+@click.option("--capture",
+    help="Performs the operation for the Capture Nodes' configuration",
+    is_flag=True,
+    default=False
+)
+@click.option("--viewer",
+    help="Performs the operation for the Viewer Nodes' configuration",
+    is_flag=True,
+    default=False
+)
+@click.option("--deployed",
+    help="Gets info on the current and previous (if it exists) configuration",
+    is_flag=True,
+    default=False
+)
+@click.pass_context
+def config_list(ctx, cluster_name, capture, viewer, deployed):
+    profile = ctx.obj.get("profile")
+    region = ctx.obj.get("region")
+    cmd_config_list(profile, region, cluster_name, capture, viewer, deployed)
+cli.add_command(config_list)
 
 def main():
     logging_wrangler = LoggingWrangler()

--- a/manage_arkime/arkime_interactions/config_wrangling.py
+++ b/manage_arkime/arkime_interactions/config_wrangling.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+import json
 import logging
 import os
 import shutil
@@ -46,11 +47,24 @@ class ConfigDetails:
                 and self.version == other.version
                 and self.previous == other.previous)
 
-    def to_dict(self) -> Dict[str, str]:
+    def to_dict(self) -> Dict[str, any]:
+        """
+        Converts the current current ConfigDetails to a dict, including recursive calls to any previous ones
+        """
+
         return {
             "s3": self.s3.to_dict(),
             "version": self.version.to_dict(),
             "previous": self.previous.to_dict() if self.previous else "None",
+        }
+    
+    def self_to_dict(self) -> Dict[str, any]:
+        """
+        Converts the current current ConfigDetails's info to a dict, but does not include any previous ones
+        """
+        return {
+            "s3": self.s3.to_dict(),
+            "version": self.version.to_dict(),
         }
     
     @classmethod

--- a/manage_arkime/arkime_interactions/config_wrangling.py
+++ b/manage_arkime/arkime_interactions/config_wrangling.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 from dataclasses import dataclass
-import json
 import logging
 import os
 import shutil

--- a/manage_arkime/aws_interactions/s3_interactions.py
+++ b/manage_arkime/aws_interactions/s3_interactions.py
@@ -167,8 +167,6 @@ def list_bucket_objects(bucket_name: str, aws_provider: AwsClientProvider, prefi
     
     return all_objects
 
-# all_objects.sort(key=lambda x: x["date_modified"], reverse=True)
-
 def get_object_user_metadata(bucket_name: str, s3_key: str, aws_provider: AwsClientProvider) -> Dict[str, str]:
     """
     Gets the user-defined object metadata for a specified S3 Key

--- a/manage_arkime/commands/config_list.py
+++ b/manage_arkime/commands/config_list.py
@@ -1,0 +1,81 @@
+import json
+import logging
+import sys
+from typing import Dict, List
+
+import arkime_interactions.config_wrangling as config_wrangling
+from aws_interactions.aws_client_provider import AwsClientProvider
+import aws_interactions.s3_interactions as s3
+import aws_interactions.ssm_operations as ssm_ops
+import core.constants as constants
+
+logger = logging.getLogger(__name__)
+
+def cmd_config_list(profile: str, region: str, cluster_name: str, capture: bool, viewer: bool, deployed: bool
+                    ) -> List[Dict[str, str]]:
+    logger.debug(f"Invoking config-list with profile '{profile}' and region '{region}'")
+
+    aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)
+
+    if not (capture or viewer):
+        logger.error("You must indicate whether to operate on the Capture or Viewer config; see --help.")
+        sys.exit(1)
+    elif capture and viewer:
+        logger.error("You must indicate either to operate on the Capture or Viewer config, not both; see --help.")
+        sys.exit(1)
+    elif deployed:
+        logger.info("Retrieving config details...")
+        config_details = _get_deployed_config(cluster_name, capture, viewer, aws_provider)
+        logger.info(f"Config Details:\n{config_details}")
+    else:
+        logger.info("Retrieving config details (may take a while)...")
+        config_details = _get_all_configs(cluster_name, capture, viewer, aws_provider)
+        logger.info(f"Config Details:\n{config_details}")
+
+def _get_deployed_config(cluster_name: str, capture: bool, viewer: bool, aws_provider: AwsClientProvider) -> str:
+    config_details_param = (
+        constants.get_capture_config_details_ssm_param_name(cluster_name)
+        if capture
+        else constants.get_viewer_config_details_ssm_param_name(cluster_name)
+    )
+    raw_param_val = ssm_ops.get_ssm_param_value(config_details_param, aws_provider)
+    config = config_wrangling.ConfigDetails.from_dict(json.loads(raw_param_val))
+
+    return_value = {
+        "current": config.self_to_dict()
+    }
+    if not config.previous:
+        return_value["previous"] = "None"
+    else:
+        return_value["previous"] = config.previous.self_to_dict()
+    
+    return json.dumps(return_value, indent=4)
+
+def _get_all_configs(cluster_name: str, capture: bool, viewer: bool, aws_provider: AwsClientProvider) -> str:
+    aws_env = aws_provider.get_aws_env()
+    bucket_name = constants.get_config_bucket_name(aws_env.aws_account, aws_env.aws_region, cluster_name)
+    key_prefix = "capture" if capture else "viewer"
+
+    # Get the raw object listings, sorted newest to oldest
+    logger.debug(f"Listing S3 objects for bucket {bucket_name} and key prefix {key_prefix}")
+    config_objects = s3.list_bucket_objects(bucket_name, aws_provider, prefix=key_prefix)
+    config_objects.sort(key=lambda x: x['date_modified'], reverse=True)
+
+    # Get the metadata for each config
+    all_config_details = []
+    for config in config_objects:
+        logger.debug(f"Getting S3 metadata for bucket {bucket_name} and key {config['key']}")
+        metadata_json = s3.get_object_user_metadata(bucket_name, config["key"], aws_provider)
+
+        config_details = config_wrangling.ConfigDetails(
+            config_wrangling.S3Details(bucket_name, config["key"]),
+            config_wrangling.VersionInfo(**metadata_json)
+        )
+        all_config_details.append(config_details.self_to_dict())    
+    
+    # Return as a string
+    return json.dumps(all_config_details, indent=4)
+
+    
+
+    

--- a/test_manage_arkime/arkime_interactions/test_config_wrangling.py
+++ b/test_manage_arkime/arkime_interactions/test_config_wrangling.py
@@ -1,3 +1,4 @@
+import json
 import os
 import pytest
 import unittest.mock as mock
@@ -8,6 +9,40 @@ import core.constants as constants
 
 
 TEST_ENV = AwsEnvironment("account", "region", "profile")
+
+def test_WHEN_ConfigDetails_self_to_dict_called_THEN_as_expected():
+    # TEST: Does have a previous config
+    previous_details = config.ConfigDetails(
+        config.S3Details("bucket-name", "viewer/5/archive.zip"),
+        config.VersionInfo("1", "5", "2222", "v0.1.1", "then")
+    )
+    current_details = config.ConfigDetails(
+        config.S3Details("bucket-name", "viewer/6/archive.zip"),
+        config.VersionInfo("1", "6", "3333", "v0.1.1", "now"),
+        previous=previous_details
+    )
+    actual_value = current_details.self_to_dict()
+
+    expected_value = {
+        "s3": {"bucket": "bucket-name","key": "viewer/6/archive.zip"},
+        "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v0.1.1","time_utc": "now"}
+    }
+    assert expected_value == actual_value
+
+    # TEST: Does not have a previous config
+    previous_details = None
+    current_details = config.ConfigDetails(
+        config.S3Details("bucket-name", "viewer/6/archive.zip"),
+        config.VersionInfo("1", "6", "3333", "v0.1.1", "now"),
+        previous=previous_details
+    )
+    actual_value = current_details.self_to_dict()
+
+    expected_value = {
+        "s3": {"bucket": "bucket-name","key": "viewer/6/archive.zip"},
+        "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v0.1.1","time_utc": "now"}
+    }
+    assert expected_value == actual_value
 
 def test_WHEN_get_cluster_dir_name_called_THEN_as_expected():
     # TEST: Valid name should give right answer

--- a/test_manage_arkime/commands/test_config_list.py
+++ b/test_manage_arkime/commands/test_config_list.py
@@ -1,0 +1,185 @@
+import json
+import unittest.mock as mock
+
+import commands.config_list as cl
+import core.constants as constants
+
+
+@mock.patch("commands.config_list._get_all_configs")
+@mock.patch("commands.config_list._get_deployed_config")
+@mock.patch("commands.config_list.sys.exit")
+def test_WHEN_cmd_config_list_called_AND_dont_specify_which_THEN_exits(mock_exit, mock_get_deployed, mock_get_all):
+    # Run our test
+    cl.cmd_config_list("profile", "region", "MyCluster", False, False, False)
+
+    # Check our results
+    assert mock_exit.called_once_with(1)
+    assert not mock_get_deployed.called
+    assert not mock_get_all.called
+
+@mock.patch("commands.config_list._get_all_configs")
+@mock.patch("commands.config_list._get_deployed_config")
+@mock.patch("commands.config_list.sys.exit")
+def test_WHEN_cmd_config_list_called_AND_specify_both_which_THEN_exits(mock_exit, mock_get_deployed, mock_get_all):
+    # Run our test
+    cl.cmd_config_list("profile", "region", "MyCluster", True, True, False)
+
+    # Check our results
+    assert mock_exit.called_once_with(1)
+    assert not mock_get_deployed.called
+    assert not mock_get_all.called
+
+@mock.patch("commands.config_list._get_all_configs")
+@mock.patch("commands.config_list._get_deployed_config")
+def test_WHEN_cmd_config_list_called_AND_default_THEN_as_expected(mock_get_deployed, mock_get_all):
+    # Run our test
+    cl.cmd_config_list("profile", "region", "MyCluster", True, False, False)
+
+    # Check our results
+    expected_get_deployed_calls = []
+    assert expected_get_deployed_calls == mock_get_deployed.call_args_list
+
+    expected_get_all_calls = [
+        mock.call("MyCluster", True, False, mock.ANY)
+    ]
+    assert expected_get_all_calls == mock_get_all.call_args_list
+
+@mock.patch("commands.config_list._get_all_configs")
+@mock.patch("commands.config_list._get_deployed_config")
+def test_WHEN_cmd_config_list_called_AND_deployed_flag_THEN_as_expected(mock_get_deployed, mock_get_all):
+    # Run our test
+    cl.cmd_config_list("profile", "region", "MyCluster", True, False, True)
+
+    # Check our results
+    expected_get_deployed_calls = [
+        mock.call("MyCluster", True, False, mock.ANY)
+    ]
+    assert expected_get_deployed_calls == mock_get_deployed.call_args_list
+
+    expected_get_all_calls = []
+    assert expected_get_all_calls == mock_get_all.call_args_list
+
+@mock.patch("commands.config_list.ssm_ops.get_ssm_param_value")
+def test_WHEN_get_deployed_config_called_AND_capture_THEN_as_expected(mock_get_val):
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    mock_get_val.return_value = '{"s3": {"bucket": "bucket-name","key": "capture/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v0.1.1","time_utc": "now"}, "previous": {"s3": {"bucket": "bucket-name","key": "capture/5/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "5","md5_version": "2222","source_version": "v0.1.1","time_utc": "then"}, "previous": "None"}}'
+
+    # Run our test
+    result = cl._get_deployed_config("MyCluster", True, False, mock_aws)
+
+    # Check our results
+    expected_result_dict = {
+        "current": {
+            "s3": {"bucket": "bucket-name","key": "capture/6/archive.zip"},
+            "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v0.1.1","time_utc": "now"}
+        },
+        "previous": {
+            "s3": {"bucket": "bucket-name","key": "capture/5/archive.zip"},
+            "version": {"aws_aio_version": "1","config_version": "5","md5_version": "2222","source_version": "v0.1.1","time_utc": "then"}
+        }
+    }
+    expected_result = json.dumps(expected_result_dict, indent=4)
+    assert expected_result == result
+
+    expected_get_ssm_calls = [
+        mock.call(constants.get_capture_config_details_ssm_param_name("MyCluster"), mock_aws)
+    ]
+    assert expected_get_ssm_calls == mock_get_val.call_args_list
+
+@mock.patch("commands.config_list.ssm_ops.get_ssm_param_value")
+def test_WHEN_get_deployed_config_called_AND_viewer_THEN_as_expected(mock_get_val):
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    mock_get_val.return_value = '{"s3": {"bucket": "bucket-name","key": "viewer/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v0.1.1","time_utc": "now"}, "previous": {"s3": {"bucket": "bucket-name","key": "viewer/5/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "5","md5_version": "2222","source_version": "v0.1.1","time_utc": "then"}, "previous": "None"}}'
+
+    # Run our test
+    result = cl._get_deployed_config("MyCluster", False, True, mock_aws)
+
+    # Check our results
+    expected_result_dict = {
+        "current": {
+            "s3": {"bucket": "bucket-name","key": "viewer/6/archive.zip"},
+            "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v0.1.1","time_utc": "now"}
+        },
+        "previous": {
+            "s3": {"bucket": "bucket-name","key": "viewer/5/archive.zip"},
+            "version": {"aws_aio_version": "1","config_version": "5","md5_version": "2222","source_version": "v0.1.1","time_utc": "then"}
+        }
+    }
+    expected_result = json.dumps(expected_result_dict, indent=4)
+    assert expected_result == result
+
+    expected_get_ssm_calls = [
+        mock.call(constants.get_viewer_config_details_ssm_param_name("MyCluster"), mock_aws)
+    ]
+    assert expected_get_ssm_calls == mock_get_val.call_args_list
+
+@mock.patch("commands.config_list.ssm_ops.get_ssm_param_value")
+def test_WHEN_get_deployed_config_called_AND_no_previous_THEN_as_expected(mock_get_val):
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    mock_get_val.return_value = '{"s3": {"bucket": "bucket-name","key": "capture/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v0.1.1","time_utc": "now"}, "previous": "None"}'
+
+    # Run our test
+    result = cl._get_deployed_config("MyCluster", True, False, mock_aws)
+
+    # Check our results
+    expected_result_dict = {
+        "current": {
+            "s3": {"bucket": "bucket-name","key": "capture/6/archive.zip"},
+            "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v0.1.1","time_utc": "now"}
+        },
+        "previous": "None"
+    }
+    expected_result = json.dumps(expected_result_dict, indent=4)
+    assert expected_result == result
+
+
+@mock.patch("commands.config_list.s3.get_object_user_metadata")
+@mock.patch("commands.config_list.s3.list_bucket_objects")
+def test_WHEN_get_all_configs_called_THEN_as_expected(mock_list_objects, mock_get_metadata):
+    # Set up our mock
+    mock_aws_env = mock.Mock()
+    mock_aws_env.aws_account = "XXXXXXXXXXXX"
+    mock_aws_env.aws_region = "us-fake-1"
+    mock_aws = mock.Mock()
+    mock_aws.get_aws_env.return_value = mock_aws_env
+
+    mock_objects_list = [
+        {"key": "capture/1/archive.zip", "date_modified": "2021-01-01T12:00:00"},
+        {"key": "capture/2/archive.zip", "date_modified": "2021-01-02T12:00:00"},
+        {"key": "capture/3/archive.zip", "date_modified": "2021-01-03T12:00:00"},
+    ]
+    mock_list_objects.return_value = mock_objects_list
+
+    mock_metadata = [
+        {"aws_aio_version": "1", "config_version": "3", "md5_version": "3333", "source_version": "v0.1.1", "time_utc": "2021-01-03T12:00:00"},
+        {"aws_aio_version": "1", "config_version": "2", "md5_version": "2222", "source_version": "v0.1.1", "time_utc": "2021-01-02T12:00:00"},
+        {"aws_aio_version": "1", "config_version": "1", "md5_version": "1111", "source_version": "v0.1.1", "time_utc": "2021-01-01T12:00:00"},
+    ]
+    mock_get_metadata.side_effect = mock_metadata
+
+    # Run our test
+    result = cl._get_all_configs("MyCluster", True, False, mock_aws)
+
+    # Check our results
+    expected_result_dict = [
+        {
+            "s3": {"bucket": constants.get_config_bucket_name("XXXXXXXXXXXX", "us-fake-1", "MyCluster"), "key": "capture/3/archive.zip"},
+            "version": {"aws_aio_version": "1", "config_version": "3", "md5_version": "3333", "source_version": "v0.1.1", "time_utc": "2021-01-03T12:00:00"}
+        },
+        {
+            "s3": {"bucket": constants.get_config_bucket_name("XXXXXXXXXXXX", "us-fake-1", "MyCluster"), "key": "capture/2/archive.zip"},
+            "version": {"aws_aio_version": "1", "config_version": "2", "md5_version": "2222", "source_version": "v0.1.1", "time_utc": "2021-01-02T12:00:00"}
+        },
+        {
+            "s3": {"bucket": constants.get_config_bucket_name("XXXXXXXXXXXX", "us-fake-1", "MyCluster"), "key": "capture/1/archive.zip"},
+            "version": {"aws_aio_version": "1", "config_version": "1", "md5_version": "1111", "source_version": "v0.1.1", "time_utc": "2021-01-01T12:00:00"}
+        },
+    ]
+    expected_result = json.dumps(expected_result_dict, indent=4)
+    assert expected_result == result


### PR DESCRIPTION
## Description
* Added a basic implementation of `config-list`.  The default behavior is to retrieve the metadata of all config bundles the user has deployed.  The user can get the currently (and most recent previously) deployed config using the `--deployed` flag.
* One thing to consider is what the "default" should be.  I can see good argument to flipping what I've done around and making the default be the deployed config and have an `--all` flag to grab everything.  I guess it comes down to how you think about a `list`-type call.  IMO, the default should be "give me everything" and flags are used to filter, even if I suspect most users will use a flag most of the time.

## Tasks
* https://github.com/arkime/aws-aio/issues/139

## Testing
* Added unit tests
* Ran manually against my AWS account, with all options.  Here's a few runs.

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py config-list --cluster-name MyCluster --viewer --deployed
2023-12-12 14:06:48 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-12-12 14:06:48 - Using AWS Credential Profile: None
2023-12-12 14:06:48 - Using AWS Region: default from AWS Config settings
2023-12-12 14:06:48 - Retrieving config details...
2023-12-12 14:06:48 - Config Details:
{
    "current": {
        "s3": {
            "bucket": "arkimeconfig-968674222892-us-east-2-mycluster",
            "key": "viewer/6/archive.zip"
        },
        "version": {
            "aws_aio_version": "1",
            "config_version": "6",
            "md5_version": "1a3e8232c093b419d590c0709d523759",
            "source_version": "v0.1.1-62-gd833c35",
            "time_utc": "2023-09-22 18:58:36"
        }
    },
    "previous": {
        "s3": {
            "bucket": "arkimeconfig-968674222892-us-east-2-mycluster",
            "key": "viewer/5/archive.zip"
        },
        "version": {
            "aws_aio_version": "1",
            "config_version": "5",
            "md5_version": "60b50c3ebdd8b02641d5d412f46519a3",
            "source_version": "v0.1.1-62-gd833c35",
            "time_utc": "2023-09-22 18:44:02"
        }
    }
}
```

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py config-list --cluster-name MyCluster --viewer
2023-12-12 13:52:04 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-12-12 13:52:04 - Using AWS Credential Profile: None
2023-12-12 13:52:04 - Using AWS Region: default from AWS Config settings
2023-12-12 13:52:04 - Retrieving config details (may take a bit)...
2023-12-12 13:52:07 - Config Details:
[
    {
        "s3": {
            "bucket": "arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster",
            "key": "viewer/6/archive.zip"
        },
        "version": {
            "aws_aio_version": "1",
            "config_version": "6",
            "md5_version": "1a3e8232c093b419d590c0709d523759",
            "source_version": "v0.1.1-62-gd833c35",
            "time_utc": "2023-09-22 18:58:36"
        }
    },
    {
        "s3": {
            "bucket": "arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster",
            "key": "viewer/5/archive.zip"
        },
        "version": {
            "aws_aio_version": "1",
            "config_version": "5",
            "md5_version": "60b50c3ebdd8b02641d5d412f46519a3",
            "source_version": "v0.1.1-62-gd833c35",
            "time_utc": "2023-09-22 18:44:02"
        }
    },
    {
        "s3": {
            "bucket": "arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster",
            "key": "viewer/4/archive.zip"
        },
        "version": {
            "aws_aio_version": "1",
            "config_version": "4",
            "md5_version": "d89f1396c8ccb54ec8c1db15ed8e51a8",
            "source_version": "v0.1.1-62-g8ac9e44",
            "time_utc": "2023-09-22 18:00:02"
        }
    },
    {
        "s3": {
            "bucket": "arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster",
            "key": "viewer/3/archive.zip"
        },
        "version": {
            "aws_aio_version": "1",
            "config_version": "3",
            "md5_version": "aa6cb798d96b86edf5e5d4560c0751b4",
            "source_version": "v0.1.1-62-g8ac9e44",
            "time_utc": "2023-09-22 17:56:00"
        }
    },
    {
        "s3": {
            "bucket": "arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster",
            "key": "viewer/2/archive.zip"
        },
        "version": {
            "aws_aio_version": "1",
            "config_version": "2",
            "md5_version": "640321fdab99767578cfbdb75fedcb1d",
            "source_version": "v0.1.1-62-g8ac9e44",
            "time_utc": "2023-09-22 17:25:37"
        }
    },
    {
        "s3": {
            "bucket": "arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster",
            "key": "viewer/1/archive.zip"
        },
        "version": {
            "aws_aio_version": "1",
            "config_version": "1",
            "md5_version": "1c42f3c8f3b70abe58afac52df89ba15",
            "source_version": "v0.1.1-62-g8ac9e44",
            "time_utc": "2023-09-22 16:05:28"
        }
    }
]
```

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
