### PR TITLE
Added quick version checks to risky cluster-* and config-* cmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The CDK is used to perform infrastructure specification, setup, management, and 
 - [How to shell into the ECS containers](#how-to-shell-into-the-ecs-containers)
 - [Setting Up Demo Traffic Generation](#setting-up-demo-traffic-generation)
 - [Account Limits, Scaling, and Other Concerns](#account-limits-scaling-and-other-concerns)
+- [Troubleshooting](#troubleshooting)
 - [Generally useful NPM/CDK commands](#generally-useful-npmcdk-commands)
 - [Contribute](#contribute)
 - [Maintainers](#maintainers)
@@ -375,6 +376,36 @@ Here are some account limits you'll want to watch out for:
 * There's a max of 10,000 Standard SSM Parameters per account/region.  We use at least one for each User ENI, several for each Subnet in a User VPC, and several for each User VPC and Cluster.
 
 ## Troubleshooting
+
+### AWS AIO version mismatch
+
+The AWS AIO project contains many components that must operate together, and these components have embedded assumptions of how the other components will behave.  We use a concept called the "AWS AIO Version" to determine whether the various components of the solution should be able to operate together successfully.
+
+Most importantly, the version of the CLI currently installed must be compatible with the version of the Arkime Cluster it is operating against.  If the CLI and Arkime Cluster are both on the same AWS AIO major version (e.g. v7.x.x), then they should be interoperable.  If they are not on the same major version, then it is possible (or even likely) that performing CLI operations against the Arkime Cluster is unsafe and should be avoided.  To help protect deployed Arkime Clusters, the CLI compares the AWS AIO version of the CLI and the Arkime Cluster before sensitive operations and aborts if there is a detected mismatch, or it can't figure out if there is one (which itself is likely a sign of a mismatch).
+
+In the event you discover your installed CLI is not compatible with your Arkime Cluster, you should check out the latest version of the CLI whose major version matches the AWS AIO version of your Arkime Cluster.  You can find the version of your installed CLI using git tags like so:
+
+```
+git describe --tags
+```
+
+You can retrieve a listing of CLI versions using git tags as well:
+
+```
+git ls-remote --tags git@github.com:arkime/aws-aio.git
+```
+
+If the CLI detects a version mismatch, it should inform you of the AWS AIO version of the Arkime Cluster you tried to operate against.  However, you can also find the AWS AIO version of deployed Arkime Clusters in your account/region using the `clusters-list` command:
+
+```
+./manage_arkime.py clusters-list
+```
+
+Once you determine the correct major version to you with your Arkime Cluster, you can then check out the latest minor/patch version using git and operate against your Arkime Cluster as planned:
+
+```
+git checkout v2.2.0
+```
 
 ### "This CDK CLI is not compatible with the CDK library"
 This error is caused by having a mismatch between the Node packages `aws-cdk` (the CLI) and `aws-cdk-lib` (the CDK library), which can occaisionally result if one package is upgraded without the other package package.  You'll see an error message like the following in the manage_arkime.log file:

--- a/manage_arkime/commands/cluster_destroy.py
+++ b/manage_arkime/commands/cluster_destroy.py
@@ -57,7 +57,7 @@ def cmd_cluster_destroy(profile: str, region: str, name: str, destroy_everything
 
     has_viewer_vpc = cluster_plan.viewerVpc is not None
     stacks_to_destroy = _get_stacks_to_destroy(name, destroy_everything, has_viewer_vpc)
-    destroy_context = _get_cdk_context(name, has_viewer_vpc)
+    destroy_context = _get_cdk_context(name, cluster_plan)
 
     cdk_client.destroy(stacks_to_destroy, context=destroy_context)
 
@@ -135,7 +135,7 @@ def _get_stacks_to_destroy(cluster_name: str, destroy_everything: bool, has_view
 
     return stacks
 
-def _get_cdk_context(cluster_name: str, has_viewer_vpc: bool) -> Dict[str, any]:
+def _get_cdk_context(cluster_name: str, cluster_plan: ClusterPlan) -> Dict[str, any]:
     stack_names = context.ClusterStackNames(
         captureBucket=constants.get_capture_bucket_stack_name(cluster_name),
         captureNodes=constants.get_capture_nodes_stack_name(cluster_name),
@@ -145,4 +145,4 @@ def _get_cdk_context(cluster_name: str, has_viewer_vpc: bool) -> Dict[str, any]:
         viewerNodes=constants.get_viewer_nodes_stack_name(cluster_name),
         viewerVpc=constants.get_viewer_vpc_stack_name(cluster_name),
     )
-    return context.generate_cluster_destroy_context(cluster_name, stack_names, has_viewer_vpc)
+    return context.generate_cluster_destroy_context(cluster_name, stack_names, cluster_plan)

--- a/manage_arkime/core/versioning.py
+++ b/manage_arkime/core/versioning.py
@@ -91,19 +91,21 @@ class UnableToRetrieveClusterVersion(Exception):
 
 class CaptureViewerVersionMismatch(Exception):
     def __init__(self, capture_version: int, viewer_version: int):
-        super().__init__(f"The AWS AIO versions of your Capture ({capture_version}) and Viewer ({viewer_version}) components"
-                         + " do not match.  This is unexpected and should not happen.  Please cut us a ticket at:"
-                         + " https://github.com/arkime/aws-aio/issues/new")
+        super().__init__(f"The AWS AIO versions of your Capture ({capture_version}) and Viewer ({viewer_version})"
+                         + " components do not match.  This is unexpected and should not happen.  Please cut us a"
+                         + " ticket at: https://github.com/arkime/aws-aio/issues/new")
 
 class CliClusterVersionMismatch(Exception):
     def __init__(self, cli_version: int, cluster_version: int):
         super().__init__(f"The AWS AIO versions of your CLI ({cli_version}) and Cluster ({cluster_version}) do not"
-                         + " match.  This is likely to result in unexpected behavior.  Please revert your CLI to the latest"
-                         + f" minor version under the major version ({cluster_version}).  You can see a version listing of"
-                         + " the CLI using the command: git ls-remote --tags git@github.com:arkime/aws-aio.git")
+                         + " match.  This is likely to result in unexpected behavior.  Please change your CLI to the"
+                         + f" latest minor version under the major version ({cluster_version}).  Check out the"
+                         + " following README section for more details:"
+                         + " https://github.com/arkime/aws-aio#aws-aio-version-mismatch")
 
-def confirm_aws_aio_version_compatibility(cluster_name: str, aws_provider: AwsClientProvider, cli_version: int = AWS_AIO_VERSION):
-    # Unfortunately, it appears currently impossible to distinguish between the scenarios where the cluster doesn't
+def confirm_aws_aio_version_compatibility(cluster_name: str, aws_provider: AwsClientProvider,
+                                          cli_version: int = AWS_AIO_VERSION):
+    # Unfortunately, it currently appears impossible to distinguish between the scenarios where the cluster doesn't
     # exist and the cluster exists but is a different version.  In either case, we could get the ParamDoesNotExist
     # exception.
     try:

--- a/manage_arkime/core/versioning.py
+++ b/manage_arkime/core/versioning.py
@@ -1,10 +1,18 @@
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import hashlib
+import json
+import logging
 from typing import Dict
 
+import arkime_interactions.config_wrangling as config_wrangling
+from aws_interactions.aws_client_provider import AwsClientProvider
+import aws_interactions.ssm_operations as ssm_ops
+import core.constants as constants
 from core.local_file import LocalFile
 from core.shell_interactions import call_shell_command
+
+logger = logging.getLogger(__name__)
 
 """
 Manually updated/managed version number.  Increment if/when a backwards incompatible change is made.
@@ -74,4 +82,53 @@ def get_version_info(config_file: LocalFile, config_version: str = None) -> Vers
         datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
     )
 
+class UnableToRetrieveClusterVersion(Exception):
+    def __init__(self, cluster_name: str, cli_version: int):
+        super().__init__(f"It appears the cluster {cluster_name} does not exist.  There's also a chance the AWS AIO version"
+                        + f" of the CLI ({cli_version}) is incompatible with your Cluster.  If you're confident the Cluster"
+                        + " exists, you can try checking the AWS AIO version of your cluster using the clusters-list"
+                        + " command.  The CLI and Cluster versions must match.")
 
+class CaptureViewerVersionMismatch(Exception):
+    def __init__(self, capture_version: int, viewer_version: int):
+        super().__init__(f"The AWS AIO versions of your Capture ({capture_version}) and Viewer ({viewer_version}) components"
+                         + " do not match.  This is unexpected and should not happen.  Please cut us a ticket at:"
+                         + " https://github.com/arkime/aws-aio/issues/new")
+
+class CliClusterVersionMismatch(Exception):
+    def __init__(self, cli_version: int, cluster_version: int):
+        super().__init__(f"The AWS AIO versions of your CLI ({cli_version}) and Cluster ({cluster_version}) do not"
+                         + " match.  This is likely to result in unexpected behavior.  Please revert your CLI to the latest"
+                         + f" minor version under the major version ({cluster_version}).  You can see a version listing of"
+                         + " the CLI using the command: git ls-remote --tags git@github.com:arkime/aws-aio.git")
+
+def confirm_aws_aio_version_compatibility(cluster_name: str, aws_provider: AwsClientProvider, cli_version: int = AWS_AIO_VERSION):
+    # Unfortunately, it appears currently impossible to distinguish between the scenarios where the cluster doesn't
+    # exist and the cluster exists but is a different version.  In either case, we could get the ParamDoesNotExist
+    # exception.
+    try:
+        raw_capture_details_val = ssm_ops.get_ssm_param_value(
+            constants.get_capture_config_details_ssm_param_name(cluster_name),
+            aws_provider
+        )
+        capture_config_details = config_wrangling.ConfigDetails.from_dict(json.loads(raw_capture_details_val))
+
+        raw_viewer_details_val = ssm_ops.get_ssm_param_value(
+            constants.get_viewer_config_details_ssm_param_name(cluster_name),
+            aws_provider
+        )
+        viewer_config_details = config_wrangling.ConfigDetails.from_dict(json.loads(raw_viewer_details_val))
+    except ssm_ops.ParamDoesNotExist:
+        raise UnableToRetrieveClusterVersion(cluster_name, cli_version)
+    
+    capture_version = int(capture_config_details.version.aws_aio_version)
+    viewer_version = int(viewer_config_details.version.aws_aio_version)
+
+    if capture_version != viewer_version:
+        raise CaptureViewerVersionMismatch(capture_version, viewer_version)
+
+    if capture_version != cli_version:
+        raise CliClusterVersionMismatch(cli_version, capture_version)
+    
+    # Everything matches, we're good to go
+    return

--- a/test_manage_arkime/commands/test_cluster_destroy.py
+++ b/test_manage_arkime/commands/test_cluster_destroy.py
@@ -66,7 +66,7 @@ def test_WHEN_cmd_cluster_destroy_called_AND_dont_destroy_everything_THEN_expect
     expected_stacks_calls = [mock.call(TEST_CLUSTER, False, False)]
     assert expected_stacks_calls == mock_get_stacks.call_args_list
 
-    expected_cdk_calls = [mock.call(TEST_CLUSTER, False)]
+    expected_cdk_calls = [mock.call(TEST_CLUSTER, test_plan)]
     assert expected_cdk_calls == mock_get_context.call_args_list
 
     expected_calls = [
@@ -157,7 +157,7 @@ def test_WHEN_cmd_cluster_destroy_called_AND_destroy_everything_THEN_expected_cm
     expected_stacks_calls = [mock.call(TEST_CLUSTER, True, True)]
     assert expected_stacks_calls == mock_get_stacks.call_args_list
 
-    expected_cdk_calls = [mock.call(TEST_CLUSTER, True)]
+    expected_cdk_calls = [mock.call(TEST_CLUSTER, test_plan)]
     assert expected_cdk_calls == mock_get_context.call_args_list
 
     expected_cdk_calls = [
@@ -452,7 +452,7 @@ def test_WHEN_get_cdk_context_called_AND_viewer_vpc_THEN_as_expected():
         viewerVpc=constants.get_viewer_vpc_stack_name(cluster_name),
     )
 
-    actual_value = _get_cdk_context(cluster_name, True)
+    actual_value = _get_cdk_context(cluster_name, default_plan)
 
     expected_value = {
         constants.CDK_CONTEXT_CMD_VAR: constants.CMD_cluster_destroy,
@@ -499,7 +499,7 @@ def test_WHEN_get_cdk_context_called_AND_no_viewer_vpc_THEN_as_expected():
         viewerVpc=constants.get_viewer_vpc_stack_name(cluster_name),
     )
 
-    actual_value = _get_cdk_context(cluster_name, False)
+    actual_value = _get_cdk_context(cluster_name, default_plan)
 
     expected_value = {
         constants.CDK_CONTEXT_CMD_VAR: constants.CMD_cluster_destroy,

--- a/test_manage_arkime/commands/test_cluster_destroy.py
+++ b/test_manage_arkime/commands/test_cluster_destroy.py
@@ -12,9 +12,11 @@ from core.capacity_planning import (CaptureNodesPlan, ViewerNodesPlan, EcsSysRes
                                     ClusterPlan, VpcPlan, S3Plan, DEFAULT_S3_STORAGE_CLASS, DEFAULT_VPC_CIDR, DEFAULT_CAPTURE_PUBLIC_MASK,
                                     DEFAULT_NUM_AZS, DEFAULT_S3_STORAGE_DAYS)
 from core.user_config import UserConfig
+from core.versioning import CliClusterVersionMismatch, UnableToRetrieveClusterVersion
 
 TEST_CLUSTER = "my-cluster"
 
+@mock.patch("commands.cluster_destroy.ver.confirm_aws_aio_version_compatibility", mock.Mock())
 @mock.patch("commands.cluster_destroy.get_ssm_param_json_value")
 @mock.patch("commands.cluster_destroy._get_cdk_context")
 @mock.patch("commands.cluster_destroy._get_stacks_to_destroy")
@@ -90,6 +92,7 @@ def test_WHEN_cmd_cluster_destroy_called_AND_dont_destroy_everything_THEN_expect
     ]
     assert expected_delete_arkime_calls == mock_delete_arkime.call_args_list
 
+@mock.patch("commands.cluster_destroy.ver.confirm_aws_aio_version_compatibility", mock.Mock())
 @mock.patch("commands.cluster_destroy._get_cdk_context")
 @mock.patch("commands.cluster_destroy._get_stacks_to_destroy")
 @mock.patch("commands.cluster_destroy.AwsClientProvider")
@@ -180,6 +183,7 @@ def test_WHEN_cmd_cluster_destroy_called_AND_destroy_everything_THEN_expected_cm
     ]
     assert expected_delete_arkime_calls == mock_delete_arkime.call_args_list
 
+@mock.patch("commands.cluster_destroy.ver.confirm_aws_aio_version_compatibility", mock.Mock())
 @mock.patch("commands.cluster_destroy.AwsClientProvider", mock.Mock())
 @mock.patch("commands.cluster_destroy.get_ssm_param_json_value")
 @mock.patch("commands.cluster_destroy.get_ssm_names_by_path")
@@ -214,20 +218,38 @@ def test_WHEN_cmd_cluster_destroy_called_AND_existing_captures_THEN_abort(mock_c
     mock_client.destroy.assert_not_called()
 
 @mock.patch("commands.cluster_destroy.AwsClientProvider", mock.Mock())
-@mock.patch("commands.cluster_destroy.get_ssm_param_json_value")
-@mock.patch("commands.cluster_destroy.get_ssm_names_by_path")
+@mock.patch("commands.cluster_destroy.ver.confirm_aws_aio_version_compatibility")
 @mock.patch("commands.cluster_destroy.destroy_os_domain_and_wait")
 @mock.patch("commands.cluster_destroy.destroy_bucket")
 @mock.patch("commands.cluster_destroy.CdkClient")
 def test_WHEN_cmd_cluster_destroy_called_AND_doesnt_exist_THEN_abort(mock_cdk_client_cls, mock_destroy_bucket, mock_destroy_domain,
-                                                                          mock_ssm_names, mock_get_ssm_json):
+                                                                          mock_confirm_ver):
     # Set up our mock
-    mock_ssm_names.return_value = ["vpc-1", "vpc-2"]
-
     mock_client = mock.Mock()
     mock_cdk_client_cls.return_value = mock_client
 
-    mock_get_ssm_json.side_effect = ParamDoesNotExist("")
+    mock_confirm_ver.side_effect = UnableToRetrieveClusterVersion("cluster", 1)
+
+    # Run our test
+    cmd_cluster_destroy("profile", "region", TEST_CLUSTER, False, True)
+
+    # Check our results
+    mock_destroy_bucket.assert_not_called()
+    mock_destroy_domain.assert_not_called()
+    mock_client.destroy.assert_not_called()
+    
+@mock.patch("commands.cluster_destroy.AwsClientProvider", mock.Mock())
+@mock.patch("commands.cluster_destroy.ver.confirm_aws_aio_version_compatibility")
+@mock.patch("commands.cluster_destroy.destroy_os_domain_and_wait")
+@mock.patch("commands.cluster_destroy.destroy_bucket")
+@mock.patch("commands.cluster_destroy.CdkClient")
+def test_WHEN_cmd_cluster_destroy_called_AND_cli_version_THEN_abort(mock_cdk_client_cls, mock_destroy_bucket, mock_destroy_domain,
+                                                                          mock_confirm_ver):
+    # Set up our mock
+    mock_client = mock.Mock()
+    mock_cdk_client_cls.return_value = mock_client
+
+    mock_confirm_ver.side_effect = CliClusterVersionMismatch(2, 1)
 
     # Run our test
     cmd_cluster_destroy("profile", "region", TEST_CLUSTER, False, True)
@@ -237,6 +259,7 @@ def test_WHEN_cmd_cluster_destroy_called_AND_doesnt_exist_THEN_abort(mock_cdk_cl
     mock_destroy_domain.assert_not_called()
     mock_client.destroy.assert_not_called()
 
+@mock.patch("commands.cluster_destroy.ver.confirm_aws_aio_version_compatibility", mock.Mock())
 @mock.patch("commands.cluster_destroy.AwsClientProvider", mock.Mock())
 @mock.patch("commands.cluster_destroy.get_ssm_param_json_value")
 @mock.patch("commands.cluster_destroy.get_ssm_names_by_path")

--- a/test_manage_arkime/commands/test_cluster_register_vpc.py
+++ b/test_manage_arkime/commands/test_cluster_register_vpc.py
@@ -2,12 +2,13 @@ import json
 import unittest.mock as mock
 
 from aws_interactions.aws_environment import AwsEnvironment
-from aws_interactions.ssm_operations import ParamDoesNotExist
 import commands.cluster_register_vpc as crv
 import core.constants as constants
 from core.cross_account_wrangling import CrossAccountAssociation
+from core.versioning import UnableToRetrieveClusterVersion, CliClusterVersionMismatch
 
 
+@mock.patch("commands.cluster_register_vpc.ver.confirm_aws_aio_version_compatibility", mock.Mock())
 @mock.patch("commands.cluster_register_vpc.add_vpce_permissions")
 @mock.patch("commands.cluster_register_vpc.ensure_cross_account_role_exists")
 @mock.patch("commands.cluster_register_vpc.ssm_ops.put_ssm_param")
@@ -61,6 +62,7 @@ def test_WHEN_cmd_cluster_register_vpc_called_THEN_as_expected(mock_provider_cls
     ]
     assert expected_put_ssm_calls == mock_put_ssm.call_args_list
 
+@mock.patch("commands.cluster_register_vpc.ver.confirm_aws_aio_version_compatibility")
 @mock.patch("commands.cluster_register_vpc.add_vpce_permissions")
 @mock.patch("commands.cluster_register_vpc.ensure_cross_account_role_exists")
 @mock.patch("commands.cluster_register_vpc.ssm_ops.put_ssm_param")
@@ -68,26 +70,20 @@ def test_WHEN_cmd_cluster_register_vpc_called_THEN_as_expected(mock_provider_cls
 @mock.patch("commands.cluster_register_vpc.AwsClientProvider")
 def test_WHEN_cmd_cluster_register_vpc_called_AND_doesnt_exist_THEN_as_expected(mock_provider_cls, mock_get_ssm_json,
                                                                                 mock_put_ssm, mock_ensure, 
-                                                                                mock_add_perms):
+                                                                                mock_add_perms, mock_confirm_ver):
     # Set up our mock
     test_env = AwsEnvironment("XXXXXXXXXXXX", "region", "profile")
     mock_provider = mock.Mock()
     mock_provider.get_aws_env.return_value = test_env
     mock_provider_cls.return_value = mock_provider
 
-    mock_get_ssm_json.side_effect = ParamDoesNotExist("")
+    mock_confirm_ver.side_effect = UnableToRetrieveClusterVersion("my_cluster", 1)
 
     # Run our test
     crv.cmd_cluster_register_vpc("profile", "region", "my_cluster", "YYYYYYYYYYYY", "vpc")
 
     # Check our results
-    expected_get_ssm_calls = [
-        mock.call(
-            constants.get_cluster_ssm_param_name("my_cluster"),
-            "vpceServiceId",
-            mock_provider
-        )
-    ]
+    expected_get_ssm_calls = []
     assert expected_get_ssm_calls == mock_get_ssm_json.call_args_list
 
     expected_ensure_calls = []
@@ -97,5 +93,38 @@ def test_WHEN_cmd_cluster_register_vpc_called_AND_doesnt_exist_THEN_as_expected(
     assert expected_add_perms_calls == mock_add_perms.call_args_list
 
     expected_put_ssm_calls = []
-    assert expected_put_ssm_calls == mock_put_ssm.call_args_list    
+    assert expected_put_ssm_calls == mock_put_ssm.call_args_list
+
+@mock.patch("commands.cluster_register_vpc.ver.confirm_aws_aio_version_compatibility")
+@mock.patch("commands.cluster_register_vpc.add_vpce_permissions")
+@mock.patch("commands.cluster_register_vpc.ensure_cross_account_role_exists")
+@mock.patch("commands.cluster_register_vpc.ssm_ops.put_ssm_param")
+@mock.patch("commands.cluster_register_vpc.ssm_ops.get_ssm_param_json_value")
+@mock.patch("commands.cluster_register_vpc.AwsClientProvider")
+def test_WHEN_cmd_cluster_register_vpc_called_AND_cli_version_THEN_as_expected(mock_provider_cls, mock_get_ssm_json,
+                                                                                mock_put_ssm, mock_ensure, 
+                                                                                mock_add_perms, mock_confirm_ver):
+    # Set up our mock
+    test_env = AwsEnvironment("XXXXXXXXXXXX", "region", "profile")
+    mock_provider = mock.Mock()
+    mock_provider.get_aws_env.return_value = test_env
+    mock_provider_cls.return_value = mock_provider
+
+    mock_confirm_ver.side_effect = CliClusterVersionMismatch(2, 1)
+
+    # Run our test
+    crv.cmd_cluster_register_vpc("profile", "region", "my_cluster", "YYYYYYYYYYYY", "vpc")
+
+    # Check our results
+    expected_get_ssm_calls = []
+    assert expected_get_ssm_calls == mock_get_ssm_json.call_args_list
+
+    expected_ensure_calls = []
+    assert expected_ensure_calls == mock_ensure.call_args_list
+
+    expected_add_perms_calls = []
+    assert expected_add_perms_calls == mock_add_perms.call_args_list
+
+    expected_put_ssm_calls = []
+    assert expected_put_ssm_calls == mock_put_ssm.call_args_list
 

--- a/test_manage_arkime/core/test_versioning.py
+++ b/test_manage_arkime/core/test_versioning.py
@@ -2,8 +2,8 @@ import py
 import pytest
 import unittest.mock as mock
 
-import core.constants as constants
-import core.local_file as lf
+
+import aws_interactions.ssm_operations as ssm_ops
 import core.versioning as ver
 
 
@@ -73,3 +73,51 @@ def test_WHEN_get_version_info_called_THEN_as_expected(mock_get_md5, mock_get_so
         "2023-05-11 07:13:42",
     )
     assert expected_versions == actual_versions
+
+@mock.patch("commands.config_list.ssm_ops.get_ssm_param_value")
+def test_WHEN_confirm_aws_aio_version_compatibility_called_AND_compatible_THEN_no_op(mock_get_val):
+    # Set up our mock
+    mock_aws = mock.Mock()
+    mock_get_val.side_effect = [
+        '{"s3": {"bucket": "bucket-name","key": "capture/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v1.0.0","time_utc": "now"}, "previous": "None"}',
+        '{"s3": {"bucket": "bucket-name","key": "viewer/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v1.0.0","time_utc": "now"}, "previous": "None"}',
+    ]
+
+    # Run our test
+    ver.confirm_aws_aio_version_compatibility("MyCluster", mock_aws, cli_version=1)
+
+@mock.patch("commands.config_list.ssm_ops.get_ssm_param_value")
+def test_WHEN_confirm_aws_aio_version_compatibility_called_AND_cant_get_versions_THEN_raises(mock_get_val):
+    # Set up our mock
+    mock_aws = mock.Mock()
+    mock_get_val.side_effect = ssm_ops.ParamDoesNotExist("")
+
+    # Run our test
+    with pytest.raises(ver.UnableToRetrieveClusterVersion):
+        ver.confirm_aws_aio_version_compatibility("MyCluster", mock_aws, cli_version=1)
+
+@mock.patch("commands.config_list.ssm_ops.get_ssm_param_value")
+def test_WHEN_confirm_aws_aio_version_compatibility_called_AND_comp_mismatch_THEN_raises(mock_get_val):
+    # Set up our mock
+    mock_aws = mock.Mock()
+    mock_get_val.side_effect = [
+        '{"s3": {"bucket": "bucket-name","key": "capture/6/archive.zip"}, "version": {"aws_aio_version": "2","config_version": "6","md5_version": "3333","source_version": "v1.0.0","time_utc": "now"}, "previous": "None"}',
+        '{"s3": {"bucket": "bucket-name","key": "viewer/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v1.0.0","time_utc": "now"}, "previous": "None"}',
+    ]
+
+    # Run our test
+    with pytest.raises(ver.CaptureViewerVersionMismatch):
+        ver.confirm_aws_aio_version_compatibility("MyCluster", mock_aws, cli_version=1)
+
+@mock.patch("commands.config_list.ssm_ops.get_ssm_param_value")
+def test_WHEN_confirm_aws_aio_version_compatibility_called_AND_cli_mismatch_THEN_raises(mock_get_val):
+    # Set up our mock
+    mock_aws = mock.Mock()
+    mock_get_val.side_effect = [
+        '{"s3": {"bucket": "bucket-name","key": "capture/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v1.0.0","time_utc": "now"}, "previous": "None"}',
+        '{"s3": {"bucket": "bucket-name","key": "viewer/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v1.0.0","time_utc": "now"}, "previous": "None"}',
+    ]
+
+    # Run our test
+    with pytest.raises(ver.CliClusterVersionMismatch):
+        ver.confirm_aws_aio_version_compatibility("MyCluster", mock_aws, cli_version=2)


### PR DESCRIPTION
## Description
* Updated the `cluster-*` and `config-*` commands that have the potential for impact.  They now check if the user's deployed Arkime Cluster is compatible with the currently CLI version, using the AWS AIO Version number.
* I did not update the `vpc-*` commands with this check because that will require a backwards incompatible change (we need to embed the AWS AIO Version in an existing Param Store entry).  I'll address those changes after this PR is resolved.

## Tasks
* https://github.com/arkime/aws-aio/issues/154

## Testing
* Added unit tests
* Tested on my laptop against my own AWS account:

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py --region us-east-1 cluster-create --name MyClusterV2
2024-01-24 07:32:52 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2024-01-24 07:32:52 - Using AWS Credential Profile: None
2024-01-24 07:32:52 - Using AWS Region: us-east-1
2024-01-24 07:32:53 - The AWS AIO versions of your CLI (2) and Cluster (1) do not match.  This is likely to result in unexpected behavior.  Please change your CLI to the latest minor version under the m
ajor version (2).  Check out the following README section for more details: https://github.com/arkime/aws-aio#aws-aio-version-mismatch
2024-01-24 07:32:53 - Aborting...

(.venv) chelma@3c22fba4e266 aws-aio % git ls-remote --tags git@github.com:arkime/aws-aio.git
dfef816c31674390202b9048290037686118eec4        refs/tags/v0.1.1
a1aec22ecec9825d7d3920a2ad94800f595f9fa4        refs/tags/v1.0.0
1c851b5cd553fa2d65a68239b9f89eee4bbb2b34        refs/tags/v2.0.0
e679663ab65488802881cc7c7171c45903449a1d        refs/tags/v2.1.0
6c70ed45a4d59eae69d8ce0a85c284ad56fc2fa2        refs/tags/v2.2.0
```

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
