### PR TITLE
Capture VPC now present in all AZs

### DIFF
--- a/cdk-lib/capture-stacks/capture-nodes-stack.ts
+++ b/cdk-lib/capture-stacks/capture-nodes-stack.ts
@@ -94,7 +94,8 @@ export class CaptureNodesStack extends cdk.Stack {
             vpc: props.captureVpc,
             instanceType: new ec2.InstanceType(props.planCluster.captureNodes.instanceType),
             machineImage: ecs.EcsOptimizedImage.amazonLinux2(),
-            minCapacity: props.planCluster.captureNodes.desiredCount,
+            desiredCapacity: props.planCluster.captureNodes.desiredCount,
+            minCapacity: props.planCluster.captureNodes.minCount,
             maxCapacity: props.planCluster.captureNodes.maxCount
         });
 

--- a/cdk-lib/capture-stacks/capture-nodes-stack.ts
+++ b/cdk-lib/capture-stacks/capture-nodes-stack.ts
@@ -94,7 +94,7 @@ export class CaptureNodesStack extends cdk.Stack {
             vpc: props.captureVpc,
             instanceType: new ec2.InstanceType(props.planCluster.captureNodes.instanceType),
             machineImage: ecs.EcsOptimizedImage.amazonLinux2(),
-            minCapacity: props.planCluster.captureNodes.minCount,
+            minCapacity: props.planCluster.captureNodes.desiredCount,
             maxCapacity: props.planCluster.captureNodes.maxCount
         });
 

--- a/cdk-lib/capture-stacks/capture-vpc-stack.ts
+++ b/cdk-lib/capture-stacks/capture-vpc-stack.ts
@@ -16,7 +16,7 @@ export class CaptureVpcStack extends Stack {
 
         this.vpc = new ec2.Vpc(this, 'VPC', {
             ipAddresses: ec2.IpAddresses.cidr(props.planCluster.captureVpc.cidr.block),
-            maxAzs: props.planCluster.captureVpc.numAzs,
+            availabilityZones: props.planCluster.captureVpc.azs,
             subnetConfiguration: [
                 {
                     subnetType: ec2.SubnetType.PUBLIC,

--- a/cdk-lib/capture-stacks/opensearch-domain-stack.ts
+++ b/cdk-lib/capture-stacks/opensearch-domain-stack.ts
@@ -17,6 +17,7 @@ export interface OpenSearchDomainStackProps extends StackProps {
 }
 
 export class OpenSearchDomainStack extends Stack {
+    public readonly azCount: number = 2;
     public readonly domainKey: kms.Key;
     public readonly domain: Domain;
     public readonly osSg: ec2.SecurityGroup;
@@ -81,7 +82,8 @@ export class OpenSearchDomainStack extends Stack {
                 kmsKey: this.domainKey,
             },
             zoneAwareness: {
-                availabilityZoneCount: props.planCluster.captureVpc.numAzs,
+                enabled: true,
+                availabilityZoneCount: this.azCount,
             },
             logging: {
                 slowSearchLogEnabled: true,
@@ -90,6 +92,9 @@ export class OpenSearchDomainStack extends Stack {
             },
             vpc: props.captureVpc,
             vpcSubnets: [{
+                // The AZ list should be stable as it's pulling from the beginning of a sorted list and AZs are rarely
+                // (never?) deprecated
+                availabilityZones: props.captureVpc.availabilityZones.slice(0, this.azCount),
                 subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS
             }],
             tlsSecurityPolicy: TLSSecurityPolicy.TLS_1_2,

--- a/cdk-lib/cloud-demo.ts
+++ b/cdk-lib/cloud-demo.ts
@@ -118,6 +118,7 @@ case 'MirrorMgmtParams':
         vpcSsmParamName: params.nameVpcSsmParam,
         vpceServiceId: params.idVpceService,
         mirrorVni: params.idVni,
+        env: env,
     });
     break;
 case 'DeployDemoTrafficParams':

--- a/cdk-lib/core/context-types.ts
+++ b/cdk-lib/core/context-types.ts
@@ -71,7 +71,7 @@ export interface ViewerNodesPlan {
  */
 export interface VpcPlan {
     cidr: Cidr;
-    numAzs: number;
+    azs: string[];
     publicSubnetMask: number;
 }
 

--- a/cdk-lib/traffic-gen-sample/traffic-gen-stack.ts
+++ b/cdk-lib/traffic-gen-sample/traffic-gen-stack.ts
@@ -22,7 +22,7 @@ export class TrafficGenStack extends cdk.Stack {
         // to the private subnet.
         const vpc = new ec2.Vpc(this, 'VPC', {
             ipAddresses: ec2.IpAddresses.cidr(props.cidr),
-            maxAzs: 1
+            maxAzs: 99,  // 99 AZs means "use all AZs"
         });
 
         /**
@@ -77,7 +77,7 @@ export class TrafficGenStack extends cdk.Stack {
             machineImage: ecs.EcsOptimizedImage.amazonLinux2(),
             desiredCapacity: 3,
             minCapacity: 3,
-            maxCapacity: 10 // Arbitrarily chosen
+            maxCapacity: 20 // Arbitrarily chosen
         });
 
         const ecsCluster = new ecs.Cluster(this, 'EcsCluster', {

--- a/cdk-lib/viewer-stacks/viewer-vpc-stack.ts
+++ b/cdk-lib/viewer-stacks/viewer-vpc-stack.ts
@@ -19,7 +19,7 @@ export class ViewerVpcStack extends Stack {
         // The VPC the Viewer Nodes will live in
         this.vpc = new ec2.Vpc(this, 'VPC', {
             ipAddresses: ec2.IpAddresses.cidr(props.viewerVpcPlan.cidr.block),
-            maxAzs: props.viewerVpcPlan.numAzs,
+            availabilityZones: props.viewerVpcPlan.azs,
             subnetConfiguration: [
                 {
                     subnetType: ec2.SubnetType.PUBLIC,

--- a/manage_arkime/aws_interactions/ec2_interactions.py
+++ b/manage_arkime/aws_interactions/ec2_interactions.py
@@ -189,5 +189,6 @@ def get_azs_in_region(aws_provider: AwsClientProvider) -> List[str]:
 
     response = ec2_client.describe_availability_zones()
     azs = [az["ZoneName"] for az in response["AvailabilityZones"]]
+    azs.sort() # Ensure stable ordering
 
     return azs

--- a/manage_arkime/aws_interactions/ec2_interactions.py
+++ b/manage_arkime/aws_interactions/ec2_interactions.py
@@ -183,3 +183,11 @@ def get_vpc_details(vpc_id: str, aws_provider: AwsClientProvider) -> VpcDetails:
         cidr_blocks=cidr_blocks,
         tenancy=vpc_details["InstanceTenancy"]
     )
+
+def get_azs_in_region(aws_provider: AwsClientProvider) -> List[str]:
+    ec2_client = aws_provider.get_ec2()
+
+    response = ec2_client.describe_availability_zones()
+    azs = [az["ZoneName"] for az in response["AvailabilityZones"]]
+
+    return azs

--- a/manage_arkime/cdk_interactions/cdk_context.py
+++ b/manage_arkime/cdk_interactions/cdk_context.py
@@ -59,12 +59,12 @@ def generate_cluster_destroy_context(name: str, stack_names: ClusterStackNames, 
     fake_arn = "N/A"
     fake_cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 1, 2, 1),
-        VpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK),
+        VpcPlan(DEFAULT_VPC_CIDR, ["us-fake-1"], DEFAULT_CAPTURE_PUBLIC_MASK),
         EcsSysResourcePlan(1, 1),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, 1),
         ViewerNodesPlan(4, 2),
-        VpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK) if has_viewer_vpc else None,
+        VpcPlan(DEFAULT_VPC_CIDR, ["us-fake-1"], DEFAULT_CAPTURE_PUBLIC_MASK) if has_viewer_vpc else None,
     )
     fake_user_config = UserConfig(1, 1, 1, 1, 1)
     fake_bucket_name = ""

--- a/manage_arkime/cdk_interactions/cdk_context.py
+++ b/manage_arkime/cdk_interactions/cdk_context.py
@@ -5,8 +5,8 @@ from typing import Dict, List
 
 import core.constants as constants
 from core.capacity_planning import (CaptureNodesPlan, ViewerNodesPlan, VpcPlan, ClusterPlan, DataNodesPlan, EcsSysResourcePlan,
-                                    MasterNodesPlan, OSDomainPlan, DEFAULT_NUM_AZS, S3Plan, DEFAULT_S3_STORAGE_CLASS,
-                                    DEFAULT_VPC_CIDR, DEFAULT_CAPTURE_PUBLIC_MASK)
+                                    MasterNodesPlan, OSDomainPlan, S3Plan, DEFAULT_S3_STORAGE_CLASS, DEFAULT_VPC_CIDR,
+                                    DEFAULT_CAPTURE_PUBLIC_MASK)
 from core.user_config import UserConfig
 
 @dataclass

--- a/manage_arkime/commands/vpc_add.py
+++ b/manage_arkime/commands/vpc_add.py
@@ -35,7 +35,7 @@ def cmd_vpc_add(profile: str, region: str, cluster_name: str, vpc_id: str, user_
         vpc_acct_provider = aws_provider
     if not association:
         cluster_acct_provider = vpc_acct_provider = aws_provider
-
+    
     vpc_aws_env = vpc_acct_provider.get_aws_env()
     cdk_client = CdkClient(vpc_aws_env)
     vni_provider = SsmVniProvider(cluster_name, cluster_acct_provider)

--- a/manage_arkime/core/capacity_planning.py
+++ b/manage_arkime/core/capacity_planning.py
@@ -3,7 +3,7 @@ import math
 import logging
 import re
 import sys
-from typing import Dict, Type, TypeVar
+from typing import Dict, List, Type, TypeVar
 
 
 logger = logging.getLogger(__name__)
@@ -21,17 +21,18 @@ DEFAULT_NUM_AZS = 2 # How many AWS Availability zones to utilize
 @dataclass
 class CaptureInstance:
     instanceType: str
-    maxTraffic: float
     trafficPer: float
     ecsCPU: int
     ecsMemory: int
 
-# These are the possible instances types we assign for capture nodes based on maxTraffic
-CAPTURE_INSTANCES = [
-    CaptureInstance("t3.medium", 0.5, 0.25, 1536, 3072),
-    CaptureInstance("m5.xlarge", MAX_TRAFFIC, 2.0, 3584, 15360)
-]
+# These are the possible instances types we assign for capture nodes
+T3_MEDIUM = CaptureInstance("t3.medium", 0.25, 1536, 3072)
+M5_XLARGE = CaptureInstance("m5.xlarge", 2.0, 3584, 15360)
 
+CAPTURE_INSTANCES = [
+    T3_MEDIUM,
+    M5_XLARGE
+]
 
 @dataclass
 class MasterInstance:
@@ -95,9 +96,11 @@ class CaptureNodesPlan:
             "minCount": self.minCount,
         }
 
-def get_capture_node_capacity_plan(expected_traffic: float) -> CaptureNodesPlan:
+def get_capture_node_capacity_plan(expected_traffic: float, azs: List[str]) -> CaptureNodesPlan:
     """
-    Creates a capacity plan for the indicated traffic load.
+    Creates a capacity plan for the indicated traffic load.  We expect that we will have at least one node in each AZ
+    in order to support having a VPC Endpoint in each AZ.
+
     expected_traffic: The expected traffic volume for the Arkime cluster, in Gigabits Per Second (Gbps)
     """
 
@@ -106,16 +109,24 @@ def get_capture_node_capacity_plan(expected_traffic: float) -> CaptureNodesPlan:
 
     if expected_traffic > MAX_TRAFFIC:
         raise TooMuchTraffic(expected_traffic)
+    
+    chosen_instance = (
+        T3_MEDIUM
+        if expected_traffic <= T3_MEDIUM.trafficPer * len(azs) # No more than one of these per AZ
+        else M5_XLARGE
+    )
 
-    chosen_instance = next(instance for instance in CAPTURE_INSTANCES if expected_traffic <= instance.maxTraffic)
-
-    desired_instances = math.ceil(expected_traffic/chosen_instance.trafficPer)
-
+    min_instances = len(azs)
+    desired_instances = max(
+        min_instances,
+        math.ceil(expected_traffic/chosen_instance.trafficPer)
+    )
+    
     return CaptureNodesPlan(
         chosen_instance.instanceType,
         desired_instances,
         math.ceil(desired_instances * CAPACITY_BUFFER_FACTOR),
-        MINIMUM_NODES
+        min_instances
     )
 
 @dataclass
@@ -397,22 +408,22 @@ DEFAULT_VIEWER_PUBLIC_MASK = 28 # minimum subnet size; we don't need much in the
 T_VpcPlan = TypeVar('T_VpcPlan', bound='VpcPlan')
 
 @dataclass
-class VpcPlan:    
+class VpcPlan:
     cidr: Cidr
-    numAzs: int
+    azs: List[str]
     publicSubnetMask: int
 
     def __eq__(self, other) -> bool:
         if other is None:
             return True if self is None else False
 
-        return (self.cidr == other.cidr and self.numAzs == other.numAzs
+        return (self.cidr == other.cidr and self.azs == other.azs
                 and self.publicSubnetMask == other.publicSubnetMask)
 
     def to_dict(self) -> Dict[str, any]:
         return {
             "cidr": self.cidr.to_dict(),
-            "numAzs": self.numAzs,
+            "azs": self.azs,
             "publicSubnetMask": self.publicSubnetMask,
         }
 
@@ -422,34 +433,34 @@ class VpcPlan:
             return None
 
         cidr = Cidr(input['cidr']['block'])
-        numAzs = input["numAzs"]
+        azs = input["azs"]
         publicSubnetMask = input["publicSubnetMask"]
 
-        return cls(cidr, numAzs, publicSubnetMask)
+        return cls(cidr, azs, publicSubnetMask)
     
     def get_usable_ips(self) -> int:
         total_ips = 2 ** (32 - int(self.cidr.mask))
-        public_ips = 2 ** (32 - int(self.publicSubnetMask)) * self.numAzs
+        public_ips = 2 ** (32 - int(self.publicSubnetMask)) * len(self.azs)
         reserved_ips_per_subnet = 2 # The first (local gateway) and last (broadcast) IP are often reserved
-        reserved_private_ips = reserved_ips_per_subnet * self.numAzs
+        reserved_private_ips = reserved_ips_per_subnet * len(self.azs)
 
         return total_ips - public_ips - reserved_private_ips
     
-def get_capture_vpc_plan(previous_plan: VpcPlan, capture_cidr_block: str) -> VpcPlan:
+def get_capture_vpc_plan(previous_plan: VpcPlan, capture_cidr_block: str, azs: List[str]) -> VpcPlan:
     if previous_plan and all(value is not None for value in vars(previous_plan).values()):
         return previous_plan
     elif not capture_cidr_block:
-        return VpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK)
+        return VpcPlan(DEFAULT_VPC_CIDR, azs, DEFAULT_CAPTURE_PUBLIC_MASK)
     else:
-        return VpcPlan(Cidr(capture_cidr_block), DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK)
+        return VpcPlan(Cidr(capture_cidr_block), azs, DEFAULT_CAPTURE_PUBLIC_MASK)
     
-def get_viewer_vpc_plan(previous_plan: VpcPlan, viewer_cidr_block: str) -> VpcPlan:
+def get_viewer_vpc_plan(previous_plan: VpcPlan, viewer_cidr_block: str, azs: List[str]) -> VpcPlan:
     if previous_plan and all(value is not None for value in vars(previous_plan).values()):
         return previous_plan
     elif not viewer_cidr_block:
         return None
     else:
-        return VpcPlan(Cidr(viewer_cidr_block), DEFAULT_NUM_AZS, DEFAULT_VIEWER_PUBLIC_MASK)
+        return VpcPlan(Cidr(viewer_cidr_block), azs[0:DEFAULT_NUM_AZS], DEFAULT_VIEWER_PUBLIC_MASK)
 
 DEFAULT_S3_STORAGE_CLASS = "STANDARD"
 DEFAULT_S3_STORAGE_DAYS = 30

--- a/manage_arkime/core/versioning.py
+++ b/manage_arkime/core/versioning.py
@@ -9,7 +9,7 @@ from core.shell_interactions import call_shell_command
 """
 Manually updated/managed version number.  Increment if/when a backwards incompatible change is made.
 """
-AWS_AIO_VERSION=1
+AWS_AIO_VERSION=2
 
 class CouldntReadSourceVersion(Exception):
     def __init__(self):

--- a/manage_arkime/setup.py
+++ b/manage_arkime/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="manage_arkime",
-    version="0.1.1",
+    version="1.0.0",
     description=("Tooling and configuration to install/manage Arkime Clusters in an AWS account"),
     author="Chris Helma",
     package_dir={"": "."},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-demo",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "bin": {
     "cloud-demo": "cdk-lib/cloud-demo.js"
   },

--- a/test_manage_arkime/aws_interactions/test_ec2_interactions.py
+++ b/test_manage_arkime/aws_interactions/test_ec2_interactions.py
@@ -307,8 +307,8 @@ def test_WHEN_get_azs_in_region_called_THEN_returns_them():
     mock_ec2_client = mock.Mock()
     mock_ec2_client.describe_availability_zones.return_value = {
         "AvailabilityZones": [
+            { "ZoneName": "us-fake-1b" }, # Intentionally out of order to ensure sorting
             { "ZoneName": "us-fake-1a" },
-            { "ZoneName": "us-fake-1b" },
             { "ZoneName": "us-fake-1c" },
         ]
     }

--- a/test_manage_arkime/aws_interactions/test_ec2_interactions.py
+++ b/test_manage_arkime/aws_interactions/test_ec2_interactions.py
@@ -301,3 +301,24 @@ def test_WHEN_get_vpc_details_called_AND_doesnt_exist_THEN_raises():
     # Run our test
     with pytest.raises(ec2i.VpcDoesNotExist):
         ec2i.get_vpc_details("vpc-1234", mock_aws_provider)
+
+def test_WHEN_get_azs_in_region_called_THEN_returns_them():
+    # Set up our mock
+    mock_ec2_client = mock.Mock()
+    mock_ec2_client.describe_availability_zones.return_value = {
+        "AvailabilityZones": [
+            { "ZoneName": "us-fake-1a" },
+            { "ZoneName": "us-fake-1b" },
+            { "ZoneName": "us-fake-1c" },
+        ]
+    }
+
+    mock_aws_provider = mock.Mock()
+    mock_aws_provider.get_ec2.return_value = mock_ec2_client
+
+    # Run our test
+    result = ec2i.get_azs_in_region(mock_aws_provider)
+
+    # Check our results
+    expected_result = ["us-fake-1a", "us-fake-1b", "us-fake-1c"]
+    assert expected_result == result

--- a/test_manage_arkime/commands/test_cluster_create.py
+++ b/test_manage_arkime/commands/test_cluster_create.py
@@ -278,11 +278,12 @@ def test_WHEN_cmd_cluster_create_called_AND_just_print_THEN_as_expected(mock_cdk
 @mock.patch("commands.cluster_create._confirm_usage")
 def test_WHEN_should_proceed_with_operation_AND_happy_path_THEN_as_expected(mock_confirm):
     # Set up our mock
+    azs = ["az1", "az2"]
     user_config = UserConfig(1, 30, 365, 2, 30)   
 
     cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 1, 2, 1),
-        VpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK),
+        VpcPlan(DEFAULT_VPC_CIDR, azs, DEFAULT_CAPTURE_PUBLIC_MASK),
         EcsSysResourcePlan(3584, 15360),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS),
@@ -307,11 +308,12 @@ def test_WHEN_should_proceed_with_operation_AND_happy_path_THEN_as_expected(mock
 @mock.patch("commands.cluster_create._confirm_usage")
 def test_WHEN_should_proceed_with_operation_AND_change_capture_cidr_THEN_as_expected(mock_confirm):
     # Set up our mock
+    azs = ["az1", "az2"]
     user_config = UserConfig(1, 30, 365, 2, 30)  
 
     cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 20, 25, 1),
-        VpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK),
+        VpcPlan(DEFAULT_VPC_CIDR, azs, DEFAULT_CAPTURE_PUBLIC_MASK),
         EcsSysResourcePlan(3584, 15360),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS),
@@ -333,11 +335,12 @@ def test_WHEN_should_proceed_with_operation_AND_change_capture_cidr_THEN_as_expe
 @mock.patch("commands.cluster_create._confirm_usage")
 def test_WHEN_should_proceed_with_operation_AND_change_viewer_cidr_THEN_as_expected(mock_confirm):
     # Set up our mock
+    azs = ["az1", "az2"]
     user_config = UserConfig(1, 30, 365, 2, 30)  
 
     cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 20, 25, 1),
-        VpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK),
+        VpcPlan(DEFAULT_VPC_CIDR, azs, DEFAULT_CAPTURE_PUBLIC_MASK),
         EcsSysResourcePlan(3584, 15360),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS),
@@ -358,18 +361,19 @@ def test_WHEN_should_proceed_with_operation_AND_change_viewer_cidr_THEN_as_expec
 
 @mock.patch("commands.cluster_create._confirm_usage")
 def test_WHEN_should_proceed_with_operation_AND_check_overlapping_cidrs_THEN_as_expected(mock_confirm):
+    azs = ["az1", "az2"]
     user_config = UserConfig(1, 30, 365, 2, 30)
     mock_confirm.return_value = True
 
     # TEST: Both specified, and don't overlap
     cluster_plan =  ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 20, 25, 1),
-        VpcPlan(Cidr("1.2.3.4/24"), DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK),
+        VpcPlan(Cidr("1.2.3.4/24"), azs, DEFAULT_CAPTURE_PUBLIC_MASK),
         EcsSysResourcePlan(3584, 15360),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS),
         ViewerNodesPlan(20, 5),
-        VpcPlan(Cidr("2.3.4.5/24"), DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK),
+        VpcPlan(Cidr("2.3.4.5/24"), azs, DEFAULT_CAPTURE_PUBLIC_MASK),
     )    
 
     actual_value = _should_proceed_with_operation(False, cluster_plan, cluster_plan, user_config, user_config, True, None, None)
@@ -380,12 +384,12 @@ def test_WHEN_should_proceed_with_operation_AND_check_overlapping_cidrs_THEN_as_
     # TEST: Both specified, and do overlap
     cluster_plan =  ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 20, 25, 1),
-        VpcPlan(Cidr("1.2.3.4/24"), DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK),
+        VpcPlan(Cidr("1.2.3.4/24"), azs, DEFAULT_CAPTURE_PUBLIC_MASK),
         EcsSysResourcePlan(3584, 15360),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS),
         ViewerNodesPlan(20, 5),
-        VpcPlan(Cidr("1.2.3.48/26"), DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK),
+        VpcPlan(Cidr("1.2.3.48/26"), azs, DEFAULT_CAPTURE_PUBLIC_MASK),
     )
     user_config = UserConfig(1, 30, 365, 2, 30)
 
@@ -395,11 +399,12 @@ def test_WHEN_should_proceed_with_operation_AND_check_overlapping_cidrs_THEN_as_
 @mock.patch("commands.cluster_create._confirm_usage")
 def test_WHEN_should_proceed_with_operation_AND_abort_usage_THEN_as_expected(mock_confirm):
     # Set up our mock
+    azs = ["az1", "az2"]
     user_config = UserConfig(1, 30, 365, 2, 30) 
 
     cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 1, 2, 1),
-        VpcPlan(DEFAULT_VPC_CIDR, DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK),
+        VpcPlan(DEFAULT_VPC_CIDR, azs, DEFAULT_CAPTURE_PUBLIC_MASK),
         EcsSysResourcePlan(3584, 15360),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS),
@@ -423,11 +428,12 @@ def test_WHEN_should_proceed_with_operation_AND_abort_usage_THEN_as_expected(moc
 @mock.patch("commands.cluster_create._confirm_usage")
 def test_WHEN_should_proceed_with_operation_AND_doesnt_fit_THEN_as_expected(mock_confirm):
     # Set up our mock
+    azs = ["az1", "az2"]
     user_config = UserConfig(1, 30, 365, 2, 30) 
 
     cluster_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 100, 200, 100),
-        VpcPlan(Cidr("1.2.3.4/28"), DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK),
+        VpcPlan(Cidr("1.2.3.4/28"), azs, DEFAULT_CAPTURE_PUBLIC_MASK),
         EcsSysResourcePlan(3584, 15360),
         OSDomainPlan(DataNodesPlan(100, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS),
@@ -587,6 +593,8 @@ def test_WHEN_get_previous_capacity_plan_called_AND_exists_THEN_as_expected(mock
     # Set up our mock
     mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
 
+    azs = ["az1", "az2"]
+
     mock_ssm_ops.get_ssm_param_json_value.return_value = {
         "captureNodes": {
             "instanceType": "m5.xlarge",
@@ -600,7 +608,7 @@ def test_WHEN_get_previous_capacity_plan_called_AND_exists_THEN_as_expected(mock
                 "prefix": "1.2.3.4",
                 "mask": "24",
             },
-            "numAzs": 2,
+            "azs": azs,
             "publicSubnetMask": 28,
         },
         "ecsResources": {
@@ -632,7 +640,7 @@ def test_WHEN_get_previous_capacity_plan_called_AND_exists_THEN_as_expected(mock
                 "prefix": "2.3.4.5",
                 "mask": "26",
             },
-            "numAzs": 2,
+            "azs": azs,
             "publicSubnetMask": 28,
         },
     }
@@ -645,12 +653,12 @@ def test_WHEN_get_previous_capacity_plan_called_AND_exists_THEN_as_expected(mock
     # Check our results
     expected_value = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 1, 2, 1),
-        VpcPlan(Cidr("1.2.3.4/24"), DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK),
+        VpcPlan(Cidr("1.2.3.4/24"), azs, DEFAULT_CAPTURE_PUBLIC_MASK),
         EcsSysResourcePlan(3584, 15360),
         OSDomainPlan(DataNodesPlan(2, "r6g.large.search", 1024), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, 30),
         ViewerNodesPlan(4, 2),
-        VpcPlan(Cidr("2.3.4.5/26"), DEFAULT_NUM_AZS, DEFAULT_VIEWER_PUBLIC_MASK),
+        VpcPlan(Cidr("2.3.4.5/26"), azs, DEFAULT_VIEWER_PUBLIC_MASK),
     )
     assert expected_value == actual_value
 
@@ -689,20 +697,26 @@ def test_WHEN_get_previous_capacity_plan_called_AND_doesnt_exist_THEN_as_expecte
     assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
 
 
+@mock.patch("commands.cluster_create.ec2")
 @mock.patch("commands.cluster_create.get_viewer_vpc_plan")
 @mock.patch("commands.cluster_create.get_capture_vpc_plan")
 @mock.patch("commands.cluster_create.get_os_domain_plan")
 @mock.patch("commands.cluster_create.get_capture_node_capacity_plan")
 @mock.patch("commands.cluster_create.ssm_ops")
-def test_WHEN_get_next_capacity_plan_called_THEN_as_expected(mock_ssm_ops, mock_get_cap, mock_get_os, mock_get_capture, mock_get_viewer):
+def test_WHEN_get_next_capacity_plan_called_THEN_as_expected(mock_ssm_ops, mock_get_cap, mock_get_os, mock_get_capture, mock_get_viewer,
+                                                             mock_ec2):
     # Set up our mock
+    azs = ["az1", "az2", "az3", "az4", "az5"]
+
     mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
     mock_ssm_ops.get_ssm_param_json_value.side_effect = ssm_ops.ParamDoesNotExist("")
 
     mock_get_cap.return_value = CaptureNodesPlan("m5.xlarge", 1, 2, 1)
     mock_get_os.return_value = OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search"))
-    mock_get_capture.return_value = VpcPlan(Cidr("1.2.3.4/24"), DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK)
-    mock_get_viewer.return_value = VpcPlan(Cidr("2.3.4.5/26"), DEFAULT_NUM_AZS, DEFAULT_VIEWER_PUBLIC_MASK)
+    mock_get_capture.return_value = VpcPlan(Cidr("1.2.3.4/20"), azs, DEFAULT_CAPTURE_PUBLIC_MASK)
+    mock_get_viewer.return_value = VpcPlan(Cidr("2.3.4.5/26"), azs, DEFAULT_VIEWER_PUBLIC_MASK)
+
+    mock_ec2.get_azs_in_region.return_value = azs
 
     previous_cluster_plan = ClusterPlan(
         CaptureNodesPlan(None, None, None, None),
@@ -717,33 +731,35 @@ def test_WHEN_get_next_capacity_plan_called_THEN_as_expected(mock_ssm_ops, mock_
     mock_provider = mock.Mock()
 
     # Run our test
-    actual_value = _get_next_capacity_plan(UserConfig(1, 40, 120, 2, 35), previous_cluster_plan, "1.2.3.4/24", "2.3.4.5/26")
+    actual_value = _get_next_capacity_plan(UserConfig(1, 40, 120, 2, 35), previous_cluster_plan, "1.2.3.4/24", "2.3.4.5/26", mock_provider)
 
     # Check our results
+    assert mock_ec2.get_azs_in_region.called
+
     assert mock_get_cap.return_value == actual_value.captureNodes
-    assert VpcPlan(Cidr("1.2.3.4/24"), DEFAULT_NUM_AZS, DEFAULT_CAPTURE_PUBLIC_MASK) == actual_value.captureVpc
+    assert VpcPlan(Cidr("1.2.3.4/20"), azs, DEFAULT_CAPTURE_PUBLIC_MASK) == actual_value.captureVpc
     assert mock_get_os.return_value == actual_value.osDomain
     assert EcsSysResourcePlan(3584, 15360) == actual_value.ecsResources
     assert S3Plan(DEFAULT_S3_STORAGE_CLASS, 35) == actual_value.s3
-    assert VpcPlan(Cidr("2.3.4.5/26"), DEFAULT_NUM_AZS, DEFAULT_VIEWER_PUBLIC_MASK) == actual_value.viewerVpc
+    assert VpcPlan(Cidr("2.3.4.5/26"), azs, DEFAULT_VIEWER_PUBLIC_MASK) == actual_value.viewerVpc
 
     expected_get_cap_calls = [
-        mock.call(1)
+        mock.call(1, azs)
     ]
     assert expected_get_cap_calls == mock_get_cap.call_args_list
 
     expected_get_os_calls = [
-        mock.call(1, 40, 2, DEFAULT_NUM_AZS)
+        mock.call(1, 40, 2, len(azs))
     ]
     assert expected_get_os_calls == mock_get_os.call_args_list
 
     expected_get_capture_vpc_calls = [
-        mock.call(VpcPlan(None, None, None), "1.2.3.4/24")
+        mock.call(VpcPlan(None, None, None), "1.2.3.4/24", azs)
     ]
     assert expected_get_capture_vpc_calls == mock_get_capture.call_args_list
 
     expected_get_viewer_vpc_calls = [
-        mock.call(None, "2.3.4.5/26")
+        mock.call(None, "2.3.4.5/26", azs)
     ]
     assert expected_get_viewer_vpc_calls == mock_get_viewer.call_args_list
 

--- a/test_manage_arkime/commands/test_cluster_destroy.py
+++ b/test_manage_arkime/commands/test_cluster_destroy.py
@@ -384,16 +384,17 @@ def test_WHEN_get_stacks_to_destroy_called_THEN_as_expected():
     assert expected_value == actual_value
 
 def test_WHEN_get_cdk_context_called_AND_viewer_vpc_THEN_as_expected():
+    azs = ["us-fake-1"]
     cluster_name = "MyCluster"
 
     default_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 1, 2, 1),
-        VpcPlan(DEFAULT_VPC_CIDR, 2, DEFAULT_CAPTURE_PUBLIC_MASK),
+        VpcPlan(DEFAULT_VPC_CIDR, azs, DEFAULT_CAPTURE_PUBLIC_MASK),
         EcsSysResourcePlan(1, 1),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, 1),
         ViewerNodesPlan(4, 2),
-        VpcPlan(DEFAULT_VPC_CIDR, 2, DEFAULT_CAPTURE_PUBLIC_MASK),
+        VpcPlan(DEFAULT_VPC_CIDR, azs, DEFAULT_CAPTURE_PUBLIC_MASK),
     )
 
     stack_names = context.ClusterStackNames(
@@ -430,11 +431,12 @@ def test_WHEN_get_cdk_context_called_AND_viewer_vpc_THEN_as_expected():
     assert expected_value == actual_value
 
 def test_WHEN_get_cdk_context_called_AND_no_viewer_vpc_THEN_as_expected():
+    azs = ["us-fake-1"]
     cluster_name = "MyCluster"
 
     default_plan = ClusterPlan(
         CaptureNodesPlan("m5.xlarge", 1, 2, 1),
-        VpcPlan(DEFAULT_VPC_CIDR, 2, DEFAULT_CAPTURE_PUBLIC_MASK),
+        VpcPlan(DEFAULT_VPC_CIDR, azs, DEFAULT_CAPTURE_PUBLIC_MASK),
         EcsSysResourcePlan(1, 1),
         OSDomainPlan(DataNodesPlan(2, "t3.small.search", 100), MasterNodesPlan(3, "m6g.large.search")),
         S3Plan(DEFAULT_S3_STORAGE_CLASS, 1),

--- a/test_manage_arkime/core/test_capacity_planning.py
+++ b/test_manage_arkime/core/test_capacity_planning.py
@@ -14,28 +14,28 @@ def test_WHEN_get_capture_node_capacity_plan_called_THEN_as_expected():
     # TEST 1: No expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(None, azs)
-    expected_value = cap.CaptureNodesPlan(cap.T3_MEDIUM.instanceType, 4, 5, 4)
+    expected_value = cap.CaptureNodesPlan(cap.T3_MEDIUM.instanceType, 2, 3, 2)
 
     assert expected_value == actual_value
 
     # TEST 2: Small expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(0.001, azs)
-    expected_value = cap.CaptureNodesPlan(cap.T3_MEDIUM.instanceType, 4, 5, 4)
+    expected_value = cap.CaptureNodesPlan(cap.T3_MEDIUM.instanceType, 2, 3, 2)
 
     assert expected_value == actual_value
 
     # TEST 3: Mid-range expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(20, azs)
-    expected_value = cap.CaptureNodesPlan(cap.M5_XLARGE.instanceType, 10, 13, 4)
+    expected_value = cap.CaptureNodesPlan(cap.M5_XLARGE.instanceType, 10, 13, 2)
 
     assert expected_value == actual_value
 
     # TEST 4: Max expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(cap.MAX_TRAFFIC, azs)
-    expected_value = cap.CaptureNodesPlan(cap.M5_XLARGE.instanceType, 50, 63, 4)
+    expected_value = cap.CaptureNodesPlan(cap.M5_XLARGE.instanceType, 50, 63, 2)
 
     assert expected_value == actual_value
 

--- a/test_manage_arkime/core/test_capacity_planning.py
+++ b/test_manage_arkime/core/test_capacity_planning.py
@@ -28,14 +28,14 @@ def test_WHEN_get_capture_node_capacity_plan_called_THEN_as_expected():
     # TEST 3: Mid-range expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(20, azs)
-    expected_value = cap.CaptureNodesPlan(cap.M5_XLARGE.instanceType, 10, 13, 1)
+    expected_value = cap.CaptureNodesPlan(cap.M5_XLARGE.instanceType, 10, 13, 2)
 
     assert expected_value == actual_value
 
     # TEST 4: Max expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(cap.MAX_TRAFFIC, azs)
-    expected_value = cap.CaptureNodesPlan(cap.M5_XLARGE.instanceType, 50, 63, 1)
+    expected_value = cap.CaptureNodesPlan(cap.M5_XLARGE.instanceType, 50, 63, 2)
 
     assert expected_value == actual_value
 

--- a/test_manage_arkime/core/test_capacity_planning.py
+++ b/test_manage_arkime/core/test_capacity_planning.py
@@ -14,28 +14,28 @@ def test_WHEN_get_capture_node_capacity_plan_called_THEN_as_expected():
     # TEST 1: No expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(None, azs)
-    expected_value = cap.CaptureNodesPlan(cap.T3_MEDIUM.instanceType, 2, 3, 2)
+    expected_value = cap.CaptureNodesPlan(cap.T3_MEDIUM.instanceType, 1, 2, 1)
 
     assert expected_value == actual_value
 
     # TEST 2: Small expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(0.001, azs)
-    expected_value = cap.CaptureNodesPlan(cap.T3_MEDIUM.instanceType, 2, 3, 2)
+    expected_value = cap.CaptureNodesPlan(cap.T3_MEDIUM.instanceType, 1, 2, 1)
 
     assert expected_value == actual_value
 
     # TEST 3: Mid-range expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(20, azs)
-    expected_value = cap.CaptureNodesPlan(cap.M5_XLARGE.instanceType, 10, 13, 2)
+    expected_value = cap.CaptureNodesPlan(cap.M5_XLARGE.instanceType, 10, 13, 1)
 
     assert expected_value == actual_value
 
     # TEST 4: Max expected traffic number
 
     actual_value = cap.get_capture_node_capacity_plan(cap.MAX_TRAFFIC, azs)
-    expected_value = cap.CaptureNodesPlan(cap.M5_XLARGE.instanceType, 50, 63, 2)
+    expected_value = cap.CaptureNodesPlan(cap.M5_XLARGE.instanceType, 50, 63, 1)
 
     assert expected_value == actual_value
 

--- a/test_manage_arkime/core/test_versioning.py
+++ b/test_manage_arkime/core/test_versioning.py
@@ -54,7 +54,7 @@ def test_WHEN_get_version_info_called_THEN_as_expected(mock_get_md5, mock_get_so
     actual_versions = ver.get_version_info(mock_file)
 
     expected_versions = ver.VersionInfo(
-        "1",
+        "2",
         "1",
         "86d3f3a95c324c9479bd8986968f4327",
         "v0.1.1-1-gd8e1200",
@@ -66,7 +66,7 @@ def test_WHEN_get_version_info_called_THEN_as_expected(mock_get_md5, mock_get_so
     actual_versions = ver.get_version_info(mock_file, config_version="3")
 
     expected_versions = ver.VersionInfo(
-        "1",
+        "2",
         "3",
         "86d3f3a95c324c9479bd8986968f4327",
         "v0.1.1-1-gd8e1200",


### PR DESCRIPTION
## Description
* An error occurred when users tried to add VPCs to an Arkime Cluster that were present in AZs the Cluster's Capture VPC wasn't in.  This was due to the GWLB needing a Target in every AZ that it needed to create a VPC Endpoint in.  In order for the GWLB to have a Target in every AZ, the Capture Node's ASG must be present in every AZ (even if it currently has no provisioned instances in the AZ).
* The solution was to update the Capture VPC to provision subnets in every AZ in the region and have the Capture Node ASG span all of those subnets.  This "enabled" every AZ from the GWLB's perspective.  Cross-zone load balancing is enabled on the GWLB/ASG combo so that we don't have to have a Capture Node in every AZ.
* This is a backwards-incompatible change because we had to modify how we store our VPC Plan in Param Store, so the major version has been bumped.

## Tasks
* https://github.com/arkime/aws-aio/issues/147

## Testing
* I updated the Demo Traffic CDK to provision our test instances in every AZ (6, in us-east-1), then ensured that I was able to run `cluster-create` and `vpc-add` on the Demo VPC.  I then confirmed that test traffic from AZs that we did not have Capture Nodes in still were being captured by searching for those test instance's private IPs on the Arkime Portal.  Everything seemed to still work correctly.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
