### PR TITLE
Turned off unused NAT Gateways in Capture/Viewer VPCs

### DIFF
--- a/cdk-lib/capture-stacks/capture-vpc-stack.ts
+++ b/cdk-lib/capture-stacks/capture-vpc-stack.ts
@@ -16,6 +16,7 @@ export class CaptureVpcStack extends Stack {
 
         this.vpc = new ec2.Vpc(this, 'VPC', {
             ipAddresses: ec2.IpAddresses.cidr(props.planCluster.captureVpc.cidr.block),
+            natGateways: 0,
             availabilityZones: props.planCluster.captureVpc.azs,
             subnetConfiguration: [
                 {

--- a/cdk-lib/viewer-stacks/viewer-vpc-stack.ts
+++ b/cdk-lib/viewer-stacks/viewer-vpc-stack.ts
@@ -19,6 +19,7 @@ export class ViewerVpcStack extends Stack {
         // The VPC the Viewer Nodes will live in
         this.vpc = new ec2.Vpc(this, 'VPC', {
             ipAddresses: ec2.IpAddresses.cidr(props.viewerVpcPlan.cidr.block),
+            natGateways: 0,
             availabilityZones: props.viewerVpcPlan.azs,
             subnetConfiguration: [
                 {


### PR DESCRIPTION
## Description
* Turned off the NAT Gateways in the Capture and Viewer VPCs.  These are created by default as a part of the CDK's opinionated baseline configuration for a VPC, but we aren't using them.  Their purpose is to enable compute in the private subnets to initiate outbound connections outside the VPC, and that's not something we need.

## Tasks
* N/A

## Testing
* Made the change in the CDK code, re-deployed the Cluster to update the AWS Resources, added a new VPC to the capture portfolio, and ensured I was able to hit the viewer and see the traffic from the VPC:

<img width="1593" alt="Screenshot 2024-02-02 at 1 17 08 PM" src="https://github.com/arkime/aws-aio/assets/25470211/6a2492b5-bebb-41e8-9272-4be786ad3df5">


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
