### PR TITLE
set elbv2.SslPolicy.RECOMMENDED_TLS

### DIFF
--- a/cdk-lib/viewer-stacks/viewer-nodes-stack.ts
+++ b/cdk-lib/viewer-stacks/viewer-nodes-stack.ts
@@ -151,7 +151,8 @@ export class ViewerNodesStack extends cdk.Stack {
         const listener = lb.addListener('Listener', {
             protocol: elbv2.ApplicationProtocol.HTTP,
             port: 80,
-            open: true
+            open: true,
+            sslPolicy: elbv2.SslPolicy.RECOMMENDED_TLS,
         });
 
         listener.addTargets('TargetGroup', {


### PR DESCRIPTION
## Description
Set the sslPolicy on https listener

## Testing
Ran cluster-create and made sure it set sslPolicy on listener to the newer recommended version.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
