### PR TITLE
use the cdk binary from node_modules instead of path

### DIFF
--- a/manage_arkime/cdk_interactions/cdk_client.py
+++ b/manage_arkime/cdk_interactions/cdk_client.py
@@ -9,7 +9,7 @@ import core.constants as constants
 logger = logging.getLogger(__name__)
 
 def get_command_prefix(aws_profile: str = None, aws_region: str = None, context: Dict[str, str] = None) -> str:
-    prefix_sections = ["cdk"]
+    prefix_sections = ["node_modules/.bin/cdk"]
 
     if aws_profile:
         prefix_sections.append(f"--profile {aws_profile}")
@@ -31,12 +31,12 @@ class CdkClient:
 
     def __init__(self, aws_env: AwsEnvironment):
         self._aws_env = aws_env
-    
+
     def bootstrap(self, context: Dict[str, str] = None) -> None:
         command_prefix = get_command_prefix(aws_profile=self._aws_env.aws_profile, aws_region=self._aws_env.aws_region, context=context)
         command_suffix = f"bootstrap {str(self._aws_env)}"
         command = f"{command_prefix} {command_suffix}"
-        
+
         logger.info(f"Executing command: {command_suffix}")
         logger.warning("NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.")
         exit_code, stdout = shell.call_shell_command(command=command)
@@ -122,7 +122,7 @@ class CdkClient:
         command_suffix = f"synthesize --quiet {' '.join(stack_names)}"
         command = f"{command_prefix} {command_suffix}"
 
-        # Execute the command.  
+        # Execute the command.
         logger.info(f"Executing command: {command_suffix}")
         logger.warning("NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.")
         exit_code, stdout = shell.call_shell_command(command=command)
@@ -133,4 +133,4 @@ class CdkClient:
             raise exceptions.CdkSynthesizeFailedUnknown()
 
         logger.info(f"Synthesize succeeded")
-        
+

--- a/manage_arkime/cdk_interactions/cdk_client.py
+++ b/manage_arkime/cdk_interactions/cdk_client.py
@@ -9,7 +9,7 @@ import core.constants as constants
 logger = logging.getLogger(__name__)
 
 def get_command_prefix(aws_profile: str = None, aws_region: str = None, context: Dict[str, str] = None) -> str:
-    prefix_sections = ["node_modules/.bin/cdk"]
+    prefix_sections = [constants.get_repo_root_dir() + "/node_modules/.bin/cdk"]
 
     if aws_profile:
         prefix_sections.append(f"--profile {aws_profile}")

--- a/test_manage_arkime/cdk_interactions/test_cdk_client.py
+++ b/test_manage_arkime/cdk_interactions/test_cdk_client.py
@@ -12,7 +12,7 @@ def test_WHEN_get_command_prefix_called_AND_no_args_THEN_gens_correctly():
     actual_value = cdk.get_command_prefix()
 
     # Check our results
-    expected_value = "node_modules/.bin/cdk"
+    expected_value = constants.get_repo_root_dir() + "/node_modules/.bin/cdk"
     assert expected_value == actual_value
 
 def test_WHEN_get_command_prefix_called_AND_profile_THEN_gens_correctly():
@@ -20,7 +20,7 @@ def test_WHEN_get_command_prefix_called_AND_profile_THEN_gens_correctly():
     actual_value = cdk.get_command_prefix(aws_profile="my_profile")
 
     # Check our results
-    expected_value = "node_modules/.bin/cdk --profile my_profile"
+    expected_value = constants.get_repo_root_dir() + "/node_modules/.bin/cdk --profile my_profile"
     assert expected_value == actual_value
 
 def test_WHEN_get_command_prefix_called_AND_region_THEN_gens_correctly():
@@ -28,7 +28,7 @@ def test_WHEN_get_command_prefix_called_AND_region_THEN_gens_correctly():
     actual_value = cdk.get_command_prefix(aws_region="mars-north-1")
 
     # Check our results
-    expected_value = f"node_modules/.bin/cdk --context {constants.CDK_CONTEXT_REGION_VAR}=mars-north-1"
+    expected_value = constants.get_repo_root_dir() + f"/node_modules/.bin/cdk --context {constants.CDK_CONTEXT_REGION_VAR}=mars-north-1"
     assert expected_value == actual_value
 
 def test_WHEN_get_command_prefix_called_AND_context_THEN_gens_correctly():
@@ -42,7 +42,7 @@ def test_WHEN_get_command_prefix_called_AND_context_THEN_gens_correctly():
     actual_value = cdk.get_command_prefix(aws_region="mars-north-1", context=test_context)
 
     # Check our results
-    expected_value = f"node_modules/.bin/cdk --context {constants.CDK_CONTEXT_REGION_VAR}=mars-north-1 --context k1=v1 --context k2=v2"
+    expected_value = constants.get_repo_root_dir() + f"/node_modules/.bin/cdk --context {constants.CDK_CONTEXT_REGION_VAR}=mars-north-1 --context k1=v1 --context k2=v2"
     assert expected_value == actual_value
 
 @mock.patch('cdk_interactions.cdk_client.shell')

--- a/test_manage_arkime/cdk_interactions/test_cdk_client.py
+++ b/test_manage_arkime/cdk_interactions/test_cdk_client.py
@@ -12,7 +12,7 @@ def test_WHEN_get_command_prefix_called_AND_no_args_THEN_gens_correctly():
     actual_value = cdk.get_command_prefix()
 
     # Check our results
-    expected_value = "cdk"
+    expected_value = "node_modules/.bin/cdk"
     assert expected_value == actual_value
 
 def test_WHEN_get_command_prefix_called_AND_profile_THEN_gens_correctly():
@@ -20,7 +20,7 @@ def test_WHEN_get_command_prefix_called_AND_profile_THEN_gens_correctly():
     actual_value = cdk.get_command_prefix(aws_profile="my_profile")
 
     # Check our results
-    expected_value = "cdk --profile my_profile"
+    expected_value = "node_modules/.bin/cdk --profile my_profile"
     assert expected_value == actual_value
 
 def test_WHEN_get_command_prefix_called_AND_region_THEN_gens_correctly():
@@ -28,7 +28,7 @@ def test_WHEN_get_command_prefix_called_AND_region_THEN_gens_correctly():
     actual_value = cdk.get_command_prefix(aws_region="mars-north-1")
 
     # Check our results
-    expected_value = f"cdk --context {constants.CDK_CONTEXT_REGION_VAR}=mars-north-1"
+    expected_value = f"node_modules/.bin/cdk --context {constants.CDK_CONTEXT_REGION_VAR}=mars-north-1"
     assert expected_value == actual_value
 
 def test_WHEN_get_command_prefix_called_AND_context_THEN_gens_correctly():
@@ -42,7 +42,7 @@ def test_WHEN_get_command_prefix_called_AND_context_THEN_gens_correctly():
     actual_value = cdk.get_command_prefix(aws_region="mars-north-1", context=test_context)
 
     # Check our results
-    expected_value = f"cdk --context {constants.CDK_CONTEXT_REGION_VAR}=mars-north-1 --context k1=v1 --context k2=v2"
+    expected_value = f"node_modules/.bin/cdk --context {constants.CDK_CONTEXT_REGION_VAR}=mars-north-1 --context k1=v1 --context k2=v2"
     assert expected_value == actual_value
 
 @mock.patch('cdk_interactions.cdk_client.shell')
@@ -145,7 +145,7 @@ def test_WHEN_deploy_called_AND_cant_bootstrap_THEN_raises(mock_shell):
     client = cdk.CdkClient(test_env)
     with pytest.raises(exceptions.CdkBootstrapFailedUnknown):
         client.deploy(["MyStack"])
-    
+
     # Check our results
     expected_calls = [
         mock.call(command=f"{cmd_prefix} deploy MyStack", request_response_pairs=mock.ANY),
@@ -168,7 +168,7 @@ def test_WHEN_deploy_called_AND_fails_THEN_raises(mock_shell):
     client = cdk.CdkClient(test_env)
     with pytest.raises(exceptions.CdkDeployFailedUnknown):
         client.deploy(["MyStack"])
-    
+
     # Check our results
     expected_calls = [mock.call(command=f"{cmd_prefix} deploy MyStack", request_response_pairs=mock.ANY)]
     assert expected_calls == mock_shell.call_shell_command.call_args_list


### PR DESCRIPTION
## Description
Instead of relying on our path for the cdk binary, use the one that was installed by the aws-cdk nodejs package

## Tasks
N/A

## Testing
Ran create-cluster which uses the cdk path and it worked fine.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
