### PR TITLE
Extra tags

### DIFF
--- a/cdk-lib/cloud-demo.ts
+++ b/cdk-lib/cloud-demo.ts
@@ -23,18 +23,19 @@ const env: Environment = {
     region: params.awsRegion
 };
 
-switch(params.type) {
-case 'ClusterMgmtParams': {
-    function addTags (stack: cdk.Stack) {
-        const clusterParams = params as prms.ClusterMgmtParams;
-        cdk.Tags.of(stack).add('arkime_cluster', clusterParams.nameCluster);
+function addTags (stack: cdk.Stack) {
+    const clusterParams = params as prms.ClusterMgmtParams;
+    cdk.Tags.of(stack).add('arkime_cluster', clusterParams.nameCluster);
 
-        if (clusterParams.userConfig.extraTags) {
-            for (const tag of clusterParams.userConfig.extraTags) {
-                cdk.Tags.of(stack).add(tag.key, tag.value);
-            }
+    if (clusterParams.userConfig.extraTags) {
+        for (const tag of clusterParams.userConfig.extraTags) {
+            cdk.Tags.of(stack).add(tag.key, tag.value);
         }
     }
+}
+
+switch(params.type) {
+case 'ClusterMgmtParams': {
     const captureBucketStack = new CaptureBucketStack(app, params.stackNames.captureBucket, {
         env: env,
         planCluster: params.planCluster,

--- a/cdk-lib/core/context-types.ts
+++ b/cdk-lib/core/context-types.ts
@@ -98,6 +98,7 @@ export interface UserConfig {
     replicas: number;
     pcapDays: number;
     viewerPrefixList: string;
+    extraTags: ExtraTag[]
 }
 
 /**
@@ -111,4 +112,12 @@ export interface ClusterMgmtStackNames {
     osDomain: string;
     viewerNodes: string;
     viewerVpc: string;
+}
+
+/**
+ * Structure to hold the Extra Tags
+ */
+export interface ExtraTag {
+    key: string;
+    value: string
 }

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -130,13 +130,25 @@ cli.add_command(demo_traffic_destroy)
     default=None,
     type=click.STRING,
     required=False)
+@click.option(
+    "--extra-tag",
+    help=("Extra AWS Tag to apply to all resources."),
+    default=None,
+    nargs=2,
+    type=(click.STRING, click.STRING),
+    multiple=True,
+    required=False)
 @click.pass_context
 def cluster_create(ctx, name, expected_traffic, spi_days, history_days, replicas, pcap_days, preconfirm_usage,
-                   just_print_cfn, capture_cidr, viewer_cidr, viewer_prefix_list):
+                   just_print_cfn, capture_cidr, viewer_cidr, viewer_prefix_list, extra_tag):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
+    extra_tags = []
+    if extra_tag:
+        for key, value in extra_tag:
+            extra_tags.append({"key": key, "value": value})
     cmd_cluster_create(profile, region, name, expected_traffic, spi_days, history_days, replicas, pcap_days,
-                       preconfirm_usage, just_print_cfn, capture_cidr, viewer_cidr, viewer_prefix_list)
+                       preconfirm_usage, just_print_cfn, capture_cidr, viewer_cidr, viewer_prefix_list, extra_tags)
 cli.add_command(cluster_create)
 
 @click.command(help="Tears down the Arkime Cluster in your account; by default, leaves your data intact")

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -132,7 +132,7 @@ cli.add_command(demo_traffic_destroy)
     required=False)
 @click.option(
     "--extra-tag",
-    help=("Extra AWS Tag to apply to all resources."),
+    help=("Extra AWS Tag to add to all resources, previously added tags are not deleted."),
     default=None,
     nargs=2,
     type=(click.STRING, click.STRING),

--- a/manage_arkime/commands/cluster_create.py
+++ b/manage_arkime/commands/cluster_create.py
@@ -3,7 +3,7 @@ import json
 import logging
 import shutil
 import sys
-from typing import Callable, List, Tuple, Dict
+from typing import Callable, List, Dict
 
 import arkime_interactions.config_wrangling as config_wrangling
 from aws_interactions.acm_interactions import upload_default_elb_cert

--- a/manage_arkime/commands/cluster_create.py
+++ b/manage_arkime/commands/cluster_create.py
@@ -3,7 +3,7 @@ import json
 import logging
 import shutil
 import sys
-from typing import Callable, List
+from typing import Callable, List, Tuple, Dict
 
 import arkime_interactions.config_wrangling as config_wrangling
 from aws_interactions.acm_interactions import upload_default_elb_cert
@@ -31,7 +31,8 @@ from core.user_config import UserConfig
 logger = logging.getLogger(__name__)
 
 def cmd_cluster_create(profile: str, region: str, name: str, expected_traffic: float, spi_days: int, history_days: int, replicas: int,
-                       pcap_days: int, preconfirm_usage: bool, just_print_cfn: bool, capture_cidr: str, viewer_cidr: str, viewer_prefix_list: str):
+                       pcap_days: int, preconfirm_usage: bool, just_print_cfn: bool, capture_cidr: str, viewer_cidr: str, viewer_prefix_list: str,
+                       extra_tags: List[Dict[str, str]]):
     logger.debug(f"Invoking cluster-create with profile '{profile}' and region '{region}'")
 
     aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)
@@ -50,7 +51,7 @@ def cmd_cluster_create(profile: str, region: str, name: str, expected_traffic: f
 
     # Generate our capacity plan, then confirm it's what the user expected and it's safe to proceed with the operation
     previous_user_config = _get_previous_user_config(name, aws_provider)
-    next_user_config = _get_next_user_config(name, expected_traffic, spi_days, history_days, replicas, pcap_days, viewer_prefix_list,  aws_provider)
+    next_user_config = _get_next_user_config(name, expected_traffic, spi_days, history_days, replicas, pcap_days, viewer_prefix_list, extra_tags, aws_provider)
     previous_capacity_plan = _get_previous_capacity_plan(name, aws_provider)
     next_capacity_plan = _get_next_capacity_plan(next_user_config, previous_capacity_plan, capture_cidr, viewer_cidr, aws_provider)
 
@@ -81,9 +82,6 @@ def cmd_cluster_create(profile: str, region: str, name: str, expected_traffic: f
     else:
         # Deploy the CFN resources
         cdk_client.deploy(stacks_to_deploy, context=create_context)
-
-        # Tag the OpenSearch Domain
-        _tag_domain(name, aws_provider)
 
         # Kick off Events to ensure that ISM is set up on the CFN-created OpenSearch Domain
         _configure_ism(name, next_user_config.historyDays, next_user_config.spiDays, next_user_config.replicas, aws_provider)
@@ -156,7 +154,7 @@ def _get_previous_user_config(cluster_name: str, aws_provider: AwsClientProvider
         return UserConfig(None, None, None, None, None)
 
 def _get_next_user_config(cluster_name: str, expected_traffic: float, spi_days: int, history_days: int, replicas: int,
-                          pcap_days: int, viewer_prefix_list: str, aws_provider: AwsClientProvider) -> UserConfig:
+                          pcap_days: int, viewer_prefix_list: str, extra_tags: str, aws_provider: AwsClientProvider) -> UserConfig:
     # At least one parameter isn't defined
     if None in [expected_traffic, spi_days, replicas, pcap_days, history_days, viewer_prefix_list]:
         # Re-use the existing configuration if it exists
@@ -183,14 +181,16 @@ def _get_next_user_config(cluster_name: str, expected_traffic: float, spi_days: 
                 user_config.pcapDays = pcap_days
             if viewer_prefix_list is not None:
                 user_config.viewerPrefixList = viewer_prefix_list
+            if extra_tags is not None:
+                user_config.extraTags = extra_tags
             return user_config
 
         # Existing configuration doesn't exist, use defaults
         except ssm_ops.ParamDoesNotExist:
-            return UserConfig(expected_traffic, spi_days, history_days, replicas, pcap_days, viewer_prefix_list)
+            return UserConfig(expected_traffic, spi_days, history_days, replicas, pcap_days, viewer_prefix_list, extra_tags)
     # All of the parameters defined
     else:
-        return UserConfig(expected_traffic, spi_days, history_days, replicas, pcap_days, viewer_prefix_list)
+        return UserConfig(expected_traffic, spi_days, history_days, replicas, pcap_days, viewer_prefix_list, extra_tags)
 
 def _get_previous_capacity_plan(cluster_name: str, aws_provider: AwsClientProvider) -> ClusterPlan:
     # Pull the existing plan, if possible
@@ -356,21 +356,6 @@ def _configure_ism(cluster_name: str, history_days: int, spi_days: int, replicas
         [events.ConfigureIsmEvent(history_days, spi_days, replicas)],
         event_bus_arn,
         aws_provider
-    )
-
-def _tag_domain(cluster_name: str, aws_provider: AwsClientProvider):
-    os_domain_Arn = ssm_ops.get_ssm_param_json_value(
-        constants.get_opensearch_domain_ssm_param_name(cluster_name),
-        "domainArn",
-        aws_provider
-    )
-
-    opensearch_client = aws_provider.get_opensearch()
-    opensearch_client.add_tags(
-        ARN=os_domain_Arn,
-        TagList=[
-            {"Key": "arkime_cluster", "Value": cluster_name},
-        ]
     )
 
 def _get_stacks_to_deploy(cluster_name: str, next_user_config: UserConfig, next_capacity_plan: ClusterPlan) -> List[str]:

--- a/manage_arkime/core/user_config.py
+++ b/manage_arkime/core/user_config.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, fields
 import logging
-from typing import Dict
+from typing import Dict, List
 
 from core.capacity_planning import (MINIMUM_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_REPLICAS, DEFAULT_S3_STORAGE_DAYS, DEFAULT_HISTORY_DAYS)
 
@@ -14,30 +14,31 @@ class UserConfig:
     replicas: int
     pcapDays: int
     viewerPrefixList: str = None
+    extraTags: List[Dict[str, str]] = None
 
-    def __init__(self, expectedTraffic: float, spiDays: int, historyDays: int, replicas: int, pcapDays: int, viewerPrefixList: str = None):
-        if (expectedTraffic is None):
-            expectedTraffic = MINIMUM_TRAFFIC
-
-        if (spiDays is None):
-            spiDays = DEFAULT_SPI_DAYS
-
-        if (historyDays is None):
-            historyDays = DEFAULT_HISTORY_DAYS
-
-        if (replicas is None):
-            replicas = DEFAULT_REPLICAS
-
-        if (pcapDays is None):
-            pcapDays = DEFAULT_S3_STORAGE_DAYS
-
-
+    def __init__(self, expectedTraffic: float, spiDays: int, historyDays: int, replicas: int, pcapDays: int, viewerPrefixList: str = None, extraTags: List[Dict[str, str]] = []):
         self.expectedTraffic = expectedTraffic
         self.spiDays = spiDays
         self.historyDays = historyDays
         self.replicas = replicas
         self.pcapDays = pcapDays
         self.viewerPrefixList = viewerPrefixList
+        self.extraTags = extraTags
+
+        if (expectedTraffic is None):
+            self.expectedTraffic = MINIMUM_TRAFFIC
+
+        if (spiDays is None):
+            self.spiDays = DEFAULT_SPI_DAYS
+
+        if (historyDays is None):
+            self.historyDays = DEFAULT_HISTORY_DAYS
+
+        if (replicas is None):
+            self.replicas = DEFAULT_REPLICAS
+
+        if (pcapDays is None):
+            self.pcapDays = DEFAULT_S3_STORAGE_DAYS
 
     """ Only process fields we still need, this allows us to ignore config no longer used """
     @classmethod
@@ -47,12 +48,21 @@ class UserConfig:
         return cls(**valid_kwargs)
 
     def __eq__(self, other):
+        set1 = None
+        if self.extraTags is not None:
+            set1 = {frozenset(d.items()) for d in self.extraTags}
+
+        set2 = None
+        if other.extraTags is not None:
+            set2 = {frozenset(d.items()) for d in other.extraTags}
+
         return (self.expectedTraffic == other.expectedTraffic and
                 self.spiDays == other.spiDays and
                 self.historyDays == other.historyDays and
                 self.replicas == other.replicas and
                 self.pcapDays == other.pcapDays and
-                self.viewerPrefixList == other.viewerPrefixList)
+                self.viewerPrefixList == other.viewerPrefixList and
+                set1 == set2)
 
     def to_dict(self) -> Dict[str, any]:
         return {
@@ -62,5 +72,6 @@ class UserConfig:
             'pcapDays': self.pcapDays,
             'historyDays': self.historyDays,
             'viewerPrefixList': self.viewerPrefixList,
+            'extraTags': self.extraTags,
         }
 

--- a/test_manage_arkime/commands/test_cluster_create.py
+++ b/test_manage_arkime/commands/test_cluster_create.py
@@ -12,7 +12,7 @@ import cdk_interactions.cdk_context as context
 
 from commands.cluster_create import (cmd_cluster_create, _set_up_viewer_cert, _get_next_capacity_plan, _get_next_user_config, _confirm_usage,
                                      _get_previous_capacity_plan, _get_previous_user_config, _configure_ism, _set_up_arkime_config,
-                                     _tag_domain, _should_proceed_with_operation, _is_initial_invocation, _get_stacks_to_deploy, _get_cdk_context)
+                                     _should_proceed_with_operation, _is_initial_invocation, _get_stacks_to_deploy, _get_cdk_context)
 from core.compatibility import CliClusterVersionMismatch
 import core.constants as constants
 from core.capacity_planning import (CaptureNodesPlan, ViewerNodesPlan, EcsSysResourcePlan, MINIMUM_TRAFFIC, OSDomainPlan, DataNodesPlan, MasterNodesPlan,
@@ -28,7 +28,6 @@ from core.versioning import VersionInfo
 @mock.patch("commands.cluster_create._get_cdk_context")
 @mock.patch("commands.cluster_create._get_stacks_to_deploy")
 @mock.patch("commands.cluster_create._is_initial_invocation")
-@mock.patch("commands.cluster_create._tag_domain")
 @mock.patch("commands.cluster_create._set_up_arkime_config")
 @mock.patch("commands.cluster_create._configure_ism")
 @mock.patch("commands.cluster_create._get_previous_user_config")
@@ -40,7 +39,7 @@ from core.versioning import VersionInfo
 @mock.patch("commands.cluster_create.CdkClient")
 def test_WHEN_cmd_cluster_create_called_THEN_cdk_command_correct(mock_cdk_client_cls, mock_set_up, mock_get_plans, mock_get_config,
                                                                  mock_proceed, mock_get_prev_plan, mock_get_prev_config, mock_configure,
-                                                                 mock_set_up_arkime_conf, mock_tag, mock_initial,mock_get_stacks,
+                                                                 mock_set_up_arkime_conf, mock_initial,mock_get_stacks,
                                                                  mock_get_context, mock_aws_provider_cls):
     # Set up our mock
     mock_set_up.return_value = "arn"
@@ -74,7 +73,7 @@ def test_WHEN_cmd_cluster_create_called_THEN_cdk_command_correct(mock_cdk_client
     mock_get_context.return_value = {"key": "value"}
 
     # Run our test
-    cmd_cluster_create("profile", "region", "my-cluster", None, None, None, None, None, True, False, None, None, None)
+    cmd_cluster_create("profile", "region", "my-cluster", None, None, None, None, None, True, False, None, None, None, None)
 
     # Check our results
     expected_calls = [
@@ -105,15 +104,9 @@ def test_WHEN_cmd_cluster_create_called_THEN_cdk_command_correct(mock_cdk_client
     ]
     assert expected_set_up_arkime_conf_calls == mock_set_up_arkime_conf.call_args_list
 
-    expected_tag_calls = [
-        mock.call("my-cluster",mock.ANY)
-    ]
-    assert expected_tag_calls == mock_tag.call_args_list
-
 @mock.patch("commands.cluster_create.AwsClientProvider", mock.Mock())
 @mock.patch("commands.cluster_create.compat.confirm_aws_aio_version_compatibility")
 @mock.patch("commands.cluster_create._is_initial_invocation")
-@mock.patch("commands.cluster_create._tag_domain")
 @mock.patch("commands.cluster_create._set_up_arkime_config")
 @mock.patch("commands.cluster_create._configure_ism")
 @mock.patch("commands.cluster_create._get_previous_user_config")
@@ -125,7 +118,7 @@ def test_WHEN_cmd_cluster_create_called_THEN_cdk_command_correct(mock_cdk_client
 @mock.patch("commands.cluster_create.CdkClient")
 def test_WHEN_cmd_cluster_create_called_AND_ver_mismatch_THEN_as_expected(mock_cdk_client_cls, mock_set_up, mock_get_plans, mock_get_config,
                                                                          mock_proceed, mock_get_prev_plan, mock_get_prev_config, mock_configure,
-                                                                         mock_set_up_arkime_conf, mock_tag, mock_initial, mock_confirm_ver):
+                                                                         mock_set_up_arkime_conf, mock_initial, mock_confirm_ver):
     # Set up our mock
     mock_set_up.return_value = "arn"
 
@@ -146,7 +139,7 @@ def test_WHEN_cmd_cluster_create_called_AND_ver_mismatch_THEN_as_expected(mock_c
     mock_confirm_ver.side_effect = CliClusterVersionMismatch(2, 1)
 
     # Run our test
-    cmd_cluster_create("profile", "region", "my-cluster", None, None, None, None, None, True, False, "1.2.3.4/24", "2.3.4.5/26", None)
+    cmd_cluster_create("profile", "region", "my-cluster", None, None, None, None, None, True, False, "1.2.3.4/24", "2.3.4.5/26", None, None)
 
     # Check our results
     expected_proceed_calls = []
@@ -161,15 +154,11 @@ def test_WHEN_cmd_cluster_create_called_AND_ver_mismatch_THEN_as_expected(mock_c
     expected_configure_calls = []
     assert expected_configure_calls == mock_configure.call_args_list
 
-    expected_tag_calls = []
-    assert expected_tag_calls == mock_tag.call_args_list
-
     expected_set_up_arkime_conf_calls = []
     assert expected_set_up_arkime_conf_calls == mock_set_up_arkime_conf.call_args_list
 
 @mock.patch("commands.cluster_create.AwsClientProvider", mock.Mock())
 @mock.patch("commands.cluster_create._is_initial_invocation")
-@mock.patch("commands.cluster_create._tag_domain")
 @mock.patch("commands.cluster_create._set_up_arkime_config")
 @mock.patch("commands.cluster_create._configure_ism")
 @mock.patch("commands.cluster_create._get_previous_user_config")
@@ -181,7 +170,7 @@ def test_WHEN_cmd_cluster_create_called_AND_ver_mismatch_THEN_as_expected(mock_c
 @mock.patch("commands.cluster_create.CdkClient")
 def test_WHEN_cmd_cluster_create_called_AND_shouldnt_proceed_THEN_as_expected(mock_cdk_client_cls, mock_set_up, mock_get_plans, mock_get_config,
                                                                          mock_proceed, mock_get_prev_plan, mock_get_prev_config, mock_configure,
-                                                                         mock_set_up_arkime_conf, mock_tag, mock_initial):
+                                                                         mock_set_up_arkime_conf, mock_initial):
     # Set up our mock
     mock_set_up.return_value = "arn"
 
@@ -200,7 +189,7 @@ def test_WHEN_cmd_cluster_create_called_AND_shouldnt_proceed_THEN_as_expected(mo
     mock_proceed.return_value = False
 
     # Run our test
-    cmd_cluster_create("profile", "region", "my-cluster", None, None, None, None, None, True, False, "1.2.3.4/24", "2.3.4.5/26", None)
+    cmd_cluster_create("profile", "region", "my-cluster", None, None, None, None, None, True, False, "1.2.3.4/24", "2.3.4.5/26", None, None)
 
     # Check our results
     expected_proceed_calls = [
@@ -217,9 +206,6 @@ def test_WHEN_cmd_cluster_create_called_AND_shouldnt_proceed_THEN_as_expected(mo
     expected_configure_calls = []
     assert expected_configure_calls == mock_configure.call_args_list
 
-    expected_tag_calls = []
-    assert expected_tag_calls == mock_tag.call_args_list
-
     expected_set_up_arkime_conf_calls = []
     assert expected_set_up_arkime_conf_calls == mock_set_up_arkime_conf.call_args_list
 
@@ -227,7 +213,6 @@ def test_WHEN_cmd_cluster_create_called_AND_shouldnt_proceed_THEN_as_expected(mo
 @mock.patch("commands.cluster_create._get_cdk_context")
 @mock.patch("commands.cluster_create._get_stacks_to_deploy")
 @mock.patch("commands.cluster_create._is_initial_invocation")
-@mock.patch("commands.cluster_create._tag_domain")
 @mock.patch("commands.cluster_create.cfn.set_up_cloudformation_template_dir")
 @mock.patch("commands.cluster_create.constants.get_repo_root_dir")
 @mock.patch("commands.cluster_create.shutil.rmtree")
@@ -246,7 +231,7 @@ def test_WHEN_cmd_cluster_create_called_AND_just_print_THEN_as_expected(mock_cdk
                                                                 mock_get_config, mock_proceed, mock_get_prev_plan,
                                                                 mock_get_prev_config, mock_configure, mock_set_up_arkime_conf,
                                                                 mock_aws_provider_cls, mock_get_cdk_dir, mock_rmtree,
-                                                                mock_get_root_dir, mock_set_up_cfn, mock_tag, mock_initial,
+                                                                mock_get_root_dir, mock_set_up_cfn, mock_initial,
                                                                 mock_get_stacks, mock_get_context):
     # Set up our mock
     mock_set_up.return_value = "arn"
@@ -283,7 +268,7 @@ def test_WHEN_cmd_cluster_create_called_AND_just_print_THEN_as_expected(mock_cdk
     mock_get_context.return_value = {"key": "value"}
 
     # Run our test
-    cmd_cluster_create("profile", "region", "my-cluster", None, None, None, None, None, True, True, None, None, None)
+    cmd_cluster_create("profile", "region", "my-cluster", None, None, None, None, None, True, True, None, None, None, None)
 
     # Check our results
     expected_calls = [
@@ -309,9 +294,6 @@ def test_WHEN_cmd_cluster_create_called_AND_just_print_THEN_as_expected(mock_cdk
 
     expected_configure_calls = []
     assert expected_configure_calls == mock_configure.call_args_list
-
-    expected_tag_calls = []
-    assert expected_tag_calls == mock_tag.call_args_list
 
     expected_set_up_arkime_conf_calls = [
         mock.call("my-cluster", mock.ANY)
@@ -574,7 +556,7 @@ def test_WHEN_get_next_user_config_called_AND_use_existing_THEN_as_expected(mock
     mock_provider = mock.Mock()
 
     # Run our test
-    actual_value = _get_next_user_config("my-cluster", None, None, None, None, None, None, mock_provider)
+    actual_value = _get_next_user_config("my-cluster", None, None, None, None, None, None, None, mock_provider)
 
     # Check our results
     assert UserConfig(1.2, 40, 120, 2, 35) == actual_value
@@ -600,7 +582,7 @@ def test_WHEN_get_next_user_config_called_AND_partial_update_THEN_as_expected(mo
     mock_provider = mock.Mock()
 
     # Run our test
-    actual_value = _get_next_user_config("my-cluster", None, 30, None, None, None, None, mock_provider)
+    actual_value = _get_next_user_config("my-cluster", None, 30, None, None, None, None, None, mock_provider)
 
     # Check our results
     assert UserConfig(1.2, 30, 120, 2, 35) == actual_value
@@ -619,10 +601,10 @@ def test_WHEN_get_next_user_config_called_AND_use_default_THEN_as_expected(mock_
     mock_provider = mock.Mock()
 
     # Run our test
-    actual_value = _get_next_user_config("my-cluster", None, None, None, None, None, None, mock_provider)
+    actual_value = _get_next_user_config("my-cluster", None, None, None, None, None, None, None, mock_provider)
 
     # Check our results
-    assert UserConfig(MINIMUM_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_HISTORY_DAYS, DEFAULT_REPLICAS, DEFAULT_S3_STORAGE_DAYS) == actual_value
+    assert UserConfig(MINIMUM_TRAFFIC, DEFAULT_SPI_DAYS, DEFAULT_HISTORY_DAYS, DEFAULT_REPLICAS, DEFAULT_S3_STORAGE_DAYS, None, None) == actual_value
 
     expected_get_ssm_calls = [
         mock.call(constants.get_cluster_ssm_param_name("my-cluster"), "userConfig", mock.ANY)
@@ -637,10 +619,10 @@ def test_WHEN_get_next_user_config_called_AND_specify_all_THEN_as_expected(mock_
     mock_provider = mock.Mock()
 
     # Run our test
-    actual_value = _get_next_user_config("my-cluster", 10, 40, 120, 2, 35, "viewer-prefix-list", mock_provider)
+    actual_value = _get_next_user_config("my-cluster", 10, 40, 120, 2, 35, "viewer-prefix-list", [{"key": "key", "value": "value"}], mock_provider)
 
     # Check our results
-    assert UserConfig(10, 40, 120, 2, 35, "viewer-prefix-list") == actual_value
+    assert UserConfig(10, 40, 120, 2, 35, "viewer-prefix-list", [{"key": "key", "value": "value"}]) == actual_value
 
     expected_get_ssm_calls = []
     assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_json_value.call_args_list
@@ -1137,34 +1119,6 @@ def test_WHEN_set_up_arkime_config_called_AND_couldnt_make_bucket_THEN_as_expect
 
     expected_exit_calls = [mock.call(1)]
     assert expected_exit_calls == mock_exit.call_args_list
-
-@mock.patch("commands.cluster_create.ssm_ops.get_ssm_param_json_value")
-def test_WHEN_tag_domain_called_THEN_as_expected(mock_get_ssm_json):
-    # Set up our mock
-    mock_os_client = mock.Mock()
-    mock_provider = mock.Mock()
-    mock_provider.get_opensearch.return_value = mock_os_client
-
-    mock_get_ssm_json.return_value = "os-arn"
-
-    # Run our test
-    _tag_domain("MyCluster", mock_provider)
-
-    # Check our results
-    expected_get_ssm_json_calls = [
-        mock.call(constants.get_opensearch_domain_ssm_param_name("MyCluster"), "domainArn", mock_provider)
-    ]
-    assert expected_get_ssm_json_calls == mock_get_ssm_json.call_args_list
-
-    expected_add_tag_calls = [
-        mock.call(
-            ARN="os-arn",
-            TagList=[
-                {"Key": "arkime_cluster", "Value": "MyCluster"},
-            ]
-        )
-    ]
-    assert expected_add_tag_calls == mock_os_client.add_tags.call_args_list
 
 @mock.patch("commands.cluster_create.ssm_ops.get_ssm_param_value")
 def test_WHEN_is_initial_invocation_called_THEN_as_expected(mock_get_ssm):


### PR DESCRIPTION
## Description
Add the ability to assign extra tags to all resources and add the arkime_cluster tag to all resources. Also removed the old way tags were being added to the OS Domain and moved to the cdk-lib

## Testing
* Tested creating a cluster without tags, only arkime_cluster shows up
* Tested rerunning with tags on that same cluster, now the new tags show up
* Tested creating a new cluster with tags, all tags showed up

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
