### PR TITLE
Added a GitHub workflow to auto-tag merges to `main`

### DIFF
--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -1,0 +1,26 @@
+name: Bump version
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main-test
+
+jobs:
+  build:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.merge_commit_sha }}
+        fetch-depth: '0'
+
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@1.64.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DEFAULT_BUMP: minor
+        WITH_V: true

--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -4,7 +4,7 @@ on:
     types:
       - closed
     branches:
-      - main-test
+      - main
 
 jobs:
   build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,9 @@ To implement something new, please create an issue first so we can discuss it to
 * When creating a Pull Request please follow [best practices](https://github.com/trein/dev-best-practices/wiki/Git-Commit-Best-Practices) for creating git commits.
 * When your code is ready to be submitted, submit a Pull Request to begin the code review process.
 
+**Versioning:**
+We use [a GitHub workflow](https://github.com/anothrNick/github-tag-action) to automatically tag merges to `main` using [semver rules](https://semver.org/).  By default, it increments the minor version number.  If you need to increment the major version or patch version, include #major or #patch somewhere in your merge commit's message.
+
 #### How to run the unit tests & lint
 
 We require that the ruff linter and unit tests pass before merging PRs.


### PR DESCRIPTION
## Description
* Added a new workflow that creates tags when there is a merge into `main`.  By default, it increments the minor version number.  Repo owners can increment the major and patch version instead by including the strings #major or #patch in the merge commit message.

## Tasks
* https://github.com/arkime/aws-aio/issues/154

## Testing
* Tested many times on temporary branches within this repo by doing commits/merges to confirm the major, minor, and patch versions incremented as expected.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
