### PR TITLE
Added `config-pull` command to the CLI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,11 @@
+## Description
+* Describe the changes you made
+
+## Tasks
+* Link any related issues or PRs
+
+## Testing
+* Describe how you tested the change and why you have confidence it will perform as expected
 
 ## License
 I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

--- a/.github/workflows/manage_arkime.yml
+++ b/.github/workflows/manage_arkime.yml
@@ -43,17 +43,17 @@ jobs:
       - name: Run config-list
         run: |
           source .venv/bin/activate
-          ./manage_arkime.py config-list --cluster-name test --capture
-          ./manage_arkime.py config-list --cluster-name test --capture --deployed
-          ./manage_arkime.py config-list --cluster-name test --viewer
-          ./manage_arkime.py config-list --cluster-name test --viewer --deployed
+          ./manage_arkime.py --region us-east-1 config-list --cluster-name test --capture
+          ./manage_arkime.py --region us-east-1 config-list --cluster-name test --capture --deployed
+          ./manage_arkime.py --region us-east-1 config-list --cluster-name test --viewer
+          ./manage_arkime.py --region us-east-1 config-list --cluster-name test --viewer --deployed
       - name: Run config-pull
         run: |
           source .venv/bin/activate
-          ./manage_arkime.py config-pull --cluster-name test --capture
-          ./manage_arkime.py config-pull --cluster-name test --capture --previous
-          ./manage_arkime.py config-pull --cluster-name test --viewer
-          ./manage_arkime.py config-pull --cluster-name test --viewer --previous
+          ./manage_arkime.py --region us-east-1 config-pull --cluster-name test --capture
+          ./manage_arkime.py --region us-east-1 config-pull --cluster-name test --capture --previous
+          ./manage_arkime.py --region us-east-1 config-pull --cluster-name test --viewer
+          ./manage_arkime.py --region us-east-1 config-pull --cluster-name test --viewer --previous
     
 
 

--- a/.github/workflows/manage_arkime.yml
+++ b/.github/workflows/manage_arkime.yml
@@ -40,5 +40,20 @@ jobs:
         run: |
           source .venv/bin/activate
           ./manage_arkime.py --region us-east-1 cluster-create --replicas 0 --name test --spi-days 1 --expected-traffic 0.01 --history-days 7 --pcap-days 1 --preconfirm-usage
+      - name: Run config-list
+        run: |
+          source .venv/bin/activate
+          ./manage_arkime.py config-list --cluster-name test --capture
+          ./manage_arkime.py config-list --cluster-name test --capture --deployed
+          ./manage_arkime.py config-list --cluster-name test --viewer
+          ./manage_arkime.py config-list --cluster-name test --viewer --deployed
+      - name: Run config-pull
+        run: |
+          source .venv/bin/activate
+          ./manage_arkime.py config-pull --cluster-name test --capture
+          ./manage_arkime.py config-pull --cluster-name test --capture --previous
+          ./manage_arkime.py config-pull --cluster-name test --viewer
+          ./manage_arkime.py config-pull --cluster-name test --viewer --previous
+    
 
 

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -298,7 +298,7 @@ def config_list(ctx, cluster_name, capture, viewer, deployed):
     cmd_config_list(profile, region, cluster_name, capture, viewer, deployed)
 cli.add_command(config_list)
 
-@click.command(help=("Retrieves the config deployed to the Arkime Cluster's Capture or Viewer Nodes."
+@click.command(help=("Retrieves the config deployed to the Arkime Cluster's Capture or Viewer Nodes to your machine."
                      + "  Pulls the currently config deployed by default."))
 @click.option("--cluster-name", help="The name of the Arkime Cluster to update", required=True)
 @click.option("--capture",
@@ -316,11 +316,16 @@ cli.add_command(config_list)
     is_flag=True,
     default=False
 )
+@click.option("--config-version",
+    help="Pulls the specified version of the config (if it exists); should be an integer number",
+    type=click.INT,
+    default=None,
+)
 @click.pass_context
-def config_pull(ctx, cluster_name, capture, viewer, previous):
+def config_pull(ctx, cluster_name, capture, viewer, previous, config_version):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_config_pull(profile, region, cluster_name, capture, viewer, previous)
+    cmd_config_pull(profile, region, cluster_name, capture, viewer, previous, config_version)
 cli.add_command(config_pull)
 
 def main():

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -311,11 +311,16 @@ cli.add_command(config_list)
     is_flag=True,
     default=False
 )
+@click.option("--previous",
+    help="Pulls the most recent, previously deployed config rather than the current (if there is one)",
+    is_flag=True,
+    default=False
+)
 @click.pass_context
-def config_pull(ctx, cluster_name, capture, viewer):
+def config_pull(ctx, cluster_name, capture, viewer, previous):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_config_pull(profile, region, cluster_name, capture, viewer)
+    cmd_config_pull(profile, region, cluster_name, capture, viewer, previous)
 cli.add_command(config_pull)
 
 def main():

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -5,6 +5,7 @@ import click
 
 from commands.vpc_add import cmd_vpc_add
 from commands.config_list import cmd_config_list
+from commands.config_pull import cmd_config_pull
 from commands.config_update import cmd_config_update
 from commands.cluster_create import cmd_cluster_create
 from commands.cluster_deregister_vpc import cmd_cluster_deregister_vpc
@@ -296,6 +297,26 @@ def config_list(ctx, cluster_name, capture, viewer, deployed):
     region = ctx.obj.get("region")
     cmd_config_list(profile, region, cluster_name, capture, viewer, deployed)
 cli.add_command(config_list)
+
+@click.command(help=("Retrieves the config deployed to the Arkime Cluster's Capture or Viewer Nodes."
+                     + "  Pulls the currently config deployed by default."))
+@click.option("--cluster-name", help="The name of the Arkime Cluster to update", required=True)
+@click.option("--capture",
+    help="Performs the operation for the Capture Nodes' configuration",
+    is_flag=True,
+    default=False
+)
+@click.option("--viewer",
+    help="Performs the operation for the Viewer Nodes' configuration",
+    is_flag=True,
+    default=False
+)
+@click.pass_context
+def config_pull(ctx, cluster_name, capture, viewer):
+    profile = ctx.obj.get("profile")
+    region = ctx.obj.get("region")
+    cmd_config_pull(profile, region, cluster_name, capture, viewer)
+cli.add_command(config_pull)
 
 def main():
     logging_wrangler = LoggingWrangler()

--- a/manage_arkime/arkime_interactions/config_wrangling.py
+++ b/manage_arkime/arkime_interactions/config_wrangling.py
@@ -139,6 +139,22 @@ def get_cluster_dir_name(cluster_name: str, aws_env: AwsEnvironment) -> str:
     # We want to avoid collisions between Clusters across accounts/regions
     return f"config-{cluster_name}-{aws_env.aws_account}-{aws_env.aws_region}"
 
+def get_capture_config_copy_file_name(cluster_name: str, aws_env: AwsEnvironment, config_version: str) -> str:
+    return f"{get_cluster_dir_name(cluster_name, aws_env)}-capture-v{config_version}.zip"
+
+def get_capture_config_copy_path(cluster_name: str, aws_env: AwsEnvironment, config_version: str) -> str:
+    parent_dir = get_repo_root_dir()
+
+    return os.path.join(parent_dir, get_capture_config_copy_file_name(cluster_name, aws_env, config_version))
+
+def get_viewer_config_copy_file_name(cluster_name: str, aws_env: AwsEnvironment, config_version: str) -> str:
+    return f"{get_cluster_dir_name(cluster_name, aws_env)}-viewer-v{config_version}.zip"
+
+def get_viewer_config_copy_path(cluster_name: str, aws_env: AwsEnvironment, config_version: str) -> str:
+    parent_dir = get_repo_root_dir()
+
+    return os.path.join(parent_dir, get_viewer_config_copy_file_name(cluster_name, aws_env, config_version))
+
 def get_cluster_dir_path(cluster_name: str, aws_env: AwsEnvironment, parent_dir: str):
     cluster_dir_name = get_cluster_dir_name(cluster_name, aws_env)
     return os.path.join(parent_dir, cluster_dir_name)

--- a/manage_arkime/aws_interactions/s3_interactions.py
+++ b/manage_arkime/aws_interactions/s3_interactions.py
@@ -1,11 +1,12 @@
 from enum import Enum
 import logging
+import os
 from typing import Dict, List
 
 from botocore.exceptions import ClientError
 
 from aws_interactions.aws_client_provider import AwsClientProvider
-from core.local_file import S3File
+from core.local_file import PlainFile, S3File
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +33,22 @@ class BucketNameNotAvailable(Exception):
 class CouldntEnsureBucketExists(Exception):
     def __init__(self, bucket_name: str):
         self.bucket_name = bucket_name
-        super().__init__(f"We could not ensure that the S3 bucket name {bucket_name} exists and is accessible")
+        super().__init__(f"Could not ensure that the S3 bucket name {bucket_name} exists and is accessible")
+
+class CantWriteFileDirDoesntExist(Exception):
+    def __init__(self, local_path: str):
+        self.local_path = local_path
+        super().__init__(f"Could not write to the location {local_path} because its directory doesn't exist")
+
+class CantWriteFileAlreadyExists(Exception):
+    def __init__(self, local_path: str):
+        self.local_path = local_path
+        super().__init__(f"Could not write to the location {local_path} because a file already exists there")
+
+class CantWriteFileLackPermission(Exception):
+    def __init__(self, local_path: str):
+        self.local_path = local_path
+        super().__init__(f"Could not write to the location {local_path} because you lack permission to do so")
 
 def get_bucket_status(bucket_name: str, aws_provider: AwsClientProvider) -> BucketStatus:
     s3_client = aws_provider.get_s3()
@@ -179,3 +195,30 @@ def get_object_user_metadata(bucket_name: str, s3_key: str, aws_provider: AwsCli
     )
     object_metadata = response.get("Metadata", None)
     return object_metadata
+
+def get_object(bucket_name: str, s3_key: str, local_path: str, aws_provider: AwsClientProvider) -> S3File:
+    """
+    Gets the object from S3 and places it at the defined local_path, raising an error if a file already exists at that
+    location on disk.
+    """
+    s3_client = aws_provider.get_s3()
+
+    if os.path.exists(local_path):
+        raise CantWriteFileAlreadyExists(local_path)
+    
+    if not os.path.exists(os.path.dirname(local_path)):
+        raise CantWriteFileDirDoesntExist(local_path)
+    
+    response = s3_client.get_object(Bucket=bucket_name, Key=s3_key)
+
+    try:
+        with open(local_path, 'wb') as file:
+            file.write(response['Body'].read())
+    except PermissionError:
+        raise CantWriteFileLackPermission(local_path)
+
+    return S3File(
+        PlainFile(local_path),
+        metadata=response.get("Metadata", None)
+    )
+

--- a/manage_arkime/commands/config_list.py
+++ b/manage_arkime/commands/config_list.py
@@ -11,8 +11,7 @@ import core.constants as constants
 
 logger = logging.getLogger(__name__)
 
-def cmd_config_list(profile: str, region: str, cluster_name: str, capture: bool, viewer: bool, deployed: bool
-                    ) -> List[Dict[str, str]]:
+def cmd_config_list(profile: str, region: str, cluster_name: str, capture: bool, viewer: bool, deployed: bool):
     logger.debug(f"Invoking config-list with profile '{profile}' and region '{region}'")
 
     aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)

--- a/manage_arkime/commands/config_list.py
+++ b/manage_arkime/commands/config_list.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import sys
-from typing import Dict, List
 
 import arkime_interactions.config_wrangling as config_wrangling
 from aws_interactions.aws_client_provider import AwsClientProvider

--- a/manage_arkime/commands/config_pull.py
+++ b/manage_arkime/commands/config_pull.py
@@ -1,0 +1,57 @@
+import json
+import logging
+import sys
+from typing import Dict, List
+
+import arkime_interactions.config_wrangling as config_wrangling
+from aws_interactions.aws_client_provider import AwsClientProvider
+import aws_interactions.s3_interactions as s3
+import aws_interactions.ssm_operations as ssm_ops
+import core.constants as constants
+
+logger = logging.getLogger(__name__)
+
+def cmd_config_pull(profile: str, region: str, cluster_name: str, capture: bool, viewer: bool):
+    logger.debug(f"Invoking config-list with profile '{profile}' and region '{region}'")
+
+    aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)
+
+    if not (capture or viewer):
+        logger.error("You must indicate whether to operate on the Capture or Viewer config; see --help.")
+        sys.exit(1)
+    elif capture and viewer:
+        logger.error("You must indicate either to operate on the Capture or Viewer config, not both; see --help.")
+        sys.exit(1)
+    else:
+        logger.info("Retrieving config bundle...")
+        disk_location = _get_current_config(cluster_name, capture, viewer, aws_provider)
+        logger.info(f"Placed config bundle on disk:\n{disk_location}")
+
+def _get_current_config(cluster_name: str, capture: bool, viewer: bool, aws_provider: AwsClientProvider) -> str:
+    config_details_param = (
+        constants.get_capture_config_details_ssm_param_name(cluster_name)
+        if capture
+        else constants.get_viewer_config_details_ssm_param_name(cluster_name)
+    )
+    raw_param_val = ssm_ops.get_ssm_param_value(config_details_param, aws_provider)
+    current_config = config_wrangling.ConfigDetails.from_dict(json.loads(raw_param_val))
+
+    aws_env = aws_provider.get_aws_env()
+    local_path = (
+        config_wrangling.get_capture_config_copy_path(cluster_name, aws_env, current_config.version.config_version)
+        if capture
+        else config_wrangling.get_viewer_config_copy_path(cluster_name, aws_env, current_config.version.config_version)
+    )
+
+    s3_file = s3.get_object(
+        current_config.s3.bucket,
+        current_config.s3.key,
+        local_path,
+        aws_provider
+    )
+    
+    return s3_file.local_path
+
+    
+
+    

--- a/manage_arkime/commands/config_pull.py
+++ b/manage_arkime/commands/config_pull.py
@@ -11,41 +11,79 @@ import core.constants as constants
 
 logger = logging.getLogger(__name__)
 
-def cmd_config_pull(profile: str, region: str, cluster_name: str, capture: bool, viewer: bool):
+def cmd_config_pull(profile: str, region: str, cluster_name: str, capture: bool, viewer: bool, previous: bool):
     logger.debug(f"Invoking config-list with profile '{profile}' and region '{region}'")
 
     aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)
 
-    if not (capture or viewer):
-        logger.error("You must indicate whether to operate on the Capture or Viewer config; see --help.")
+    try:
+        if not (capture or viewer):
+            logger.error("You must indicate whether to operate on the Capture or Viewer config; see --help.")
+            sys.exit(1)
+        elif capture and viewer:
+            logger.error("You must indicate either to operate on the Capture or Viewer config, not both; see --help.")
+            sys.exit(1)
+        elif previous:
+            logger.info("Retrieving config bundle...")
+            disk_location = _get_previous_config(cluster_name, capture, viewer, aws_provider)
+            if not disk_location:
+                logger.warning("There was no previously deployed config; aborting...")
+            else:
+                logger.info(f"Placed config bundle on disk:\n{disk_location}")
+        else:
+            logger.info("Retrieving config bundle...")
+            disk_location = _get_current_config(cluster_name, capture, viewer, aws_provider)
+            logger.info(f"Placed config bundle on disk:\n{disk_location}")
+    except (s3.CantWriteFileAlreadyExists, s3.CantWriteFileDirDoesntExist, s3.CantWriteFileLackPermission) as ex:
+        logger.error(str(ex))
         sys.exit(1)
-    elif capture and viewer:
-        logger.error("You must indicate either to operate on the Capture or Viewer config, not both; see --help.")
-        sys.exit(1)
-    else:
-        logger.info("Retrieving config bundle...")
-        disk_location = _get_current_config(cluster_name, capture, viewer, aws_provider)
-        logger.info(f"Placed config bundle on disk:\n{disk_location}")
 
-def _get_current_config(cluster_name: str, capture: bool, viewer: bool, aws_provider: AwsClientProvider) -> str:
+def _get_deployed_config_metadata(cluster_name: str, capture: bool, viewer: bool,
+                                  aws_provider: AwsClientProvider)-> config_wrangling.ConfigDetails:
     config_details_param = (
         constants.get_capture_config_details_ssm_param_name(cluster_name)
         if capture
         else constants.get_viewer_config_details_ssm_param_name(cluster_name)
     )
     raw_param_val = ssm_ops.get_ssm_param_value(config_details_param, aws_provider)
-    current_config = config_wrangling.ConfigDetails.from_dict(json.loads(raw_param_val))
+    return config_wrangling.ConfigDetails.from_dict(json.loads(raw_param_val))
+
+
+def _get_current_config(cluster_name: str, capture: bool, viewer: bool, aws_provider: AwsClientProvider) -> str:
+    deployed_config = _get_deployed_config_metadata(cluster_name, capture, viewer, aws_provider)
 
     aws_env = aws_provider.get_aws_env()
     local_path = (
-        config_wrangling.get_capture_config_copy_path(cluster_name, aws_env, current_config.version.config_version)
+        config_wrangling.get_capture_config_copy_path(cluster_name, aws_env, deployed_config.version.config_version)
         if capture
-        else config_wrangling.get_viewer_config_copy_path(cluster_name, aws_env, current_config.version.config_version)
+        else config_wrangling.get_viewer_config_copy_path(cluster_name, aws_env, deployed_config.version.config_version)
     )
 
     s3_file = s3.get_object(
-        current_config.s3.bucket,
-        current_config.s3.key,
+        deployed_config.s3.bucket,
+        deployed_config.s3.key,
+        local_path,
+        aws_provider
+    )
+    
+    return s3_file.local_path
+
+def _get_previous_config(cluster_name: str, capture: bool, viewer: bool, aws_provider: AwsClientProvider) -> str:
+    deployed_config = _get_deployed_config_metadata(cluster_name, capture, viewer, aws_provider)
+    previous_config = deployed_config.previous
+    if not previous_config:
+        return None
+
+    aws_env = aws_provider.get_aws_env()
+    local_path = (
+        config_wrangling.get_capture_config_copy_path(cluster_name, aws_env, previous_config.version.config_version)
+        if capture
+        else config_wrangling.get_viewer_config_copy_path(cluster_name, aws_env, previous_config.version.config_version)
+    )
+
+    s3_file = s3.get_object(
+        previous_config.s3.bucket,
+        previous_config.s3.key,
         local_path,
         aws_provider
     )

--- a/manage_arkime/core/local_file.py
+++ b/manage_arkime/core/local_file.py
@@ -103,6 +103,19 @@ class ZipDirectory(LocalFile):
 
         return self._archive_path
 
-    
+class PlainFile(LocalFile):
+    """
+    Provides an abstraction for a generic file on disk.
+    """
+    def __init__(self, local_path: str):
+        self._local_path = local_path
+
+    def __eq__(self, other):
+        return self.local_path == other.local_path
+
+    @property
+    def local_path(self) -> str:
+        return self._local_path
+
 
     

--- a/test_manage_arkime/commands/test_config_pull.py
+++ b/test_manage_arkime/commands/test_config_pull.py
@@ -7,36 +7,76 @@ import commands.config_pull as cp
 import core.constants as constants
 
 
+@mock.patch("commands.config_pull._get_previous_config")
 @mock.patch("commands.config_pull._get_current_config")
 @mock.patch("commands.config_pull.sys.exit")
-def test_WHEN_cmd_config_pull_called_AND_dont_specify_which_THEN_exits(mock_exit, mock_get_current):
+def test_WHEN_cmd_config_pull_called_AND_dont_specify_which_THEN_exits(mock_exit, mock_get_current, mock_get_previous):
     # Run our test
-    cp.cmd_config_pull("profile", "region", "MyCluster", False, False)
+    cp.cmd_config_pull("profile", "region", "MyCluster", False, False, False)
 
     # Check our results
     assert mock_exit.called_once_with(1)
     assert not mock_get_current.called
+    assert not mock_get_previous.called
 
+@mock.patch("commands.config_pull._get_previous_config")
 @mock.patch("commands.config_pull._get_current_config")
 @mock.patch("commands.config_pull.sys.exit")
-def test_WHEN_cmd_config_pull_called_AND_specify_both_which_THEN_exits(mock_exit, mock_get_current):
+def test_WHEN_cmd_config_pull_called_AND_specify_both_which_THEN_exits(mock_exit, mock_get_current, mock_get_previous):
     # Run our test
-    cp.cmd_config_pull("profile", "region", "MyCluster", True, True)
+    cp.cmd_config_pull("profile", "region", "MyCluster", True, True, False)
 
     # Check our results
     assert mock_exit.called_once_with(1)
     assert not mock_get_current.called
+    assert not mock_get_previous.called
 
+@mock.patch("commands.config_pull._get_previous_config")
 @mock.patch("commands.config_pull._get_current_config")
-def test_WHEN_cmd_config_pull_called_AND_default_THEN_as_expected(mock_get_current):
+def test_WHEN_cmd_config_pull_called_AND_default_THEN_as_expected(mock_get_current, mock_get_previous):
     # Run our test
-    cp.cmd_config_pull("profile", "region", "MyCluster", True, False)
+    cp.cmd_config_pull("profile", "region", "MyCluster", True, False, False)
 
     # Check our results
     expected_get_current_config_calls = [
         mock.call("MyCluster", True, False, mock.ANY)
     ]
     assert expected_get_current_config_calls == mock_get_current.call_args_list
+    assert not mock_get_previous.called
+
+@mock.patch("commands.config_pull._get_previous_config", mock.Mock())
+@mock.patch("commands.config_pull._get_current_config")
+@mock.patch("commands.config_pull.sys.exit")
+def test_WHEN_cmd_config_pull_called_AND_exception_THEN_handles_gracefully(mock_exit, mock_get_current):
+    # Set up our mock
+    exception_list = [
+        s3.CantWriteFileAlreadyExists(""),
+        s3.CantWriteFileDirDoesntExist(""),
+        s3.CantWriteFileLackPermission(""),
+    ]
+    mock_get_current.side_effect = exception_list
+
+    # Run our test
+    for _ in range(len(exception_list)):
+        cp.cmd_config_pull("profile", "region", "MyCluster", True, False, False)
+
+    # Check our results
+    expected_calls = [mock.call(1) for _ in range(len(exception_list))]
+    assert expected_calls == mock_exit.call_args_list
+
+@mock.patch("commands.config_pull._get_previous_config")
+@mock.patch("commands.config_pull._get_current_config")
+def test_WHEN_cmd_config_pull_called_AND_previous_THEN_as_expected(mock_get_current, mock_get_previous):
+    # Run our test
+    cp.cmd_config_pull("profile", "region", "MyCluster", True, False, True)
+
+    # Check our results
+    assert not mock_get_current.called
+
+    expected_get_previous_config_calls = [
+        mock.call("MyCluster", True, False, mock.ANY)
+    ]
+    assert expected_get_previous_config_calls == mock_get_previous.call_args_list
 
 @mock.patch("commands.config_pull.s3.get_object")
 @mock.patch("commands.config_pull.ssm_ops.get_ssm_param_value")
@@ -69,6 +109,48 @@ def test_WHEN_get_current_config_called_AND_capture_THEN_as_expected(mock_get_va
         mock.call(
             "bucket-name",
             "capture/6/archive.zip",
+            local_path,
+            mock_aws
+        )
+    ]
+    assert expected_s3_get_calls == mock_get_obj.call_args_list
+
+    expected_get_ssm_calls = [
+        mock.call(constants.get_capture_config_details_ssm_param_name("MyCluster"), mock_aws)
+    ]
+    assert expected_get_ssm_calls == mock_get_val.call_args_list
+
+@mock.patch("commands.config_pull.s3.get_object")
+@mock.patch("commands.config_pull.ssm_ops.get_ssm_param_value")
+def test_WHEN_get_previous_config_called_AND_capture_THEN_as_expected(mock_get_val, mock_get_obj):
+    # Set up our mock
+    mock_aws_env = mock.Mock(aws_account = "XXXXXXXXXXXX", aws_region = "us-fake-1")
+    mock_aws = mock.Mock()
+    mock_aws.get_aws_env.return_value = mock_aws_env
+
+    mock_get_val.return_value = '{"s3": {"bucket": "bucket-name","key": "capture/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v0.1.1","time_utc": "now"}, "previous": {"s3": {"bucket": "bucket-name","key": "capture/5/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "5","md5_version": "2222","source_version": "v0.1.1","time_utc": "then"}, "previous": "None"}}'
+
+    local_path = config_wrangling.get_capture_config_copy_path("MyCluster", mock_aws_env, "5")
+    mock_s3_file = s3.S3File(
+        s3.PlainFile(local_path),
+        metadata = {
+            "s3": {"bucket": "bucket-name", "key": "capture/5/archive.zip"},
+            "version": {"aws_aio_version": "1","config_version": "5","md5_version": "2222","source_version": "v0.1.1","time_utc": "now"}
+        }
+    )
+    mock_get_obj.return_value = mock_s3_file    
+
+    # Run our test
+    result = cp._get_previous_config("MyCluster", True, False, mock_aws)
+
+    # Check our results
+    expected_value = local_path
+    assert expected_value == result
+
+    expected_s3_get_calls = [
+        mock.call(
+            "bucket-name",
+            "capture/5/archive.zip",
             local_path,
             mock_aws
         )

--- a/test_manage_arkime/commands/test_config_pull.py
+++ b/test_manage_arkime/commands/test_config_pull.py
@@ -1,0 +1,82 @@
+import json
+import unittest.mock as mock
+
+import arkime_interactions.config_wrangling as config_wrangling
+import aws_interactions.s3_interactions as s3
+import commands.config_pull as cp
+import core.constants as constants
+
+
+@mock.patch("commands.config_pull._get_current_config")
+@mock.patch("commands.config_pull.sys.exit")
+def test_WHEN_cmd_config_pull_called_AND_dont_specify_which_THEN_exits(mock_exit, mock_get_current):
+    # Run our test
+    cp.cmd_config_pull("profile", "region", "MyCluster", False, False)
+
+    # Check our results
+    assert mock_exit.called_once_with(1)
+    assert not mock_get_current.called
+
+@mock.patch("commands.config_pull._get_current_config")
+@mock.patch("commands.config_pull.sys.exit")
+def test_WHEN_cmd_config_pull_called_AND_specify_both_which_THEN_exits(mock_exit, mock_get_current):
+    # Run our test
+    cp.cmd_config_pull("profile", "region", "MyCluster", True, True)
+
+    # Check our results
+    assert mock_exit.called_once_with(1)
+    assert not mock_get_current.called
+
+@mock.patch("commands.config_pull._get_current_config")
+def test_WHEN_cmd_config_pull_called_AND_default_THEN_as_expected(mock_get_current):
+    # Run our test
+    cp.cmd_config_pull("profile", "region", "MyCluster", True, False)
+
+    # Check our results
+    expected_get_current_config_calls = [
+        mock.call("MyCluster", True, False, mock.ANY)
+    ]
+    assert expected_get_current_config_calls == mock_get_current.call_args_list
+
+@mock.patch("commands.config_pull.s3.get_object")
+@mock.patch("commands.config_pull.ssm_ops.get_ssm_param_value")
+def test_WHEN_get_current_config_called_AND_capture_THEN_as_expected(mock_get_val, mock_get_obj):
+    # Set up our mock
+    mock_aws_env = mock.Mock(aws_account = "XXXXXXXXXXXX", aws_region = "us-fake-1")
+    mock_aws = mock.Mock()
+    mock_aws.get_aws_env.return_value = mock_aws_env
+
+    mock_get_val.return_value = '{"s3": {"bucket": "bucket-name","key": "capture/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v0.1.1","time_utc": "now"}, "previous": {"s3": {"bucket": "bucket-name","key": "capture/5/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "5","md5_version": "2222","source_version": "v0.1.1","time_utc": "then"}, "previous": "None"}}'
+
+    local_path = config_wrangling.get_capture_config_copy_path("MyCluster", mock_aws_env, "6")
+    mock_s3_file = s3.S3File(
+        s3.PlainFile(local_path),
+        metadata = {
+            "s3": {"bucket": "bucket-name", "key": "capture/6/archive.zip"},
+            "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v0.1.1","time_utc": "now"}
+        }
+    )
+    mock_get_obj.return_value = mock_s3_file    
+
+    # Run our test
+    result = cp._get_current_config("MyCluster", True, False, mock_aws)
+
+    # Check our results
+    expected_value = local_path
+    assert expected_value == result
+
+    expected_s3_get_calls = [
+        mock.call(
+            "bucket-name",
+            "capture/6/archive.zip",
+            local_path,
+            mock_aws
+        )
+    ]
+    assert expected_s3_get_calls == mock_get_obj.call_args_list
+
+    expected_get_ssm_calls = [
+        mock.call(constants.get_capture_config_details_ssm_param_name("MyCluster"), mock_aws)
+    ]
+    assert expected_get_ssm_calls == mock_get_val.call_args_list
+

--- a/test_manage_arkime/commands/test_config_pull.py
+++ b/test_manage_arkime/commands/test_config_pull.py
@@ -7,76 +7,104 @@ import commands.config_pull as cp
 import core.constants as constants
 
 
+@mock.patch("commands.config_pull._get_specific_config")
 @mock.patch("commands.config_pull._get_previous_config")
 @mock.patch("commands.config_pull._get_current_config")
 @mock.patch("commands.config_pull.sys.exit")
-def test_WHEN_cmd_config_pull_called_AND_dont_specify_which_THEN_exits(mock_exit, mock_get_current, mock_get_previous):
+def test_WHEN_cmd_config_pull_called_AND_dont_specify_which_THEN_exits(mock_exit, mock_get_current, mock_get_previous, 
+                                                                       mock_get_specific):
     # Run our test
-    cp.cmd_config_pull("profile", "region", "MyCluster", False, False, False)
+    cp.cmd_config_pull("profile", "region", "MyCluster", False, False, False, None)
 
     # Check our results
     assert mock_exit.called_once_with(1)
     assert not mock_get_current.called
     assert not mock_get_previous.called
+    assert not mock_get_specific.called
 
+@mock.patch("commands.config_pull._get_specific_config")
 @mock.patch("commands.config_pull._get_previous_config")
 @mock.patch("commands.config_pull._get_current_config")
 @mock.patch("commands.config_pull.sys.exit")
-def test_WHEN_cmd_config_pull_called_AND_specify_both_which_THEN_exits(mock_exit, mock_get_current, mock_get_previous):
+def test_WHEN_cmd_config_pull_called_AND_specify_both_which_THEN_exits(mock_exit, mock_get_current, mock_get_previous, 
+                                                                       mock_get_specific):
     # Run our test
-    cp.cmd_config_pull("profile", "region", "MyCluster", True, True, False)
+    cp.cmd_config_pull("profile", "region", "MyCluster", True, True, False, None)
 
     # Check our results
     assert mock_exit.called_once_with(1)
     assert not mock_get_current.called
     assert not mock_get_previous.called
+    assert not mock_get_specific.called
 
+@mock.patch("commands.config_pull._get_specific_config")
 @mock.patch("commands.config_pull._get_previous_config")
 @mock.patch("commands.config_pull._get_current_config")
-def test_WHEN_cmd_config_pull_called_AND_default_THEN_as_expected(mock_get_current, mock_get_previous):
+@mock.patch("commands.config_pull.sys.exit")
+def test_WHEN_cmd_config_pull_called_AND_too_many_flags_THEN_exits(mock_exit, mock_get_current, mock_get_previous, 
+                                                                       mock_get_specific):
     # Run our test
-    cp.cmd_config_pull("profile", "region", "MyCluster", True, False, False)
+    cp.cmd_config_pull("profile", "region", "MyCluster", True, False, True, "3")
+
+    # Check our results
+    assert mock_exit.called_once_with(1)
+    assert not mock_get_current.called
+    assert not mock_get_previous.called
+    assert not mock_get_specific.called
+
+@mock.patch("commands.config_pull._get_previous_config", mock.Mock())
+@mock.patch("commands.config_pull._get_current_config")
+@mock.patch("commands.config_pull.sys.exit")
+def test_WHEN_cmd_config_pull_called_AND_expected_exception_THEN_handles_gracefully(mock_exit, mock_get_current):
+    # Set up our mock
+    exception_list = [
+        s3.CantWriteFileAlreadyExists(""),
+        s3.CantWriteFileDirDoesntExist(""),
+        s3.CantWriteFileLackPermission(""),
+        s3.S3ObjectDoesntExist("", ""),
+    ]
+    mock_get_current.side_effect = exception_list
+
+    # Run our test
+    for _ in range(len(exception_list)):
+        cp.cmd_config_pull("profile", "region", "MyCluster", True, False, False, None)
+
+    # Check our results
+    expected_calls = [mock.call(1) for _ in range(len(exception_list))]
+    assert expected_calls == mock_exit.call_args_list
+
+@mock.patch("commands.config_pull._get_current_config")
+def test_WHEN_cmd_config_pull_called_AND_default_THEN_as_expected(mock_get_current):
+    # Run our test
+    cp.cmd_config_pull("profile", "region", "MyCluster", True, False, False, None)
 
     # Check our results
     expected_get_current_config_calls = [
         mock.call("MyCluster", True, False, mock.ANY)
     ]
     assert expected_get_current_config_calls == mock_get_current.call_args_list
-    assert not mock_get_previous.called
-
-@mock.patch("commands.config_pull._get_previous_config", mock.Mock())
-@mock.patch("commands.config_pull._get_current_config")
-@mock.patch("commands.config_pull.sys.exit")
-def test_WHEN_cmd_config_pull_called_AND_exception_THEN_handles_gracefully(mock_exit, mock_get_current):
-    # Set up our mock
-    exception_list = [
-        s3.CantWriteFileAlreadyExists(""),
-        s3.CantWriteFileDirDoesntExist(""),
-        s3.CantWriteFileLackPermission(""),
-    ]
-    mock_get_current.side_effect = exception_list
-
-    # Run our test
-    for _ in range(len(exception_list)):
-        cp.cmd_config_pull("profile", "region", "MyCluster", True, False, False)
-
-    # Check our results
-    expected_calls = [mock.call(1) for _ in range(len(exception_list))]
-    assert expected_calls == mock_exit.call_args_list
 
 @mock.patch("commands.config_pull._get_previous_config")
-@mock.patch("commands.config_pull._get_current_config")
-def test_WHEN_cmd_config_pull_called_AND_previous_THEN_as_expected(mock_get_current, mock_get_previous):
+def test_WHEN_cmd_config_pull_called_AND_previous_THEN_as_expected(mock_get_previous):
     # Run our test
-    cp.cmd_config_pull("profile", "region", "MyCluster", True, False, True)
+    cp.cmd_config_pull("profile", "region", "MyCluster", True, False, True, None)
 
     # Check our results
-    assert not mock_get_current.called
-
     expected_get_previous_config_calls = [
         mock.call("MyCluster", True, False, mock.ANY)
     ]
     assert expected_get_previous_config_calls == mock_get_previous.call_args_list
+
+@mock.patch("commands.config_pull._get_specific_config")
+def test_WHEN_cmd_config_pull_called_AND_specific_THEN_as_expected(mock_get_specific):
+    # Run our test
+    cp.cmd_config_pull("profile", "region", "MyCluster", True, False, False, 3)
+
+    # Check our results
+    expected_get_specific_config_calls = [
+        mock.call("MyCluster", True, False, 3, mock.ANY)
+    ]
+    assert expected_get_specific_config_calls == mock_get_specific.call_args_list
 
 @mock.patch("commands.config_pull.s3.get_object")
 @mock.patch("commands.config_pull.ssm_ops.get_ssm_param_value")
@@ -161,4 +189,40 @@ def test_WHEN_get_previous_config_called_AND_capture_THEN_as_expected(mock_get_v
         mock.call(constants.get_capture_config_details_ssm_param_name("MyCluster"), mock_aws)
     ]
     assert expected_get_ssm_calls == mock_get_val.call_args_list
+
+@mock.patch("commands.config_pull.s3.get_object")
+def test_WHEN_get_specific_config_called_AND_capture_THEN_as_expected(mock_get_obj):
+    # Set up our mock
+    mock_aws_env = mock.Mock(aws_account = "XXXXXXXXXXXX", aws_region = "us-fake-1")
+    mock_aws = mock.Mock()
+    mock_aws.get_aws_env.return_value = mock_aws_env
+
+    test_bucket = constants.get_config_bucket_name(mock_aws_env.aws_account, mock_aws_env.aws_region, "MyCluster")
+    test_key = constants.get_capture_config_s3_key("3")
+    local_path = config_wrangling.get_capture_config_copy_path("MyCluster", mock_aws_env, "3")
+    mock_s3_file = s3.S3File(
+        s3.PlainFile(local_path),
+        metadata = {
+            "s3": {"bucket": test_bucket, "key": test_key},
+            "version": {"aws_aio_version": "1","config_version": "3","md5_version": "3333","source_version": "v0.1.1","time_utc": "now"}
+        }
+    )
+    mock_get_obj.return_value = mock_s3_file    
+
+    # Run our test
+    result = cp._get_specific_config("MyCluster", True, False, 3, mock_aws)
+
+    # Check our results
+    expected_value = local_path
+    assert expected_value == result
+
+    expected_s3_get_calls = [
+        mock.call(
+            test_bucket,
+            test_key,
+            local_path,
+            mock_aws
+        )
+    ]
+    assert expected_s3_get_calls == mock_get_obj.call_args_list
 


### PR DESCRIPTION
## Description
* Added the `config-pull` command to the CLI.  The default behavior is to retrieve the currently deployed configuration, which is then written to disk in the repo directory.  The user can also request the `--previous` config, or a specific `--config-version`.  The command aborts if the location on disk it tries to write to is already occupied.

## Tasks
* https://github.com/arkime/aws-aio/issues/142

## Testing
* Added unit tests
* Tested against my own AWS account:
```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py config-pull --cluster-name MyCluster --capture
2023-12-15 13:23:49 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-12-15 13:23:49 - Using AWS Credential Profile: None
2023-12-15 13:23:49 - Using AWS Region: default from AWS Config settings
2023-12-15 13:23:49 - Retrieving current config bundle...
2023-12-15 13:23:50 - Placed config bundle on disk:
/Users/chelma/workspace/Arkime/aws-aio/config-MyCluster-XXXXXXXXXXXX-us-east-2-capture-v1.zip

(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py config-pull --cluster-name MyCluster --capture --previous
2023-12-15 13:23:57 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-12-15 13:23:57 - Using AWS Credential Profile: None
2023-12-15 13:23:57 - Using AWS Region: default from AWS Config settings
2023-12-15 13:23:57 - Retrieving previous config bundle...
2023-12-15 13:23:57 - There was no previously deployed config; aborting...

(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py config-pull --cluster-name MyCluster --viewer --previous
2023-12-15 13:24:22 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-12-15 13:24:22 - Using AWS Credential Profile: None
2023-12-15 13:24:22 - Using AWS Region: default from AWS Config settings
2023-12-15 13:24:22 - Retrieving previous config bundle...
2023-12-15 13:24:23 - Placed config bundle on disk:
/Users/chelma/workspace/Arkime/aws-aio/config-MyCluster-XXXXXXXXXXXX-us-east-2-viewer-v5.zip

(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py config-pull --cluster-name MyCluster --viewer --config-version 4
2023-12-15 13:24:55 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-12-15 13:24:55 - Using AWS Credential Profile: None
2023-12-15 13:24:55 - Using AWS Region: default from AWS Config settings
2023-12-15 13:24:55 - Retrieving version 4 config bundle...
2023-12-15 13:24:57 - Placed config bundle on disk:
/Users/chelma/workspace/Arkime/aws-aio/config-MyCluster-XXXXXXXXXXXX-us-east-2-viewer-v4.zip

(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py config-pull --cluster-name MyCluster --viewer --config-version 4
2023-12-15 13:24:59 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-12-15 13:24:59 - Using AWS Credential Profile: None
2023-12-15 13:24:59 - Using AWS Region: default from AWS Config settings
2023-12-15 13:24:59 - Retrieving version 4 config bundle...
2023-12-15 13:24:59 - Could not write to the location /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster-XXXXXXXXXXXX-us-east-2-viewer-v4.zip because a file already exists there
```


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
