### PR TITLE
vpc-* commands version checked; fixed circular import dependency

### DIFF
--- a/manage_arkime/commands/cluster_create.py
+++ b/manage_arkime/commands/cluster_create.py
@@ -20,6 +20,7 @@ import core.constants as constants
 from core.local_file import LocalFile, S3File
 from core.usage_report import UsageReport
 from core.price_report import PriceReport
+import core.compatibility as compat
 from core.capacity_planning import (get_capture_node_capacity_plan, get_viewer_node_capacity_plan, get_ecs_sys_resource_plan, get_os_domain_plan,
                                     ClusterPlan, VpcPlan, MINIMUM_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_REPLICAS, get_capture_vpc_plan,
                                     S3Plan, DEFAULT_S3_STORAGE_CLASS, DEFAULT_S3_STORAGE_DAYS, DEFAULT_HISTORY_DAYS,
@@ -42,8 +43,8 @@ def cmd_cluster_create(profile: str, region: str, name: str, expected_traffic: f
     is_initial_invocation = _is_initial_invocation(name, aws_provider)
     if not is_initial_invocation:
         try:
-            ver.confirm_aws_aio_version_compatibility(name, aws_provider)
-        except (ver.CliClusterVersionMismatch, ver.CaptureViewerVersionMismatch, ver.UnableToRetrieveClusterVersion) as e:
+            compat.confirm_aws_aio_version_compatibility(name, aws_provider)
+        except (compat.CliClusterVersionMismatch, compat.CaptureViewerVersionMismatch, compat.UnableToRetrieveClusterVersion) as e:
             logger.error(e)
             logger.warning("Aborting...")
             return

--- a/manage_arkime/commands/cluster_deregister_vpc.py
+++ b/manage_arkime/commands/cluster_deregister_vpc.py
@@ -4,9 +4,9 @@ import logging
 from aws_interactions.aws_client_provider import AwsClientProvider
 import aws_interactions.iam_interactions as iami
 import aws_interactions.ssm_operations as ssm_ops
+import core.compatibility as compat
 import core.constants as constants
 from core.cross_account_wrangling import CrossAccountAssociation, remove_vpce_permissions
-import core.versioning as ver
 
 logger = logging.getLogger(__name__)
 
@@ -17,8 +17,8 @@ def cmd_cluster_deregister_vpc(profile: str, region: str, cluster_name: str, vpc
     aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)
 
     try:
-        ver.confirm_aws_aio_version_compatibility(cluster_name, aws_provider)
-    except (ver.CliClusterVersionMismatch, ver.CaptureViewerVersionMismatch, ver.UnableToRetrieveClusterVersion) as e:
+        compat.confirm_aws_aio_version_compatibility(cluster_name, aws_provider)
+    except (compat.CliClusterVersionMismatch, compat.CaptureViewerVersionMismatch, compat.UnableToRetrieveClusterVersion) as e:
         logger.error(e)
         logger.warning("Aborting...")
         return

--- a/manage_arkime/commands/cluster_destroy.py
+++ b/manage_arkime/commands/cluster_destroy.py
@@ -8,8 +8,8 @@ from aws_interactions.s3_interactions import destroy_bucket
 from aws_interactions.ssm_operations import get_ssm_param_json_value, get_ssm_param_value, get_ssm_names_by_path, delete_ssm_param, ParamDoesNotExist
 from cdk_interactions.cdk_client import CdkClient
 from core.capacity_planning import ClusterPlan
+import core.compatibility as compat
 import core.constants as constants
-import core.versioning as ver
 import cdk_interactions.cdk_context as context
 
 logger = logging.getLogger(__name__)
@@ -26,8 +26,8 @@ def cmd_cluster_destroy(profile: str, region: str, name: str, destroy_everything
     cdk_client = CdkClient(aws_provider.get_aws_env())
 
     try:
-        ver.confirm_aws_aio_version_compatibility(name, aws_provider)
-    except (ver.CliClusterVersionMismatch, ver.CaptureViewerVersionMismatch, ver.UnableToRetrieveClusterVersion) as e:
+        compat.confirm_aws_aio_version_compatibility(name, aws_provider)
+    except (compat.CliClusterVersionMismatch, compat.CaptureViewerVersionMismatch, compat.UnableToRetrieveClusterVersion) as e:
         logger.error(e)
         logger.warning("Aborting...")
         return

--- a/manage_arkime/commands/cluster_register_vpc.py
+++ b/manage_arkime/commands/cluster_register_vpc.py
@@ -3,9 +3,9 @@ import logging
 
 from aws_interactions.aws_client_provider import AwsClientProvider
 import aws_interactions.ssm_operations as ssm_ops
+import core.compatibility as compat
 import core.constants as constants
 from core.cross_account_wrangling import CrossAccountAssociation, ensure_cross_account_role_exists, add_vpce_permissions
-import core.versioning as ver
 
 logger = logging.getLogger(__name__)
 
@@ -17,8 +17,8 @@ def cmd_cluster_register_vpc(profile: str, region: str, cluster_name: str, vpc_a
     aws_env = aws_provider.get_aws_env()
 
     try:
-        ver.confirm_aws_aio_version_compatibility(cluster_name, aws_provider)
-    except (ver.CliClusterVersionMismatch, ver.CaptureViewerVersionMismatch, ver.UnableToRetrieveClusterVersion) as e:
+        compat.confirm_aws_aio_version_compatibility(cluster_name, aws_provider)
+    except (compat.CliClusterVersionMismatch, compat.CaptureViewerVersionMismatch, compat.UnableToRetrieveClusterVersion) as e:
         logger.error(e)
         logger.warning("Aborting...")
         return

--- a/manage_arkime/commands/config_update.py
+++ b/manage_arkime/commands/config_update.py
@@ -9,6 +9,7 @@ from aws_interactions.aws_client_provider import AwsClientProvider
 import aws_interactions.ecs_interactions as ecs
 import aws_interactions.s3_interactions as s3
 import aws_interactions.ssm_operations as ssm_ops
+import core.compatibility as compat
 import core.constants as constants
 from core.local_file import LocalFile, S3File
 import core.versioning as ver
@@ -31,8 +32,8 @@ def cmd_config_update(profile: str, region: str, cluster_name: str, capture: boo
     aws_env = aws_provider.get_aws_env()
 
     try:
-        ver.confirm_aws_aio_version_compatibility(cluster_name, aws_provider)
-    except (ver.CliClusterVersionMismatch, ver.CaptureViewerVersionMismatch, ver.UnableToRetrieveClusterVersion) as e:
+        compat.confirm_aws_aio_version_compatibility(cluster_name, aws_provider)
+    except (compat.CliClusterVersionMismatch, compat.CaptureViewerVersionMismatch, compat.UnableToRetrieveClusterVersion) as e:
         logger.error(e)
         logger.warning("Aborting...")
         return

--- a/manage_arkime/core/compatibility.py
+++ b/manage_arkime/core/compatibility.py
@@ -1,0 +1,60 @@
+import json
+
+import arkime_interactions.config_wrangling as config_wrangling
+from aws_interactions.aws_client_provider import AwsClientProvider
+import aws_interactions.ssm_operations as ssm_ops
+import core.constants as constants
+from core.versioning import AWS_AIO_VERSION
+
+class UnableToRetrieveClusterVersion(Exception):
+    def __init__(self, cluster_name: str, cli_version: int):
+        super().__init__(f"It appears the cluster {cluster_name} does not exist.  There's also a chance the AWS AIO version"
+                        + f" of the CLI ({cli_version}) is incompatible with your Cluster.  If you're confident the Cluster"
+                        + " exists, you can try checking the AWS AIO version of your cluster using the clusters-list"
+                        + " command.  The CLI and Cluster versions must match.")
+
+class CaptureViewerVersionMismatch(Exception):
+    def __init__(self, capture_version: int, viewer_version: int):
+        super().__init__(f"The AWS AIO versions of your Capture ({capture_version}) and Viewer ({viewer_version})"
+                         + " components do not match.  This is unexpected and should not happen.  Please cut us a"
+                         + " ticket at: https://github.com/arkime/aws-aio/issues/new")
+
+class CliClusterVersionMismatch(Exception):
+    def __init__(self, cli_version: int, cluster_version: int):
+        super().__init__(f"The AWS AIO versions of your CLI ({cli_version}) and Cluster ({cluster_version}) do not"
+                         + " match.  This is likely to result in unexpected behavior.  Please change your CLI to the"
+                         + f" latest minor version under the major version ({cluster_version}).  Check out the"
+                         + " following README section for more details:"
+                         + " https://github.com/arkime/aws-aio#aws-aio-version-mismatch")
+
+def confirm_aws_aio_version_compatibility(cluster_name: str, aws_provider: AwsClientProvider,
+                                          cli_version: int = AWS_AIO_VERSION):
+    # Unfortunately, it currently appears impossible to distinguish between the scenarios where the cluster doesn't
+    # exist and the cluster exists but is a different version.  In either case, we could get the ParamDoesNotExist
+    # exception.
+    try:
+        raw_capture_details_val = ssm_ops.get_ssm_param_value(
+            constants.get_capture_config_details_ssm_param_name(cluster_name),
+            aws_provider
+        )
+        capture_config_details = config_wrangling.ConfigDetails.from_dict(json.loads(raw_capture_details_val))
+
+        raw_viewer_details_val = ssm_ops.get_ssm_param_value(
+            constants.get_viewer_config_details_ssm_param_name(cluster_name),
+            aws_provider
+        )
+        viewer_config_details = config_wrangling.ConfigDetails.from_dict(json.loads(raw_viewer_details_val))
+    except ssm_ops.ParamDoesNotExist:
+        raise UnableToRetrieveClusterVersion(cluster_name, cli_version)
+    
+    capture_version = int(capture_config_details.version.aws_aio_version)
+    viewer_version = int(viewer_config_details.version.aws_aio_version)
+
+    if capture_version != viewer_version:
+        raise CaptureViewerVersionMismatch(capture_version, viewer_version)
+
+    if capture_version != cli_version:
+        raise CliClusterVersionMismatch(cli_version, capture_version)
+    
+    # Everything matches, we're good to go
+    return

--- a/manage_arkime/core/versioning.py
+++ b/manage_arkime/core/versioning.py
@@ -1,14 +1,9 @@
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import hashlib
-import json
 import logging
 from typing import Dict
 
-import arkime_interactions.config_wrangling as config_wrangling
-from aws_interactions.aws_client_provider import AwsClientProvider
-import aws_interactions.ssm_operations as ssm_ops
-import core.constants as constants
 from core.local_file import LocalFile
 from core.shell_interactions import call_shell_command
 
@@ -81,56 +76,3 @@ def get_version_info(config_file: LocalFile, config_version: str = None) -> Vers
         get_source_version(),
         datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
     )
-
-class UnableToRetrieveClusterVersion(Exception):
-    def __init__(self, cluster_name: str, cli_version: int):
-        super().__init__(f"It appears the cluster {cluster_name} does not exist.  There's also a chance the AWS AIO version"
-                        + f" of the CLI ({cli_version}) is incompatible with your Cluster.  If you're confident the Cluster"
-                        + " exists, you can try checking the AWS AIO version of your cluster using the clusters-list"
-                        + " command.  The CLI and Cluster versions must match.")
-
-class CaptureViewerVersionMismatch(Exception):
-    def __init__(self, capture_version: int, viewer_version: int):
-        super().__init__(f"The AWS AIO versions of your Capture ({capture_version}) and Viewer ({viewer_version})"
-                         + " components do not match.  This is unexpected and should not happen.  Please cut us a"
-                         + " ticket at: https://github.com/arkime/aws-aio/issues/new")
-
-class CliClusterVersionMismatch(Exception):
-    def __init__(self, cli_version: int, cluster_version: int):
-        super().__init__(f"The AWS AIO versions of your CLI ({cli_version}) and Cluster ({cluster_version}) do not"
-                         + " match.  This is likely to result in unexpected behavior.  Please change your CLI to the"
-                         + f" latest minor version under the major version ({cluster_version}).  Check out the"
-                         + " following README section for more details:"
-                         + " https://github.com/arkime/aws-aio#aws-aio-version-mismatch")
-
-def confirm_aws_aio_version_compatibility(cluster_name: str, aws_provider: AwsClientProvider,
-                                          cli_version: int = AWS_AIO_VERSION):
-    # Unfortunately, it currently appears impossible to distinguish between the scenarios where the cluster doesn't
-    # exist and the cluster exists but is a different version.  In either case, we could get the ParamDoesNotExist
-    # exception.
-    try:
-        raw_capture_details_val = ssm_ops.get_ssm_param_value(
-            constants.get_capture_config_details_ssm_param_name(cluster_name),
-            aws_provider
-        )
-        capture_config_details = config_wrangling.ConfigDetails.from_dict(json.loads(raw_capture_details_val))
-
-        raw_viewer_details_val = ssm_ops.get_ssm_param_value(
-            constants.get_viewer_config_details_ssm_param_name(cluster_name),
-            aws_provider
-        )
-        viewer_config_details = config_wrangling.ConfigDetails.from_dict(json.loads(raw_viewer_details_val))
-    except ssm_ops.ParamDoesNotExist:
-        raise UnableToRetrieveClusterVersion(cluster_name, cli_version)
-    
-    capture_version = int(capture_config_details.version.aws_aio_version)
-    viewer_version = int(viewer_config_details.version.aws_aio_version)
-
-    if capture_version != viewer_version:
-        raise CaptureViewerVersionMismatch(capture_version, viewer_version)
-
-    if capture_version != cli_version:
-        raise CliClusterVersionMismatch(cli_version, capture_version)
-    
-    # Everything matches, we're good to go
-    return

--- a/test_manage_arkime/commands/test_cluster_create.py
+++ b/test_manage_arkime/commands/test_cluster_create.py
@@ -13,6 +13,7 @@ import cdk_interactions.cdk_context as context
 from commands.cluster_create import (cmd_cluster_create, _set_up_viewer_cert, _get_next_capacity_plan, _get_next_user_config, _confirm_usage,
                                      _get_previous_capacity_plan, _get_previous_user_config, _configure_ism, _set_up_arkime_config,
                                      _tag_domain, _should_proceed_with_operation, _is_initial_invocation, _get_stacks_to_deploy, _get_cdk_context)
+from core.compatibility import CliClusterVersionMismatch
 import core.constants as constants
 from core.capacity_planning import (CaptureNodesPlan, ViewerNodesPlan, EcsSysResourcePlan, MINIMUM_TRAFFIC, OSDomainPlan, DataNodesPlan, MasterNodesPlan,
                                     VpcPlan, ClusterPlan, DEFAULT_SPI_DAYS, DEFAULT_REPLICAS, DEFAULT_NUM_AZS, S3Plan,
@@ -20,7 +21,7 @@ from core.capacity_planning import (CaptureNodesPlan, ViewerNodesPlan, EcsSysRes
                                     DEFAULT_VIEWER_PUBLIC_MASK)
 import core.local_file as local_file
 from core.user_config import UserConfig
-from core.versioning import VersionInfo, CliClusterVersionMismatch
+from core.versioning import VersionInfo
 
 
 @mock.patch("commands.cluster_create.AwsClientProvider")
@@ -110,7 +111,7 @@ def test_WHEN_cmd_cluster_create_called_THEN_cdk_command_correct(mock_cdk_client
     assert expected_tag_calls == mock_tag.call_args_list
 
 @mock.patch("commands.cluster_create.AwsClientProvider", mock.Mock())
-@mock.patch("commands.cluster_create.ver.confirm_aws_aio_version_compatibility")
+@mock.patch("commands.cluster_create.compat.confirm_aws_aio_version_compatibility")
 @mock.patch("commands.cluster_create._is_initial_invocation")
 @mock.patch("commands.cluster_create._tag_domain")
 @mock.patch("commands.cluster_create._set_up_arkime_config")

--- a/test_manage_arkime/commands/test_cluster_deregister_vpc.py
+++ b/test_manage_arkime/commands/test_cluster_deregister_vpc.py
@@ -5,9 +5,9 @@ from aws_interactions.aws_environment import AwsEnvironment
 import aws_interactions.ssm_operations as ssm_ops
 import commands.cluster_deregister_vpc as cdv
 import core.constants as constants
-import core.versioning as ver
+from core.compatibility import CliClusterVersionMismatch
 
-@mock.patch("commands.cluster_deregister_vpc.ver.confirm_aws_aio_version_compatibility", mock.Mock())
+@mock.patch("commands.cluster_deregister_vpc.compat.confirm_aws_aio_version_compatibility", mock.Mock())
 @mock.patch("commands.cluster_deregister_vpc.remove_vpce_permissions")
 @mock.patch("commands.cluster_deregister_vpc.ssm_ops.delete_ssm_param")
 @mock.patch("commands.cluster_deregister_vpc.iami.delete_iam_role")
@@ -52,7 +52,7 @@ def test_WHEN_cmd_cluster_deregister_vpc_called_THEN_as_expected(mock_provider_c
     ]
     assert expected_delete_ssm_calls == mock_delete_ssm.call_args_list
 
-@mock.patch("commands.cluster_deregister_vpc.ver.confirm_aws_aio_version_compatibility", mock.Mock())
+@mock.patch("commands.cluster_deregister_vpc.compat.confirm_aws_aio_version_compatibility", mock.Mock())
 @mock.patch("commands.cluster_deregister_vpc.remove_vpce_permissions")
 @mock.patch("commands.cluster_deregister_vpc.ssm_ops.delete_ssm_param")
 @mock.patch("commands.cluster_deregister_vpc.iami.delete_iam_role")
@@ -81,7 +81,7 @@ def test_WHEN_cmd_vpc_deregister_cluster_called_AND_not_associated_THEN_as_expec
     expected_delete_ssm_calls = []
     assert expected_delete_ssm_calls == mock_delete_ssm.call_args_list
 
-@mock.patch("commands.cluster_deregister_vpc.ver.confirm_aws_aio_version_compatibility", mock.Mock())
+@mock.patch("commands.cluster_deregister_vpc.compat.confirm_aws_aio_version_compatibility", mock.Mock())
 @mock.patch("commands.cluster_deregister_vpc.remove_vpce_permissions")
 @mock.patch("commands.cluster_deregister_vpc.ssm_ops.delete_ssm_param")
 @mock.patch("commands.cluster_deregister_vpc.iami.delete_iam_role")
@@ -117,7 +117,7 @@ def test_WHEN_cmd_vpc_deregister_cluster_called_AND_wrong_account_THEN_as_expect
     expected_delete_ssm_calls = []
     assert expected_delete_ssm_calls == mock_delete_ssm.call_args_list
 
-@mock.patch("commands.cluster_deregister_vpc.ver.confirm_aws_aio_version_compatibility")
+@mock.patch("commands.cluster_deregister_vpc.compat.confirm_aws_aio_version_compatibility")
 @mock.patch("commands.cluster_deregister_vpc.remove_vpce_permissions")
 @mock.patch("commands.cluster_deregister_vpc.ssm_ops.delete_ssm_param")
 @mock.patch("commands.cluster_deregister_vpc.iami.delete_iam_role")
@@ -128,7 +128,7 @@ def test_WHEN_cmd_vpc_deregister_cluster_called_AND_cli_version_THEN_as_expected
     mock_provider = mock.Mock()
     mock_provider_cls.return_value = mock_provider
 
-    mock_confirm_ver.side_effect = ver.CliClusterVersionMismatch(2, 1)
+    mock_confirm_ver.side_effect = CliClusterVersionMismatch(2, 1)
 
     # Run our test
     cdv.cmd_cluster_deregister_vpc("profile", "region", "my_cluster", "vpc")

--- a/test_manage_arkime/commands/test_cluster_destroy.py
+++ b/test_manage_arkime/commands/test_cluster_destroy.py
@@ -12,11 +12,11 @@ from core.capacity_planning import (CaptureNodesPlan, ViewerNodesPlan, EcsSysRes
                                     ClusterPlan, VpcPlan, S3Plan, DEFAULT_S3_STORAGE_CLASS, DEFAULT_VPC_CIDR, DEFAULT_CAPTURE_PUBLIC_MASK,
                                     DEFAULT_NUM_AZS, DEFAULT_S3_STORAGE_DAYS)
 from core.user_config import UserConfig
-from core.versioning import CliClusterVersionMismatch, UnableToRetrieveClusterVersion
+from core.compatibility import CliClusterVersionMismatch, UnableToRetrieveClusterVersion
 
 TEST_CLUSTER = "my-cluster"
 
-@mock.patch("commands.cluster_destroy.ver.confirm_aws_aio_version_compatibility", mock.Mock())
+@mock.patch("commands.cluster_destroy.compat.confirm_aws_aio_version_compatibility", mock.Mock())
 @mock.patch("commands.cluster_destroy.get_ssm_param_json_value")
 @mock.patch("commands.cluster_destroy._get_cdk_context")
 @mock.patch("commands.cluster_destroy._get_stacks_to_destroy")
@@ -92,7 +92,7 @@ def test_WHEN_cmd_cluster_destroy_called_AND_dont_destroy_everything_THEN_expect
     ]
     assert expected_delete_arkime_calls == mock_delete_arkime.call_args_list
 
-@mock.patch("commands.cluster_destroy.ver.confirm_aws_aio_version_compatibility", mock.Mock())
+@mock.patch("commands.cluster_destroy.compat.confirm_aws_aio_version_compatibility", mock.Mock())
 @mock.patch("commands.cluster_destroy._get_cdk_context")
 @mock.patch("commands.cluster_destroy._get_stacks_to_destroy")
 @mock.patch("commands.cluster_destroy.AwsClientProvider")
@@ -183,7 +183,7 @@ def test_WHEN_cmd_cluster_destroy_called_AND_destroy_everything_THEN_expected_cm
     ]
     assert expected_delete_arkime_calls == mock_delete_arkime.call_args_list
 
-@mock.patch("commands.cluster_destroy.ver.confirm_aws_aio_version_compatibility", mock.Mock())
+@mock.patch("commands.cluster_destroy.compat.confirm_aws_aio_version_compatibility", mock.Mock())
 @mock.patch("commands.cluster_destroy.AwsClientProvider", mock.Mock())
 @mock.patch("commands.cluster_destroy.get_ssm_param_json_value")
 @mock.patch("commands.cluster_destroy.get_ssm_names_by_path")
@@ -218,7 +218,7 @@ def test_WHEN_cmd_cluster_destroy_called_AND_existing_captures_THEN_abort(mock_c
     mock_client.destroy.assert_not_called()
 
 @mock.patch("commands.cluster_destroy.AwsClientProvider", mock.Mock())
-@mock.patch("commands.cluster_destroy.ver.confirm_aws_aio_version_compatibility")
+@mock.patch("commands.cluster_destroy.compat.confirm_aws_aio_version_compatibility")
 @mock.patch("commands.cluster_destroy.destroy_os_domain_and_wait")
 @mock.patch("commands.cluster_destroy.destroy_bucket")
 @mock.patch("commands.cluster_destroy.CdkClient")
@@ -239,7 +239,7 @@ def test_WHEN_cmd_cluster_destroy_called_AND_doesnt_exist_THEN_abort(mock_cdk_cl
     mock_client.destroy.assert_not_called()
     
 @mock.patch("commands.cluster_destroy.AwsClientProvider", mock.Mock())
-@mock.patch("commands.cluster_destroy.ver.confirm_aws_aio_version_compatibility")
+@mock.patch("commands.cluster_destroy.compat.confirm_aws_aio_version_compatibility")
 @mock.patch("commands.cluster_destroy.destroy_os_domain_and_wait")
 @mock.patch("commands.cluster_destroy.destroy_bucket")
 @mock.patch("commands.cluster_destroy.CdkClient")
@@ -259,7 +259,7 @@ def test_WHEN_cmd_cluster_destroy_called_AND_cli_version_THEN_abort(mock_cdk_cli
     mock_destroy_domain.assert_not_called()
     mock_client.destroy.assert_not_called()
 
-@mock.patch("commands.cluster_destroy.ver.confirm_aws_aio_version_compatibility", mock.Mock())
+@mock.patch("commands.cluster_destroy.compat.confirm_aws_aio_version_compatibility", mock.Mock())
 @mock.patch("commands.cluster_destroy.AwsClientProvider", mock.Mock())
 @mock.patch("commands.cluster_destroy.get_ssm_param_json_value")
 @mock.patch("commands.cluster_destroy.get_ssm_names_by_path")

--- a/test_manage_arkime/commands/test_cluster_register_vpc.py
+++ b/test_manage_arkime/commands/test_cluster_register_vpc.py
@@ -5,10 +5,10 @@ from aws_interactions.aws_environment import AwsEnvironment
 import commands.cluster_register_vpc as crv
 import core.constants as constants
 from core.cross_account_wrangling import CrossAccountAssociation
-from core.versioning import UnableToRetrieveClusterVersion, CliClusterVersionMismatch
+from core.compatibility import UnableToRetrieveClusterVersion, CliClusterVersionMismatch
 
 
-@mock.patch("commands.cluster_register_vpc.ver.confirm_aws_aio_version_compatibility", mock.Mock())
+@mock.patch("commands.cluster_register_vpc.compat.confirm_aws_aio_version_compatibility", mock.Mock())
 @mock.patch("commands.cluster_register_vpc.add_vpce_permissions")
 @mock.patch("commands.cluster_register_vpc.ensure_cross_account_role_exists")
 @mock.patch("commands.cluster_register_vpc.ssm_ops.put_ssm_param")
@@ -62,7 +62,7 @@ def test_WHEN_cmd_cluster_register_vpc_called_THEN_as_expected(mock_provider_cls
     ]
     assert expected_put_ssm_calls == mock_put_ssm.call_args_list
 
-@mock.patch("commands.cluster_register_vpc.ver.confirm_aws_aio_version_compatibility")
+@mock.patch("commands.cluster_register_vpc.compat.confirm_aws_aio_version_compatibility")
 @mock.patch("commands.cluster_register_vpc.add_vpce_permissions")
 @mock.patch("commands.cluster_register_vpc.ensure_cross_account_role_exists")
 @mock.patch("commands.cluster_register_vpc.ssm_ops.put_ssm_param")
@@ -95,7 +95,7 @@ def test_WHEN_cmd_cluster_register_vpc_called_AND_doesnt_exist_THEN_as_expected(
     expected_put_ssm_calls = []
     assert expected_put_ssm_calls == mock_put_ssm.call_args_list
 
-@mock.patch("commands.cluster_register_vpc.ver.confirm_aws_aio_version_compatibility")
+@mock.patch("commands.cluster_register_vpc.compat.confirm_aws_aio_version_compatibility")
 @mock.patch("commands.cluster_register_vpc.add_vpce_permissions")
 @mock.patch("commands.cluster_register_vpc.ensure_cross_account_role_exists")
 @mock.patch("commands.cluster_register_vpc.ssm_ops.put_ssm_param")

--- a/test_manage_arkime/commands/test_config_update.py
+++ b/test_manage_arkime/commands/test_config_update.py
@@ -4,17 +4,16 @@ import unittest.mock as mock
 
 import arkime_interactions.config_wrangling as config_wrangling
 from aws_interactions.aws_environment import AwsEnvironment
-from aws_interactions.events_interactions import ConfigureIsmEvent
 import aws_interactions.s3_interactions as s3
-import aws_interactions.ssm_operations as ssm_ops
 from commands.config_update import (cmd_config_update, _update_config_if_necessary, _revert_arkime_config, 
                                     NoPreviousConfig, _bounce_ecs_service)
+from core.compatibility import CliClusterVersionMismatch
 import core.constants as constants
 import core.local_file as local_file
-from core.versioning import VersionInfo, CliClusterVersionMismatch
+from core.versioning import VersionInfo
 
 
-@mock.patch("commands.cluster_register_vpc.ver.confirm_aws_aio_version_compatibility", mock.Mock())
+@mock.patch("commands.cluster_register_vpc.compat.confirm_aws_aio_version_compatibility", mock.Mock())
 @mock.patch("commands.config_update._bounce_ecs_service")
 @mock.patch("commands.config_update.ssm_ops.get_ssm_param_value")
 @mock.patch("commands.config_update._update_config_if_necessary")
@@ -92,7 +91,7 @@ def test_WHEN_cmd_config_update_called_AND_happy_path_THEN_as_expected(mock_prov
     ]
     assert expected_bounce_calls == mock_bounce.call_args_list
 
-@mock.patch("commands.cluster_register_vpc.ver.confirm_aws_aio_version_compatibility", mock.Mock())
+@mock.patch("commands.cluster_register_vpc.compat.confirm_aws_aio_version_compatibility", mock.Mock())
 @mock.patch("commands.config_update._bounce_ecs_service")
 @mock.patch("commands.config_update.ssm_ops.get_ssm_param_value")
 @mock.patch("commands.config_update._update_config_if_necessary")
@@ -143,7 +142,7 @@ def test_WHEN_cmd_config_update_called_AND_shouldnt_bounce_THEN_as_expected(mock
     expected_bounce_calls = []
     assert expected_bounce_calls == mock_bounce.call_args_list
 
-@mock.patch("commands.cluster_register_vpc.ver.confirm_aws_aio_version_compatibility", mock.Mock())
+@mock.patch("commands.cluster_register_vpc.compat.confirm_aws_aio_version_compatibility", mock.Mock())
 @mock.patch("commands.config_update._bounce_ecs_service")
 @mock.patch("commands.config_update.ssm_ops.get_ssm_param_value")
 @mock.patch("commands.config_update._update_config_if_necessary")
@@ -225,7 +224,7 @@ def test_WHEN_cmd_config_update_called_AND_force_bounce_THEN_as_expected(mock_pr
 class ExpectedExit(Exception):
     pass
 
-@mock.patch("commands.cluster_register_vpc.ver.confirm_aws_aio_version_compatibility", mock.Mock())
+@mock.patch("commands.cluster_register_vpc.compat.confirm_aws_aio_version_compatibility", mock.Mock())
 @mock.patch("commands.config_update.exit")
 @mock.patch("commands.config_update._bounce_ecs_service")
 @mock.patch("commands.config_update.ssm_ops.get_ssm_param_value")
@@ -254,7 +253,7 @@ def test_WHEN_cmd_config_update_called_AND_config_ver_no_component_THEN_as_expec
 
 
 @mock.patch("commands.config_update.AwsClientProvider", mock.Mock())
-@mock.patch("commands.cluster_register_vpc.ver.confirm_aws_aio_version_compatibility")
+@mock.patch("commands.cluster_register_vpc.compat.confirm_aws_aio_version_compatibility")
 @mock.patch("commands.config_update.exit")
 @mock.patch("commands.config_update._bounce_ecs_service")
 @mock.patch("commands.config_update.ssm_ops.get_ssm_param_value")

--- a/test_manage_arkime/core/test_compatibility.py
+++ b/test_manage_arkime/core/test_compatibility.py
@@ -1,0 +1,55 @@
+import py
+import pytest
+import unittest.mock as mock
+
+import aws_interactions.ssm_operations as ssm_ops
+import core.compatibility as compat
+
+
+@mock.patch("commands.config_list.ssm_ops.get_ssm_param_value")
+def test_WHEN_confirm_aws_aio_version_compatibility_called_AND_compatible_THEN_no_op(mock_get_val):
+    # Set up our mock
+    mock_aws = mock.Mock()
+    mock_get_val.side_effect = [
+        '{"s3": {"bucket": "bucket-name","key": "capture/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v1.0.0","time_utc": "now"}, "previous": "None"}',
+        '{"s3": {"bucket": "bucket-name","key": "viewer/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v1.0.0","time_utc": "now"}, "previous": "None"}',
+    ]
+
+    # Run our test
+    compat.confirm_aws_aio_version_compatibility("MyCluster", mock_aws, cli_version=1)
+
+@mock.patch("commands.config_list.ssm_ops.get_ssm_param_value")
+def test_WHEN_confirm_aws_aio_version_compatibility_called_AND_cant_get_versions_THEN_raises(mock_get_val):
+    # Set up our mock
+    mock_aws = mock.Mock()
+    mock_get_val.side_effect = ssm_ops.ParamDoesNotExist("")
+
+    # Run our test
+    with pytest.raises(compat.UnableToRetrieveClusterVersion):
+        compat.confirm_aws_aio_version_compatibility("MyCluster", mock_aws, cli_version=1)
+
+@mock.patch("commands.config_list.ssm_ops.get_ssm_param_value")
+def test_WHEN_confirm_aws_aio_version_compatibility_called_AND_comp_mismatch_THEN_raises(mock_get_val):
+    # Set up our mock
+    mock_aws = mock.Mock()
+    mock_get_val.side_effect = [
+        '{"s3": {"bucket": "bucket-name","key": "capture/6/archive.zip"}, "version": {"aws_aio_version": "2","config_version": "6","md5_version": "3333","source_version": "v1.0.0","time_utc": "now"}, "previous": "None"}',
+        '{"s3": {"bucket": "bucket-name","key": "viewer/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v1.0.0","time_utc": "now"}, "previous": "None"}',
+    ]
+
+    # Run our test
+    with pytest.raises(compat.CaptureViewerVersionMismatch):
+        compat.confirm_aws_aio_version_compatibility("MyCluster", mock_aws, cli_version=1)
+
+@mock.patch("commands.config_list.ssm_ops.get_ssm_param_value")
+def test_WHEN_confirm_aws_aio_version_compatibility_called_AND_cli_mismatch_THEN_raises(mock_get_val):
+    # Set up our mock
+    mock_aws = mock.Mock()
+    mock_get_val.side_effect = [
+        '{"s3": {"bucket": "bucket-name","key": "capture/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v1.0.0","time_utc": "now"}, "previous": "None"}',
+        '{"s3": {"bucket": "bucket-name","key": "viewer/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v1.0.0","time_utc": "now"}, "previous": "None"}',
+    ]
+
+    # Run our test
+    with pytest.raises(compat.CliClusterVersionMismatch):
+        compat.confirm_aws_aio_version_compatibility("MyCluster", mock_aws, cli_version=2)

--- a/test_manage_arkime/core/test_versioning.py
+++ b/test_manage_arkime/core/test_versioning.py
@@ -2,8 +2,6 @@ import py
 import pytest
 import unittest.mock as mock
 
-
-import aws_interactions.ssm_operations as ssm_ops
 import core.versioning as ver
 
 
@@ -74,50 +72,3 @@ def test_WHEN_get_version_info_called_THEN_as_expected(mock_get_md5, mock_get_so
     )
     assert expected_versions == actual_versions
 
-@mock.patch("commands.config_list.ssm_ops.get_ssm_param_value")
-def test_WHEN_confirm_aws_aio_version_compatibility_called_AND_compatible_THEN_no_op(mock_get_val):
-    # Set up our mock
-    mock_aws = mock.Mock()
-    mock_get_val.side_effect = [
-        '{"s3": {"bucket": "bucket-name","key": "capture/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v1.0.0","time_utc": "now"}, "previous": "None"}',
-        '{"s3": {"bucket": "bucket-name","key": "viewer/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v1.0.0","time_utc": "now"}, "previous": "None"}',
-    ]
-
-    # Run our test
-    ver.confirm_aws_aio_version_compatibility("MyCluster", mock_aws, cli_version=1)
-
-@mock.patch("commands.config_list.ssm_ops.get_ssm_param_value")
-def test_WHEN_confirm_aws_aio_version_compatibility_called_AND_cant_get_versions_THEN_raises(mock_get_val):
-    # Set up our mock
-    mock_aws = mock.Mock()
-    mock_get_val.side_effect = ssm_ops.ParamDoesNotExist("")
-
-    # Run our test
-    with pytest.raises(ver.UnableToRetrieveClusterVersion):
-        ver.confirm_aws_aio_version_compatibility("MyCluster", mock_aws, cli_version=1)
-
-@mock.patch("commands.config_list.ssm_ops.get_ssm_param_value")
-def test_WHEN_confirm_aws_aio_version_compatibility_called_AND_comp_mismatch_THEN_raises(mock_get_val):
-    # Set up our mock
-    mock_aws = mock.Mock()
-    mock_get_val.side_effect = [
-        '{"s3": {"bucket": "bucket-name","key": "capture/6/archive.zip"}, "version": {"aws_aio_version": "2","config_version": "6","md5_version": "3333","source_version": "v1.0.0","time_utc": "now"}, "previous": "None"}',
-        '{"s3": {"bucket": "bucket-name","key": "viewer/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v1.0.0","time_utc": "now"}, "previous": "None"}',
-    ]
-
-    # Run our test
-    with pytest.raises(ver.CaptureViewerVersionMismatch):
-        ver.confirm_aws_aio_version_compatibility("MyCluster", mock_aws, cli_version=1)
-
-@mock.patch("commands.config_list.ssm_ops.get_ssm_param_value")
-def test_WHEN_confirm_aws_aio_version_compatibility_called_AND_cli_mismatch_THEN_raises(mock_get_val):
-    # Set up our mock
-    mock_aws = mock.Mock()
-    mock_get_val.side_effect = [
-        '{"s3": {"bucket": "bucket-name","key": "capture/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v1.0.0","time_utc": "now"}, "previous": "None"}',
-        '{"s3": {"bucket": "bucket-name","key": "viewer/6/archive.zip"}, "version": {"aws_aio_version": "1","config_version": "6","md5_version": "3333","source_version": "v1.0.0","time_utc": "now"}, "previous": "None"}',
-    ]
-
-    # Run our test
-    with pytest.raises(ver.CliClusterVersionMismatch):
-        ver.confirm_aws_aio_version_compatibility("MyCluster", mock_aws, cli_version=2)


### PR DESCRIPTION
## Description
* Added AWS AIO Version compatibility checks to the `vpc-add` and `vpc-remove` commands.  I had originally thought this would require backwards incompatible changes but that fortunately turned out not to be the case.
* I also fixed a circular import dependency issue by moving some code from `core.versioning` to its own, new file `core.compatibility`.  It had existed in the previous commit but only popped up under very specific circumstances.  I stumbled across it while updating the behavior of `vpc-add`.

## Tasks
* https://github.com/arkime/aws-aio/issues/154

## Testing
* Added/updated unit tests
* Tested locally with my own AWS Account:

```
(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py --region us-east-1 vpc-add --cluster-name MyClusterV2 --vpc-id vpc-0fc8b977a31286213
2024-01-24 16:23:22 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2024-01-24 16:23:22 - Using AWS Credential Profile: None
2024-01-24 16:23:22 - Using AWS Region: us-east-1
2024-01-24 16:23:26 - The AWS AIO versions of your CLI (3) and Cluster (2) do not match.  This is likely to result in unexpected behavior.  Please change your CLI to the latest minor version under the
 major version (2).  Check out the following README section for more details: https://github.com/arkime/aws-aio#aws-aio-version-mismatch
2024-01-24 16:23:26 - Aborting...

(.venv) chelma@3c22fba4e266 aws-aio % ./manage_arkime.py --region us-east-1 vpc-remove --cluster-name MyClusterV2 --vpc-id vpc-0fc8b977a31286213
2024-01-24 16:23:35 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/aws-aio/manage_arkime/manage_arkime.log
2024-01-24 16:23:35 - Using AWS Credential Profile: None
2024-01-24 16:23:35 - Using AWS Region: us-east-1
2024-01-24 16:23:37 - The AWS AIO versions of your CLI (3) and Cluster (2) do not match.  This is likely to result in unexpected behavior.  Please change your CLI to the latest minor version under the
 major version (2).  Check out the following README section for more details: https://github.com/arkime/aws-aio#aws-aio-version-mismatch
2024-01-24 16:23:37 - Aborting...
```

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
