### PR TITLE
reenable capture vpc nat gateway

### DIFF
--- a/cdk-lib/capture-stacks/capture-vpc-stack.ts
+++ b/cdk-lib/capture-stacks/capture-vpc-stack.ts
@@ -16,7 +16,7 @@ export class CaptureVpcStack extends Stack {
 
         this.vpc = new ec2.Vpc(this, 'VPC', {
             ipAddresses: ec2.IpAddresses.cidr(props.planCluster.captureVpc.cidr.block),
-            natGateways: 0,
+            // natGateways: 0, // ECS on EC2 need NatGateways, there might be another way?
             availabilityZones: props.planCluster.captureVpc.azs,
             subnetConfiguration: [
                 {


### PR DESCRIPTION
## Description
Reenable the natgateways for capture vpc. When deploying with no capturevpc the Capture Service would never start with no container instances were found error.

https://stackoverflow.com/questions/36523282/aws-ecs-error-when-running-task-no-container-instances-were-found-in-your-clust

suggested that internet is needed

## Testing
Can deploy now

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
