### PR TITLE
support only setting some parameters on first create

### DIFF
--- a/manage_arkime/commands/cluster_create.py
+++ b/manage_arkime/commands/cluster_create.py
@@ -156,6 +156,12 @@ def _get_previous_user_config(cluster_name: str, aws_provider: AwsClientProvider
     except ssm_ops.ParamDoesNotExist:
         return UserConfig(None, None, None, None, None)
 
+def _not_none(s, d):
+    if s is None:
+        return d
+    else:
+        return s
+
 def _get_next_user_config(cluster_name: str, expected_traffic: float, spi_days: int, history_days: int, replicas: int,
                           pcap_days: int, viewer_prefix_list: str, aws_provider: AwsClientProvider) -> UserConfig:
     # At least one parameter isn't defined
@@ -186,7 +192,13 @@ def _get_next_user_config(cluster_name: str, expected_traffic: float, spi_days: 
 
         # Existing configuration doesn't exist, use defaults
         except ssm_ops.ParamDoesNotExist:
-            return UserConfig(MINIMUM_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_HISTORY_DAYS, DEFAULT_REPLICAS, DEFAULT_S3_STORAGE_DAYS, None)
+            return UserConfig(_not_none(expected_traffic, MINIMUM_TRAFFIC),
+                              _not_none(spi_days, DEFAULT_SPI_DAYS),
+                              _not_none(history_days, DEFAULT_HISTORY_DAYS),
+                              _not_none(replicas, DEFAULT_REPLICAS),
+                              _not_none(pcap_days,DEFAULT_S3_STORAGE_DAYS),
+                              viewer_prefix_list
+                             )
     # All of the parameters defined
     else:
         return UserConfig(expected_traffic, spi_days, history_days, replicas, pcap_days, viewer_prefix_list)

--- a/manage_arkime/core/user_config.py
+++ b/manage_arkime/core/user_config.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, fields
 import logging
 from typing import Dict
 
+from core.capacity_planning import (MINIMUM_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_REPLICAS, DEFAULT_S3_STORAGE_DAYS, DEFAULT_HISTORY_DAYS)
+
 logger = logging.getLogger(__name__)
 
 @dataclass
@@ -12,6 +14,30 @@ class UserConfig:
     replicas: int
     pcapDays: int
     viewerPrefixList: str = None
+
+    def __init__(self, expectedTraffic: float, spiDays: int, historyDays: int, replicas: int, pcapDays: int, viewerPrefixList: str = None):
+        if (expectedTraffic is None):
+            expectedTraffic = MINIMUM_TRAFFIC
+
+        if (spiDays is None):
+            spiDays = DEFAULT_SPI_DAYS
+
+        if (historyDays is None):
+            historyDays = DEFAULT_HISTORY_DAYS
+
+        if (replicas is None):
+            replicas = DEFAULT_REPLICAS
+
+        if (pcapDays is None):
+            pcapDays = DEFAULT_S3_STORAGE_DAYS
+
+
+        self.expectedTraffic = expectedTraffic
+        self.spiDays = spiDays
+        self.historyDays = historyDays
+        self.replicas = replicas
+        self.pcapDays = pcapDays
+        self.viewerPrefixList = viewerPrefixList
 
     """ Only process fields we still need, this allows us to ignore config no longer used """
     @classmethod


### PR DESCRIPTION
## Description
Support cluster-create only having some arguments set. Previously if any of the arguments weren't set, the defaults were used for everything. This makes it so the defaults are only used for what isn't set.

## Testing
Tried with different parameters used and make sure the defaults weren't used for those provided.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
