### PR TITLE
Added --config-version to the config-update command

### DIFF
--- a/.github/workflows/manage_arkime.yml
+++ b/.github/workflows/manage_arkime.yml
@@ -54,6 +54,10 @@ jobs:
           ./manage_arkime.py --region us-east-1 config-pull --cluster-name test --capture --previous
           ./manage_arkime.py --region us-east-1 config-pull --cluster-name test --viewer
           ./manage_arkime.py --region us-east-1 config-pull --cluster-name test --viewer --previous
+      - name: Run config-update
+        run: |
+          source .venv/bin/activate
+          ./manage_arkime.py --region us-east-1 config-update --cluster-name test --force-bounce
     
 
 

--- a/.github/workflows/manage_arkime.yml
+++ b/.github/workflows/manage_arkime.yml
@@ -54,10 +54,3 @@ jobs:
           ./manage_arkime.py --region us-east-1 config-pull --cluster-name test --capture --previous
           ./manage_arkime.py --region us-east-1 config-pull --cluster-name test --viewer
           ./manage_arkime.py --region us-east-1 config-pull --cluster-name test --viewer --previous
-      - name: Run config-update
-        run: |
-          source .venv/bin/activate
-          ./manage_arkime.py --region us-east-1 config-update --cluster-name test --force-bounce
-    
-
-

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -200,24 +200,36 @@ def vpc_remove(ctx, cluster_name, vpc_id):
 cli.add_command(vpc_remove)
 
 @click.command(help="Updates specified Arkime Cluster's Capture/Viewer configuration")
-@click.option("--cluster-name", help="The name of the Arkime Cluster to update", required=True)
-@click.option("--force-bounce-capture",
-    help="Forces a bounce of the Capture Nodes, regardless of whether there is new config.",
+@click.option("--cluster-name", help="The name of the Arkime Cluster to operate on", required=True)
+@click.option("--capture",
+    help="Performs the operation for the Capture Nodes' configuration",
+    is_flag=True,
+    default=False
+)
+@click.option("--viewer",
+    help="Performs the operation for the Viewer Nodes' configuration",
+    is_flag=True,
+    default=False
+)
+@click.option("--force-bounce",
+    help=("Forces a bounce of the Arkime Nodes' compute, regardless of whether there is new config."
+          + "  Can be used to re-start/re-load the Nodes' configuration and Docker containers.  Useful as"
+          + " an ops fallback if things get wonky."),
     is_flag=True,
     show_default=True,
     default=False
 )
-@click.option("--force-bounce-viewer",
-    help="Forces a bounce of the Viewer Nodes, regardless of whether there is new config.",
-    is_flag=True,
-    show_default=True,
-    default=False
+@click.option("--config-version",
+    help=("Deploys the specified version of the config (if it exists) to either the Capture or Viewer Nodes (but not"
+          + " both).  You must specify which of the two components to deploy to."),
+    type=click.INT,
+    default=None,
 )
 @click.pass_context
-def config_update(ctx, cluster_name, force_bounce_capture, force_bounce_viewer):
+def config_update(ctx, cluster_name, capture, viewer, force_bounce, config_version):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_config_update(profile, region, cluster_name, force_bounce_capture, force_bounce_viewer)
+    cmd_config_update(profile, region, cluster_name, capture, viewer, force_bounce, config_version)
 cli.add_command(config_update)
 
 @click.command(help="Registers a VPC in another AWS Account so it can be captured by the Cluster.  Not needed for VPCs"
@@ -275,7 +287,7 @@ def vpc_deregister_cluster(ctx, cluster_name, vpc_id):
 cli.add_command(vpc_deregister_cluster)
 
 @click.command(help="Retrieves metadata about the Arkime Cluster's config deployed to the Capture or Viewer Nodes")
-@click.option("--cluster-name", help="The name of the Arkime Cluster to update", required=True)
+@click.option("--cluster-name", help="The name of the Arkime Cluster to operate on", required=True)
 @click.option("--capture",
     help="Performs the operation for the Capture Nodes' configuration",
     is_flag=True,
@@ -300,7 +312,7 @@ cli.add_command(config_list)
 
 @click.command(help=("Retrieves the config deployed to the Arkime Cluster's Capture or Viewer Nodes to your machine."
                      + "  Pulls the currently config deployed by default."))
-@click.option("--cluster-name", help="The name of the Arkime Cluster to update", required=True)
+@click.option("--cluster-name", help="The name of the Arkime Cluster to operate on", required=True)
 @click.option("--capture",
     help="Performs the operation for the Capture Nodes' configuration",
     is_flag=True,

--- a/test_manage_arkime/aws_interactions/test_s3_interactions.py
+++ b/test_manage_arkime/aws_interactions/test_s3_interactions.py
@@ -292,6 +292,17 @@ def test_WHEN_get_object_user_metadata_called_THEN_as_expected():
 
     assert None == result
 
+@mock.patch("aws_interactions.s3_interactions.AwsClientProvider")
+def test_WHEN_get_object_user_metadata_called_AND_s3_obj_doesnt_exist_THEN_raises(mock_aws_provider):
+    # Set up our mock
+    mock_s3_client = mock.Mock()
+    mock_s3_client.head_object.side_effect = ClientError(error_response={"Error": {"Code": "404", "Message": "Not found"}}, operation_name="")
+    mock_aws_provider.get_s3.return_value = mock_s3_client
+
+    # Run our test
+    with pytest.raises(s3.S3ObjectDoesntExist):
+        s3.get_object_user_metadata("my-bucket", "key", mock_aws_provider)
+
 @mock.patch("aws_interactions.s3_interactions.os.path.exists")
 @mock.patch("aws_interactions.s3_interactions.AwsClientProvider")
 def test_WHEN_get_object_called_AND_file_exists_THEN_raises(mock_aws_provider, mock_exists):

--- a/test_manage_arkime/commands/test_config_update.py
+++ b/test_manage_arkime/commands/test_config_update.py
@@ -1,6 +1,5 @@
 import json
 import pytest
-import shlex
 import unittest.mock as mock
 
 import arkime_interactions.config_wrangling as config_wrangling
@@ -8,7 +7,6 @@ from aws_interactions.aws_environment import AwsEnvironment
 from aws_interactions.events_interactions import ConfigureIsmEvent
 import aws_interactions.s3_interactions as s3
 import aws_interactions.ssm_operations as ssm_ops
-
 from commands.config_update import (cmd_config_update, _update_config_if_necessary, _revert_arkime_config, 
                                     NoPreviousConfig, _bounce_ecs_service)
 import core.constants as constants
@@ -38,7 +36,7 @@ def test_WHEN_cmd_config_update_called_AND_happy_path_THEN_as_expected(mock_prov
     ]    
 
     # Run our test
-    cmd_config_update("profile", "region", cluster_name, False, False)
+    cmd_config_update("profile", "region", cluster_name, False, False, False, None)
 
     # Check our results
     expected_update_config_calls = [
@@ -48,6 +46,7 @@ def test_WHEN_cmd_config_update_called_AND_happy_path_THEN_as_expected(mock_prov
             constants.get_capture_config_s3_key,
             constants.get_capture_config_details_ssm_param_name(cluster_name),
             config_wrangling.get_capture_config_archive,
+            None,
             mock_provider
 
         ),
@@ -57,6 +56,7 @@ def test_WHEN_cmd_config_update_called_AND_happy_path_THEN_as_expected(mock_prov
             constants.get_viewer_config_s3_key,
             constants.get_viewer_config_details_ssm_param_name(cluster_name),
             config_wrangling.get_viewer_config_archive,
+            None,
             mock_provider
         ),
     ]
@@ -109,7 +109,7 @@ def test_WHEN_cmd_config_update_called_AND_shouldnt_bounce_THEN_as_expected(mock
     mock_update_config.side_effect = [False, False]
 
     # Run our test
-    cmd_config_update("profile", "region", cluster_name, False, False)
+    cmd_config_update("profile", "region", cluster_name, False, False, False, None)
 
     # Check our results
     expected_update_config_calls = [
@@ -119,6 +119,7 @@ def test_WHEN_cmd_config_update_called_AND_shouldnt_bounce_THEN_as_expected(mock
             constants.get_capture_config_s3_key,
             constants.get_capture_config_details_ssm_param_name(cluster_name),
             config_wrangling.get_capture_config_archive,
+            None,
             mock_provider
 
         ),
@@ -128,6 +129,7 @@ def test_WHEN_cmd_config_update_called_AND_shouldnt_bounce_THEN_as_expected(mock
             constants.get_viewer_config_s3_key,
             constants.get_viewer_config_details_ssm_param_name(cluster_name),
             config_wrangling.get_viewer_config_archive,
+            None,
             mock_provider
         ),
     ]
@@ -161,7 +163,7 @@ def test_WHEN_cmd_config_update_called_AND_force_bounce_THEN_as_expected(mock_pr
     ]
 
     # Run our test
-    cmd_config_update("profile", "region", cluster_name, True, True)
+    cmd_config_update("profile", "region", cluster_name, False, False, True, None)
 
     # Check our results
     expected_update_config_calls = [
@@ -171,6 +173,7 @@ def test_WHEN_cmd_config_update_called_AND_force_bounce_THEN_as_expected(mock_pr
             constants.get_capture_config_s3_key,
             constants.get_capture_config_details_ssm_param_name(cluster_name),
             config_wrangling.get_capture_config_archive,
+            None,
             mock_provider
 
         ),
@@ -180,6 +183,7 @@ def test_WHEN_cmd_config_update_called_AND_force_bounce_THEN_as_expected(mock_pr
             constants.get_viewer_config_s3_key,
             constants.get_viewer_config_details_ssm_param_name(cluster_name),
             config_wrangling.get_viewer_config_archive,
+            None,
             mock_provider
         ),
     ]
@@ -212,6 +216,36 @@ def test_WHEN_cmd_config_update_called_AND_force_bounce_THEN_as_expected(mock_pr
             mock_provider
         ),
     ]
+    assert expected_bounce_calls == mock_bounce.call_args_list
+
+
+class ExpectedExit(Exception):
+    pass
+
+@mock.patch("commands.config_update.exit")
+@mock.patch("commands.config_update._bounce_ecs_service")
+@mock.patch("commands.config_update.ssm_ops.get_ssm_param_value")
+@mock.patch("commands.config_update._update_config_if_necessary")
+@mock.patch("commands.config_update.AwsClientProvider")
+def test_WHEN_cmd_config_update_called_AND_config_ver_no_component_THEN_as_expected(
+        mock_provider_cls, mock_update_config, mock_get_param, mock_bounce, mock_exit):
+    # Set up our mock
+    mock_exit.side_effect = ExpectedExit()
+
+    # Run our test
+    with pytest.raises(ExpectedExit):
+        cmd_config_update("profile", "region", "MyCluster", False, False, False, 3)
+
+    # Check our results
+    mock_exit.assert_called_with(1)
+
+    expected_update_config_calls = []
+    assert expected_update_config_calls == mock_update_config.call_args_list
+
+    expected_get_param_calls = []
+    assert expected_get_param_calls == mock_get_param.call_args_list
+
+    expected_bounce_calls = []
     assert expected_bounce_calls == mock_bounce.call_args_list
 
 @mock.patch("commands.config_update.ssm_ops.put_ssm_param")
@@ -306,7 +340,7 @@ def test_WHEN_update_config_if_necessary_called_AND_happy_path_THEN_as_expected(
 
     # Run our test
     actual_value = _update_config_if_necessary(cluster_name, bucket_name, mock_s3_key_provider, ssm_param,
-                                mock_archive_provider, mock_provider)
+                                mock_archive_provider, None, mock_provider)
 
     # Check our results
     assert True == actual_value
@@ -380,7 +414,7 @@ def test_WHEN_update_config_if_necessary_called_AND_same_config_THEN_as_expected
 
     # Run our test
     actual_value = _update_config_if_necessary(cluster_name, bucket_name, mock_s3_key_provider, ssm_param,
-                                mock_archive_provider, mock_provider)
+                                mock_archive_provider, None, mock_provider)
 
     # Check our results
     assert False == actual_value
@@ -393,6 +427,128 @@ def test_WHEN_update_config_if_necessary_called_AND_same_config_THEN_as_expected
     expected_get_ssm_param_calls = [
         mock.call(ssm_param, mock_provider),
     ]
+    assert expected_get_ssm_param_calls == mock_get_ssm_param.call_args_list
+
+    expected_put_file_calls = []
+    assert expected_put_file_calls == mock_put_file.call_args_list
+
+    expected_put_ssm_param_calls = []
+    assert expected_put_ssm_param_calls == mock_put_ssm_param.call_args_list
+
+@mock.patch("commands.config_update.s3.get_object_user_metadata")
+@mock.patch("commands.config_update.ssm_ops.put_ssm_param")
+@mock.patch("commands.config_update.s3.put_file_to_bucket")
+@mock.patch("commands.config_update.ssm_ops.get_ssm_param_value")
+@mock.patch("commands.config_update.get_version_info")
+def test_WHEN_update_config_if_necessary_called_AND_switch_to_version_THEN_as_expected(
+        mock_get_version, mock_get_ssm_param, mock_put_file, mock_put_ssm_param, mock_get_metadata):
+    # Set up our mock
+    bucket_name = "bucket_name"
+    cluster_name = "cluster_name"
+    s3_key = "s3_key"
+    ssm_param = "ssm_param"
+
+    mock_provider = mock.Mock()
+    mock_s3_key_provider = mock.Mock()
+    mock_s3_key_provider.return_value = s3_key
+
+    mock_archive = mock.Mock()
+    mock_archive_provider = mock.Mock()
+    mock_archive_provider.return_value = mock_archive
+
+    v1 = mock.Mock(md5_version = "5555") # the "local" config version
+    mock_get_version.return_value = v1
+
+    current_config = '{"s3": {"bucket": "arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster3", "key": "capture/4/archive.zip"}, "version": {"aws_aio_version": "1", "config_version": "4", "md5_version": "4444", "source_version": "v0.1.1-7-g9c2d7ca", "time_utc": "2023-07-24 17:04:24"}, "previous": "None"}'
+    mock_get_ssm_param.return_value = current_config
+
+    switch_to_version_dict = {"aws_aio_version": "1", "config_version": "2", "md5_version": "2222", "source_version": "v0.1.1-7-g9c2d7ca", "time_utc": "2023-07-24 17:04:24"}
+    mock_get_metadata.return_value = switch_to_version_dict
+
+    # Run our test
+    actual_value = _update_config_if_necessary(cluster_name, bucket_name, mock_s3_key_provider, ssm_param,
+                                mock_archive_provider, 1, mock_provider)
+
+    # Check our results
+    assert True == actual_value
+
+    expected_get_version_info_calls = [
+        mock.call(mock_archive)
+    ]
+    assert expected_get_version_info_calls == mock_get_version.call_args_list
+
+    expected_get_ssm_param_calls = [
+        mock.call(ssm_param, mock_provider),
+    ]
+    assert expected_get_ssm_param_calls == mock_get_ssm_param.call_args_list
+
+    expected_put_file_calls = []
+    assert expected_put_file_calls == mock_put_file.call_args_list
+
+    expected_put_ssm_param_calls = [
+        mock.call(
+            ssm_param,
+            json.dumps(
+                config_wrangling.ConfigDetails(
+                    s3=config_wrangling.S3Details(bucket_name, s3_key),
+                    version=config_wrangling.VersionInfo(**switch_to_version_dict),
+                    previous=config_wrangling.ConfigDetails.from_dict(json.loads(current_config))
+                ).to_dict()
+            ),
+            mock.ANY,
+            description=mock.ANY,
+            overwrite=True,
+        ),
+    ]
+    assert expected_put_ssm_param_calls == mock_put_ssm_param.call_args_list
+
+@mock.patch("commands.config_update.s3.get_object_user_metadata")
+@mock.patch("commands.config_update.ssm_ops.put_ssm_param")
+@mock.patch("commands.config_update.s3.put_file_to_bucket")
+@mock.patch("commands.config_update.ssm_ops.get_ssm_param_value")
+@mock.patch("commands.config_update.get_version_info")
+def test_WHEN_update_config_if_necessary_called_AND_switch_ver_doesnt_exist_THEN_as_expected(
+        mock_get_version, mock_get_ssm_param, mock_put_file, mock_put_ssm_param, mock_get_metadata):
+    # Set up our mock
+    # Set up our mock
+    bucket_name = "bucket_name"
+    cluster_name = "cluster_name"
+    md5_version = "22222222"
+    s3_key = "s3_key"
+    ssm_param = "ssm_param"
+
+    mock_provider = mock.Mock()
+    mock_s3_key_provider = mock.Mock()
+    mock_s3_key_provider.return_value = s3_key
+
+    mock_archive = mock.Mock()
+    mock_archive_provider = mock.Mock()
+    mock_archive_provider.return_value = mock_archive
+
+    v1 = mock.Mock()
+    v1.md5_version = md5_version
+    v2 = VersionInfo("aws_aio", "2", md5_version, "source", "time")
+    mock_get_version.side_effect = [v1, v2]
+
+    current_config = '{"s3": {"bucket": "arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster3", "key": "capture/1/archive.zip"}, "version": {"aws_aio_version": "1", "config_version": "1", "md5_version": "11111111", "source_version": "v0.1.1-7-g9c2d7ca", "time_utc": "2023-07-24 17:04:24"}, "previous": "None"}'
+    mock_get_ssm_param.return_value = current_config
+
+    mock_get_metadata.side_effect = s3.S3ObjectDoesntExist("blah", "blah")
+
+    # Run our test
+
+    actual_value = _update_config_if_necessary(cluster_name, bucket_name, mock_s3_key_provider, ssm_param,
+                                mock_archive_provider, 3, mock_provider)
+
+    # Check our results
+    assert False == actual_value
+
+    expected_get_version_info_calls = [
+        mock.call(mock_archive)
+    ]
+    assert expected_get_version_info_calls == mock_get_version.call_args_list
+
+    expected_get_ssm_param_calls = []
     assert expected_get_ssm_param_calls == mock_get_ssm_param.call_args_list
 
     expected_put_file_calls = []


### PR DESCRIPTION
## Description
* The default behavior of `config-update` stays the same
* The user can supply the `--capture` or `--viewer` flags to operate on just that component
* `--force-bounce-capture` and `--force-bounce-viewer` are replaced with `--force-bounce`
* If the user supplies `--force-bounce` without `--capture` or `--viewer`, it bounces both
* The user can specify `--config-version` to deploy a historical version of the configuration to either the `--capture` or `--viewer` component (but not both in a single command).

## Tasks
* https://github.com/arkime/aws-aio/issues/144

## Testing
* Added/updated unit tests
* Ran the commands against my test account.  Copied below are demos of the behavior of `--config-version` (switching viewer from v5 to v6) and the new, combined `--force-bounce` option

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py config-list --cluster-name MyCluster --viewer --deployed
2023-12-21 05:43:10 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-12-21 05:43:10 - Using AWS Credential Profile: None
2023-12-21 05:43:10 - Using AWS Region: default from AWS Config settings
2023-12-21 05:43:10 - Retrieving config details...
2023-12-21 05:43:11 - Config Details:
{
    "current": {
        "s3": {
            "bucket": "arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster",
            "key": "viewer/5/archive.zip"
        },
        "version": {
            "aws_aio_version": "1",
            "config_version": "5",
            "md5_version": "60b50c3ebdd8b02641d5d412f46519a3",
            "source_version": "v0.1.1-62-gd833c35",
            "time_utc": "2023-09-22 18:44:02"
        }
    },
    "previous": {
        "s3": {
            "bucket": "arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster",
            "key": "viewer/6/archive.zip"
        },
        "version": {
            "aws_aio_version": "1",
            "config_version": "6",
            "md5_version": "1a3e8232c093b419d590c0709d523759",
            "source_version": "v0.1.1-62-gd833c35",
            "time_utc": "2023-09-22 18:58:36"
        }
    }
}

(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py config-update --cluster-name MyCluster --viewer --config-version 6
2023-12-21 05:43:39 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-12-21 05:43:39 - Using AWS Credential Profile: None
2023-12-21 05:43:39 - Using AWS Region: default from AWS Config settings
2023-12-21 05:43:40 - Updating Arkime config for Capture Nodes, if necessary...
2023-12-21 05:43:40 - Skipping Capture Nodes due to user parameters supplied
2023-12-21 05:43:40 - Updating Arkime config for Viewer Nodes, if necessary...
2023-12-21 05:43:40 - Turning Viewer configuration at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster-XXXXXXXXXXXX-us-east-2/viewer into archive at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster-XXXXXXXXXXXX-us-east-2/viewer.zip
2023-12-21 05:43:41 - Pulling existing configuration details from Param Store at: /arkime/clusters/MyCluster/viewer-config-details
2023-12-21 05:43:41 - Updating config details in Param Store at: /arkime/clusters/MyCluster/viewer-config-details
2023-12-21 05:43:42 - Bouncing ECS Service MyCluster-ViewerNodes-ServiceD69D759B-48FYEW0I3LsB to pick up the new Arkime config...
2023-12-21 05:43:43 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:43:59 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:44:15 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:44:31 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:44:46 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:45:02 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:45:18 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:45:34 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:45:50 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:46:05 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:46:21 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:46:37 - ECS Service MyCluster-ViewerNodes-ServiceD69D759B-48FYEW0I3LsB bounced successfully

(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py config-list --cluster-name MyCluster --viewer --deployed
2023-12-21 05:50:04 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-12-21 05:50:04 - Using AWS Credential Profile: None
2023-12-21 05:50:04 - Using AWS Region: default from AWS Config settings
2023-12-21 05:50:04 - Retrieving config details...
2023-12-21 05:50:05 - Config Details:
{
    "current": {
        "s3": {
            "bucket": "arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster",
            "key": "viewer/6/archive.zip"
        },
        "version": {
            "aws_aio_version": "1",
            "config_version": "6",
            "md5_version": "1a3e8232c093b419d590c0709d523759",
            "source_version": "v0.1.1-62-gd833c35",
            "time_utc": "2023-09-22 18:58:36"
        }
    },
    "previous": {
        "s3": {
            "bucket": "arkimeconfig-XXXXXXXXXXXX-us-east-2-mycluster",
            "key": "viewer/5/archive.zip"
        },
        "version": {
            "aws_aio_version": "1",
            "config_version": "5",
            "md5_version": "60b50c3ebdd8b02641d5d412f46519a3",
            "source_version": "v0.1.1-62-gd833c35",
            "time_utc": "2023-09-22 18:44:02"
        }
    }
}
```

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py config-update --cluster-name MyCluster --force-bounce
2023-12-21 05:53:00 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2023-12-21 05:53:00 - Using AWS Credential Profile: None
2023-12-21 05:53:00 - Using AWS Region: default from AWS Config settings
2023-12-21 05:53:00 - Updating Arkime config for Capture Nodes, if necessary...
2023-12-21 05:53:00 - Turning Capture configuration at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster-XXXXXXXXXXXX-us-east-2/capture into archive at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster-XXXXXXXXXXXX-us-east-2/capture.zip
2023-12-21 05:53:00 - Pulling existing configuration details from Param Store at: /arkime/clusters/MyCluster/capture-config-details
2023-12-21 05:53:01 - The local config is the same as what's currently deployed; skipping
2023-12-21 05:53:01 - Bouncing ECS Service MyCluster-CaptureNodes-ServiceD69D759B-fUGX6Dv7dyzs to pick up the new Arkime config...
2023-12-21 05:53:03 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:53:18 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:53:34 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:53:50 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:54:06 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:54:22 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:54:37 - ECS Service MyCluster-CaptureNodes-ServiceD69D759B-fUGX6Dv7dyzs bounced successfully
2023-12-21 05:54:37 - Updating Arkime config for Viewer Nodes, if necessary...
2023-12-21 05:54:37 - Turning Viewer configuration at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster-XXXXXXXXXXXX-us-east-2/viewer into archive at /Users/chelma/workspace/Arkime/aws-aio/config-MyCluster-XXXXXXXXXXXX-us-east-2/viewer.zip
2023-12-21 05:54:38 - Pulling existing configuration details from Param Store at: /arkime/clusters/MyCluster/viewer-config-details
2023-12-21 05:54:38 - The local config is the same as what's currently deployed; skipping
2023-12-21 05:54:38 - Bouncing ECS Service MyCluster-ViewerNodes-ServiceD69D759B-48FYEW0I3LsB to pick up the new Arkime config...
2023-12-21 05:54:40 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:54:55 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:55:11 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:55:27 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:55:43 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:55:59 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:56:15 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:56:31 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:56:47 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:57:02 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:57:18 - Waiting 15 more seconds for ECS service to finish bouncing...
2023-12-21 05:57:34 - ECS Service MyCluster-ViewerNodes-ServiceD69D759B-48FYEW0I3LsB bounced successfully
```

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
