### PR TITLE
Updated README, added --retain-traffic-data to cluster-destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can see your created cluster and the VPCs it is currently monitoring using t
 By default, you will be given the minimum-size Capture Cluster.  You can provision a Cluster that will serve your expected usage using a set of optional command-line parameters, which will ensure the EC2 Capture Nodes and OpenSearch Domain are suitably provisioned (plus a little extra for safety):
 
 ```
-./manage_arkime.py cluster-create --name MyCluster --expected-traffic 1 --spi-days 30 --replicas 1
+./manage_arkime.py cluster-create --name MyCluster --expected-traffic 0.01 --spi-days 30 --replicas 1
 ```
 
 ### Setting up capture for a VPC in the Cluster account

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -142,11 +142,19 @@ cli.add_command(cluster_create)
     show_default=True,
     default=False
 )
+@click.option(
+    "--retain-traffic-data",
+    help=("Keeps the OpenSearch Domain and S3 Bucket containing your traffic data intact, along with associated CloudFormation"
+          + " stacks." ),
+    is_flag=True,
+    show_default=True,
+    default=False
+)
 @click.pass_context
-def cluster_destroy(ctx, name, destroy_everything):
+def cluster_destroy(ctx, name, destroy_everything, retain_traffic_data):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_cluster_destroy(profile, region, name, destroy_everything)
+    cmd_cluster_destroy(profile, region, name, destroy_everything, retain_traffic_data)
 cli.add_command(cluster_destroy)
 
 @click.command(help="Retrieves the login details of a cluster's the Arkime Viewer(s)")

--- a/manage_arkime/commands/cluster_destroy.py
+++ b/manage_arkime/commands/cluster_destroy.py
@@ -13,8 +13,13 @@ import cdk_interactions.cdk_context as context
 
 logger = logging.getLogger(__name__)
 
-def cmd_cluster_destroy(profile: str, region: str, name: str, destroy_everything: bool):
+def cmd_cluster_destroy(profile: str, region: str, name: str, destroy_everything: bool, retain_traffic_data: bool):
     logger.debug(f"Invoking cluster-destroy with profile '{profile}' and region '{region}'")
+
+    if not (destroy_everything or retain_traffic_data):
+        logger.error("You must specify either --destroy-everything or --retain-traffic-data")
+        logger.warning("Aborting...")
+        return
 
     aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)
     cdk_client = CdkClient(aws_provider.get_aws_env())


### PR DESCRIPTION
## Description
* A couple quick fixes per user feedback.
* The new `--retain-traffic-data` flag works the same way as the old default behavior of `cluster-destroy`; I just added a check that they provided either that flag or `--destroy-everything` to make the choice explicit and obvious.

## Tasks
* https://github.com/arkime/aws-aio/issues/158

## Testing
* Tested the new option locally against my AWS account:

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py --region us-east-1 cluster-destroy --name MyCluster
2024-01-19 15:02:13 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2024-01-19 15:02:13 - Using AWS Credential Profile: None
2024-01-19 15:02:13 - Using AWS Region: us-east-1
2024-01-19 15:02:13 - You must specify either --destroy-everything or --retain-traffic-data
2024-01-19 15:02:13 - Aborting...
```

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
